### PR TITLE
优化快捷短语设置界面，添加返回按钮，调整输入框图标颜色为黑色，设置界面未完成功能的按键设置为不可点击

### DIFF
--- a/src/components/QuickPhraseSettings.tsx
+++ b/src/components/QuickPhraseSettings.tsx
@@ -19,14 +19,19 @@ import {
   Chip,
   Alert,
   Switch,
-  FormControlLabel
+  FormControlLabel,
+  AppBar,
+  Toolbar,
+  alpha
 } from '@mui/material';
+import { useNavigate } from 'react-router-dom';
 import { useSelector, useDispatch } from 'react-redux';
 import {
   Plus as AddIcon,
   Edit as EditIcon,
   Trash2 as DeleteIcon,
-  Zap
+  Zap,
+  ArrowLeft
 } from 'lucide-react';
 import { useTheme } from '@mui/material/styles';
 import QuickPhraseService from '../shared/services/QuickPhraseService';
@@ -37,6 +42,11 @@ import { setShowQuickPhraseButton } from '../shared/store/settingsSlice';
 const QuickPhraseSettings: React.FC = () => {
   const theme = useTheme();
   const dispatch = useDispatch();
+  const navigate = useNavigate();
+
+  const handleBack = () => {
+    navigate('/settings');
+  };
 
   // 从Redux获取快捷短语按钮显示设置
   const showQuickPhraseButton = useSelector((state: RootState) => state.settings.showQuickPhraseButton ?? true);
@@ -140,185 +150,236 @@ const QuickPhraseSettings: React.FC = () => {
   }
 
   return (
-    <Box sx={{ p: 3, maxWidth: 800, mx: 'auto' }}>
-      <Box sx={{ display: 'flex', alignItems: 'center', mb: 3 }}>
-        <Zap size={24} style={{ marginRight: 8 }} />
-        <Typography variant="h5" component="h1">
-          快捷短语管理
-        </Typography>
-      </Box>
-
-      <Typography variant="body2" color="text.secondary" sx={{ mb: 3 }}>
-        管理您的快捷短语，在聊天时快速插入常用内容。
-      </Typography>
-
-      {/* 快捷短语按钮显示控制 */}
-      <Paper sx={{ p: 2, mb: 3, border: `1px solid ${theme.palette.divider}` }}>
-        <Typography variant="subtitle1" sx={{ mb: 1, fontWeight: 600 }}>
-          显示设置
-        </Typography>
-        <FormControlLabel
-          control={
-            <Switch
-              checked={showQuickPhraseButton}
-              onChange={(e) => dispatch(setShowQuickPhraseButton(e.target.checked))}
-            />
-          }
-          label="在输入框显示快捷短语按钮"
-        />
-        <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mt: 0.5 }}>
-          控制是否在聊天输入框中显示快捷短语按钮
-        </Typography>
-      </Paper>
-
-      {phrases.length === 0 ? (
-        <Paper sx={{ p: 4, textAlign: 'center' }}>
-          <Zap size={48} style={{ opacity: 0.3, marginBottom: 16 }} />
-          <Typography variant="h6" color="text.secondary" gutterBottom>
-            还没有快捷短语
-          </Typography>
-          <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
-            创建您的第一个快捷短语，让聊天更高效
-          </Typography>
-          <Button
-            variant="contained"
-            startIcon={<AddIcon />}
-            onClick={handleAdd}
-          >
-            添加快捷短语
-          </Button>
-        </Paper>
-      ) : (
-        <>
-          <List>
-            {phrases.map((phrase, index) => (
-              <React.Fragment key={phrase.id}>
-                <ListItem
-                  sx={{
-                    bgcolor: 'background.paper',
-                    borderRadius: 1,
-                    mb: 1,
-                    border: `1px solid ${theme.palette.divider}`
-                  }}
-                >
-                  <ListItemText
-                    primary={
-                      <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-                        <Typography variant="subtitle1" fontWeight="medium">
-                          {phrase.title}
-                        </Typography>
-                        <Chip
-                          size="small"
-                          label={`${phrase.content.length} 字符`}
-                          variant="outlined"
-                        />
-                      </Box>
-                    }
-                    secondary={
-                      <Typography
-                        variant="body2"
-                        color="text.secondary"
-                        sx={{
-                          mt: 1,
-                          display: '-webkit-box',
-                          WebkitLineClamp: 2,
-                          WebkitBoxOrient: 'vertical',
-                          overflow: 'hidden'
-                        }}
-                      >
-                        {phrase.content}
-                      </Typography>
-                    }
-                  />
-                  <ListItemSecondaryAction>
-                    <IconButton
-                      edge="end"
-                      onClick={() => handleEdit(phrase)}
-                      size="small"
-                      sx={{ mr: 1 }}
-                    >
-                      <EditIcon size={18} />
-                    </IconButton>
-                    <IconButton
-                      edge="end"
-                      onClick={() => handleDelete(phrase.id)}
-                      size="small"
-                      color="error"
-                    >
-                      <DeleteIcon size={18} />
-                    </IconButton>
-                  </ListItemSecondaryAction>
-                </ListItem>
-                {index < phrases.length - 1 && <Divider />}
-              </React.Fragment>
-            ))}
-          </List>
-
-          <Fab
-            color="primary"
-            aria-label="添加快捷短语"
-            onClick={handleAdd}
+    <Box sx={{
+      flexGrow: 1,
+      display: 'flex',
+      flexDirection: 'column',
+      height: '100vh',
+      bgcolor: (theme) => theme.palette.mode === 'light'
+        ? alpha(theme.palette.primary.main, 0.02)
+        : alpha(theme.palette.background.default, 0.9),
+    }}>
+      <AppBar
+        position="fixed"
+        elevation={0}
+        sx={{
+          zIndex: (theme) => theme.zIndex.drawer + 1,
+          bgcolor: 'background.paper',
+          color: 'text.primary',
+          borderBottom: 1,
+          borderColor: 'divider',
+          backdropFilter: 'blur(8px)',
+        }}
+      >
+        <Toolbar>
+          <IconButton
+            edge="start"
+            color="inherit"
+            onClick={handleBack}
+            aria-label="back"
             sx={{
-              position: 'fixed',
-              bottom: 24,
-              right: 24
+              color: (theme) => theme.palette.primary.main,
             }}
           >
-            <AddIcon />
-          </Fab>
-        </>
-      )}
-
-      {/* 添加/编辑对话框 */}
-      <Dialog
-        open={dialogOpen}
-        onClose={handleCloseDialog}
-        maxWidth="sm"
-        fullWidth
-      >
-        <DialogTitle>
-          {editingPhrase ? '编辑快捷短语' : '添加快捷短语'}
-        </DialogTitle>
-        <DialogContent>
-          <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2, pt: 1 }}>
-            <TextField
-              label="标题"
-              value={formData.title}
-              onChange={(e) => setFormData({ ...formData, title: e.target.value })}
-              fullWidth
-              size="small"
-              placeholder="为您的快捷短语起个名字"
-            />
-            
-            <TextField
-              label="内容"
-              value={formData.content}
-              onChange={(e) => setFormData({ ...formData, content: e.target.value })}
-              multiline
-              rows={6}
-              fullWidth
-              size="small"
-              placeholder="输入快捷短语的内容..."
-            />
-
-            {formData.content && (
-              <Alert severity="info" sx={{ mt: 1 }}>
-                内容长度：{formData.content.length} 字符
-              </Alert>
-            )}
-          </Box>
-        </DialogContent>
-        <DialogActions>
-          <Button onClick={handleCloseDialog}>取消</Button>
-          <Button
-            onClick={handleSave}
-            variant="contained"
-            disabled={!formData.title.trim() || !formData.content.trim()}
+            <ArrowLeft size={24} />
+          </IconButton>
+          <Typography
+            variant="h6"
+            component="div"
+            sx={{
+              flexGrow: 1,
+              fontWeight: 600,
+            }}
           >
