### PR TITLE
更改助手侧边栏的显示

### DIFF
--- a/src/components/AppInitializer.tsx
+++ b/src/components/AppInitializer.tsx
@@ -196,22 +196,28 @@ const AppInitializer = () => {
             }
           }
         } else {
-          console.log('[AppInitializer] 没有可用的助手，需要创建默认助手');
+          console.log('[AppInitializer] 没有可用的助手，请用户手动创建');
+          
+          // 2024-07-28: 暂时注释掉自动创建默认助手的功能
+          // 观察这是否能解决每次刷新都重复创建助手的问题
+          // 如果用户确实需要一个引导流程，我们后续再设计一个更完善的、只执行一次的初始化方案
 
-          // 创建默认助手
-          const defaultAssistants = await AssistantService.initializeDefaultAssistants();
+          // console.log('[AppInitializer] 没有可用的助手，需要创建默认助手');
 
-          if (defaultAssistants.length > 0) {
-            const firstAssistant = defaultAssistants[0];
+          // // 创建默认助手
+          // const defaultAssistants = await AssistantService.initializeDefaultAssistants();
 
-            // 设置当前助手
-            dispatch(setCurrentAssistant(firstAssistant));
+          // if (defaultAssistants.length > 0) {
+          //   const firstAssistant = defaultAssistants[0];
 
-            // 选择第一个话题
-            if (firstAssistant.topics && firstAssistant.topics.length > 0) {
-              dispatch(newMessagesActions.setCurrentTopicId(firstAssistant.topics[0].id));
-            }
-          }
+          //   // 设置当前助手
+          //   dispatch(setCurrentAssistant(firstAssistant));
+
+          //   // 选择第一个话题
+          //   if (firstAssistant.topics && firstAssistant.topics.length > 0) {
+          //     dispatch(newMessagesActions.setCurrentTopicId(firstAssistant.topics[0].id));
+          //   }
+          // }
         }
       } catch (error) {
         console.error('[AppInitializer] 选择第一个助手失败:', error);

--- a/src/components/TopicManagement/AssistantTab/index.tsx
+++ b/src/components/TopicManagement/AssistantTab/index.tsx
@@ -146,7 +146,7 @@ export default function AssistantTab({
   return (
     <Box sx={{ height: '100%', display: 'flex', flexDirection: 'column' }}>
       {/* 标题和按钮区域 */}
-      <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 1, minHeight: '32px' }}>
+      <Box sx={{ mb: 1 }}>
         {showSearch ? (
           <TextField
             fullWidth
@@ -174,11 +174,15 @@ export default function AssistantTab({
           />
         ) : (
           <>
-            <Typography variant="subtitle1" fontWeight="medium" sx={{ flexShrink: 0 }}>所有助手</Typography>
-            <Box sx={{ display: 'flex', gap: 0.5, alignItems: 'center', flexShrink: 0 }}>
-              <IconButton size="small" onClick={handleSearchClick} sx={{ mr: 0.5 }}>
+            {/* 第一行：标题和搜索按钮 */}
+            <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 1 }}>
+              <Typography variant="subtitle1" fontWeight="medium" sx={{ flexShrink: 0 }}>所有助手</Typography>
+              <IconButton size="small" onClick={handleSearchClick}>
                 <Search size={18} />
               </IconButton>
+            </Box>
+            {/* 第二行：创建分组和添加助手按钮 */}
+            <Box sx={{ display: 'flex', gap: 0.5 }}>
               <Tooltip title="创建分组">
                 <Button
                   variant="outlined"
@@ -186,11 +190,12 @@ export default function AssistantTab({
                   startIcon={<FolderPlus size={16} />}
                   onClick={handleOpenGroupDialog}
                   sx={{
+                    flex: 1,
                     color: 'text.primary',
                     borderColor: 'text.secondary',
-                    minWidth: 'auto',
                     px: 1,
                     fontSize: '0.75rem',
+                    justifyContent: 'center',
                     '&:hover': {
                       borderColor: 'text.primary',
                       backgroundColor: 'action.hover'
@@ -207,11 +212,12 @@ export default function AssistantTab({
                   startIcon={<Plus size={16} />}
                   onClick={handleOpenAssistantDialog}
                   sx={{
+                    flex: 1,
                     color: 'text.primary',
                     borderColor: 'text.secondary',
-                    minWidth: 'auto',
                     px: 1,
                     fontSize: '0.75rem',
+                    justifyContent: 'center',
                     '&:hover': {
                       borderColor: 'text.primary',
                       backgroundColor: 'action.hover'


### PR DESCRIPTION
![Screenshot_20250617_194111_com llmhouse app](https://github.com/user-attachments/assets/7bae104c-2f1e-4349-b933-dcdaf9055159)

注意到侧边栏添加助手这一按键经常显示不全，就改成了分成两行

![image](https://github.com/user-attachments/assets/0fbdb939-fdc3-45d9-9022-d5ddbf00c9d6)

还有给助手分组添加了删除按钮

![image](https://github.com/user-attachments/assets/b15f618b-c73d-43ed-abdc-0bde5ca4bf46)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a contextual menu to each assistant group, allowing users to delete groups directly from the interface.

- **User Interface**
  - Improved the layout and spacing of the AssistantTab header, with clearer grouping of title, search, and action buttons.

- **Behavior Changes**
  - Disabled automatic creation of default assistants; users must now manually create assistants if none exist.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->