-            {editingPhrase ? '更新' : '添加'}
-          </Button>
-        </DialogActions>
-      </Dialog>
+            快捷短语管理
+          </Typography>
+        </Toolbar>
+      </AppBar>
+      <Box sx={{
+        flexGrow: 1,
+        overflowY: 'auto',
+        p: 2,
+        mt: 8,
+        '&::-webkit-scrollbar': {
+          width: '6px',
+        },
+        '&::-webkit-scrollbar-thumb': {
+          backgroundColor: 'rgba(0,0,0,0.1)',
+          borderRadius: '3px',
+        },
+      }}>
+        <Typography variant="body2" color="text.secondary" sx={{ mb: 3, px: 1 }}>
+          管理您的快捷短语，在聊天时快速插入常用内容。
+        </Typography>
+
+        {/* 快捷短语按钮显示控制 */}
+        <Paper sx={{ p: 2, mb: 3, border: `1px solid ${theme.palette.divider}`, borderRadius: 2 }}>
+          <Typography variant="subtitle1" sx={{ mb: 1, fontWeight: 600 }}>
+            显示设置
+          </Typography>
+          <FormControlLabel
+            control={
+              <Switch
+                checked={showQuickPhraseButton}
+                onChange={(e) => dispatch(setShowQuickPhraseButton(e.target.checked))}
+              />
+            }
+            label="在输入框显示快捷短语按钮"
+          />
+          <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mt: 0.5 }}>
+            控制是否在聊天输入框中显示快捷短语按钮
+          </Typography>
+        </Paper>
+
+        {phrases.length === 0 ? (
+          <Paper sx={{ p: 4, textAlign: 'center', borderRadius: 2 }}>
+            <Zap size={48} style={{ opacity: 0.3, marginBottom: 16 }} />
+            <Typography variant="h6" color="text.secondary" gutterBottom>
+              还没有快捷短语
+            </Typography>
+            <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+              创建您的第一个快捷短语，让聊天更高效
+            </Typography>
+            <Button
+              variant="contained"
+              startIcon={<AddIcon />}
+              onClick={handleAdd}
+            >
+              添加快捷短语
+            </Button>
+          </Paper>
+        ) : (
+          <>
+            <List>
+              {phrases.map((phrase, index) => (
+                <React.Fragment key={phrase.id}>
+                  <ListItem
+                    sx={{
+                      bgcolor: 'background.paper',
+                      borderRadius: 1,
+                      mb: 1,
+                      border: `1px solid ${theme.palette.divider}`
+                    }}
+                  >
+                    <ListItemText
+                      primary={
+                        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                          <Typography variant="subtitle1" fontWeight="medium">
+                            {phrase.title}
+                          </Typography>
+                          <Chip
+                            size="small"
+                            label={`${phrase.content.length} 字符`}
+                            variant="outlined"
+                          />
+                        </Box>
+                      }
+                      secondary={
+                        <Typography
+                          variant="body2"
+                          color="text.secondary"
+                          sx={{
+                            mt: 1,
+                            display: '-webkit-box',
+                            WebkitLineClamp: 2,
+                            WebkitBoxOrient: 'vertical',
+                            overflow: 'hidden'
+                          }}
+                        >
+                          {phrase.content}
+                        </Typography>
+                      }
+                    />
+                    <ListItemSecondaryAction>
+                      <IconButton
+                        edge="end"
+                        onClick={() => handleEdit(phrase)}
+                        size="small"
+                        sx={{ mr: 1 }}
+                      >
+                        <EditIcon size={18} />
+                      </IconButton>
+                      <IconButton
+                        edge="end"
+                        onClick={() => handleDelete(phrase.id)}
+                        size="small"
+                        color="error"
+                      >
+                        <DeleteIcon size={18} />
+                      </IconButton>
+                    </ListItemSecondaryAction>
+                  </ListItem>
+                  {index < phrases.length - 1 && <Divider />}
+                </React.Fragment>
+              ))}
+            </List>
+
+            <Fab
+              color="primary"
+              aria-label="添加快捷短语"
+              onClick={handleAdd}
+              sx={{
+                position: 'fixed',
+                bottom: 24,
+                right: 24
+              }}
+            >
+              <AddIcon />
+            </Fab>
+          </>
+        )}
+
+        {/* 添加/编辑对话框 */}
+        <Dialog
+          open={dialogOpen}
+          onClose={handleCloseDialog}
+          maxWidth="sm"
+          fullWidth
+        >
+          <DialogTitle>
+            {editingPhrase ? '编辑快捷短语' : '添加快捷短语'}
+          </DialogTitle>
+          <DialogContent>
+            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2, pt: 1 }}>
+              <TextField
+                label="标题"
+                value={formData.title}
+                onChange={(e) => setFormData({ ...formData, title: e.target.value })}
+                fullWidth
+                size="small"
+                placeholder="为您的快捷短语起个名字"
+              />
+              
+              <TextField
+                label="内容"
+                value={formData.content}
+                onChange={(e) => setFormData({ ...formData, content: e.target.value })}
+                multiline
+                rows={6}
+                fullWidth
+                size="small"
+                placeholder="输入快捷短语的内容..."
+              />
+
+              {formData.content && (
+                <Alert severity="info" sx={{ mt: 1 }}>
+                  内容长度：{formData.content.length} 字符
+                </Alert>
+              )}
+            </Box>
+          </DialogContent>
+          <DialogActions>
+            <Button onClick={handleCloseDialog}>取消</Button>
+            <Button
+              onClick={handleSave}
+              variant="contained"
+              disabled={!formData.title.trim() || !formData.content.trim()}
+            >
+              {editingPhrase ? '更新' : '添加'}
+            </Button>
+          </DialogActions>
+        </Dialog>
+      </Box>
     </Box>
   );
 };

--- a/src/components/input/IntegratedChatInput.tsx
+++ b/src/components/input/IntegratedChatInput.tsx
@@ -196,7 +196,7 @@ const IntegratedChatInput: React.FC<IntegratedChatInputProps> = ({
 
   // 从 useInputStyles hook 获取样式
   const { border, borderRadius, boxShadow } = styles;
-  const iconColor = themeColors.iconColor;
+  const iconColor = '#000'; // 强制使用黑色图标颜色
   const disabledColor = themeColors.isDark ? '#555' : '#ccc';
 
   // 检测iOS设备
@@ -795,7 +795,7 @@ const IntegratedChatInput: React.FC<IntegratedChatInputProps> = ({
                   onClick={handleOpenUploadMenu}
                   disabled={uploadingMedia || (isLoading && !allowConsecutiveMessages)}
                   style={{
-                    color: uploadingMedia ? disabledColor : iconColor,
+                    color: uploadingMedia ? disabledColor : '#000',
                     padding: '6px'
                   }}
                 >
@@ -837,7 +837,7 @@ const IntegratedChatInput: React.FC<IntegratedChatInputProps> = ({
                   size="medium"
                   onClick={handleQuickWebSearchToggle}
                   style={{
-                    color: webSearchActive ? '#3b82f6' : iconColor,
+                    color: webSearchActive ? '#3b82f6' : '#000',
                     backgroundColor: webSearchActive ? 'rgba(59, 130, 246, 0.1)' : 'transparent',
                     padding: '6px',
                     transition: 'all 0.2s ease-in-out'
@@ -854,7 +854,7 @@ const IntegratedChatInput: React.FC<IntegratedChatInputProps> = ({
                   disabled={uploadingMedia || (isLoading && !allowConsecutiveMessages)}
                   size="medium"
                   style={{
-                    color: voiceState !== 'normal' ? '#f44336' : iconColor,
+                    color: voiceState !== 'normal' ? '#f44336' : '#000',
                     padding: '6px',
                     backgroundColor: voiceState !== 'normal' ? 'rgba(211, 47, 47, 0.15)' : 'transparent',
                     transition: 'all 0.25s ease-in-out'

--- a/src/pages/Settings/MCPServerSettings.tsx
+++ b/src/pages/Settings/MCPServerSettings.tsx
@@ -653,7 +653,6 @@ const MCPServerSettings: React.FC = () => {
                           e.stopPropagation();
                           handleToggleServer(server.id, e.target.checked);
                         }}
-                        onClick={(e) => e.stopPropagation()}
                       />
                       <IconButton
                         onClick={(e) => {

--- a/src/pages/Settings/index.tsx
+++ b/src/pages/Settings/index.tsx
@@ -34,6 +34,7 @@ const SettingsPage: React.FC = () => {
   };
 
   const navigateTo = (path: string) => {
+    if (path === '/settings/shortcuts' || path === '/settings/features') return; // 功能未开放
     navigate(path);
   };
 
@@ -193,6 +194,7 @@ const SettingsPage: React.FC = () => {
                 >
                   <ListItemButton
                     onClick={() => navigateTo(item.path)}
+                    disabled={item.id === 'shortcuts' || item.id === 'features'}
                     sx={{
                       p: 0,
                       height: '100%',


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/94a2b584-d004-4cbe-9423-d4365bd75543)
![image](https://github.com/user-attachments/assets/5e7374d7-3a3e-4021-b188-827bd3495343)
![image](https://github.com/user-attachments/assets/bf573439-ca2b-4c56-b70b-af6b0286511a)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a back button to the Quick Phrase Settings page for easier navigation.

- **Style**
  - Improved layout and styling of the Quick Phrase Settings page, including a fixed AppBar, rounded sections, and enhanced scrollbar appearance.
  - Updated icons in the chat input area to use a consistent black color.

- **Bug Fixes**
  - Disabled access to the "Shortcuts" and "Features" sections in Settings.
  - Simplified event handling on the server activation switch without changing functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->