### PR TITLE
fix: refetch model list on every dialog open

### DIFF
--- a/src/components/dialogs/ModelManagementDialogSolid.tsx
+++ b/src/components/dialogs/ModelManagementDialogSolid.tsx
@@ -2,7 +2,7 @@
  * ModelManagementDialog - SolidJS 版本的 React 包装器
  * 使用 SolidBridge 桥接 SolidJS 组件
  */
-import React, { useState, useEffect, useRef, useMemo } from 'react';
+import React, { useState, useEffect, useMemo } from 'react';
 import { useTheme, alpha } from '@mui/material';
 import { SolidBridge } from '../../shared/bridges/SolidBridge';
 import { ModelManagementDrawer } from '../../solid/components/ModelSelector/ModelManagementDrawer.solid';
@@ -43,17 +43,16 @@ const ModelManagementDialogSolid: React.FC<ModelManagementDialogSolidProps> = ({
   const theme = useTheme();
   const [loading, setLoading] = useState<boolean>(false);
   const [models, setModels] = useState<Model[]>([]);
-  const initialProviderRef = useRef<any>(null);
 
   // 注册返回键处理，使手机系统返回键关闭此抽屉而非导航回上一页
   useDialogBackHandler('model-management-drawer', open, onClose);
 
   // 加载模型列表
   const loadModels = async () => {
+    if (!provider) return;
     try {
       setLoading(true);
-      const providerToUse = initialProviderRef.current || provider;
-      const fetchedModels = await fetchModels(providerToUse);
+      const fetchedModels = await fetchModels(provider);
       setModels(fetchedModels);
     } catch (error) {
       console.error('加载模型失败:', error);
@@ -63,13 +62,15 @@ const ModelManagementDialogSolid: React.FC<ModelManagementDialogSolidProps> = ({
     }
   };
 
-  // 当对话框打开时加载模型
+  // 每次对话框打开时都重新加载模型，保证用户能拿到最新结果
+  // 之前用 ref 缓存了首次打开时的 provider，导致同一 provider 重复打开时不会刷新
   useEffect(() => {
-    if (open && provider && (!initialProviderRef.current || initialProviderRef.current.id !== provider.id)) {
-      initialProviderRef.current = provider;
+    if (open && provider) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect
       loadModels();
     }
-  }, [open, provider]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open, provider?.id, provider?.apiKey, provider?.baseUrl]);
 
   // 主题模式
   const themeMode = useMemo(() => theme.palette.mode as 'light' | 'dark', [theme.palette.mode]);

--- a/src/components/dialogs/ModelManagementDialogSolid.tsx
+++ b/src/components/dialogs/ModelManagementDialogSolid.tsx
@@ -2,7 +2,7 @@
  * ModelManagementDialog - SolidJS 版本的 React 包装器
  * 使用 SolidBridge 桥接 SolidJS 组件
  */
-import React, { useState, useEffect, useMemo } from 'react';
+import React, { useState, useEffect, useMemo, useRef } from 'react';
 import { useTheme, alpha } from '@mui/material';
 import { SolidBridge } from '../../shared/bridges/SolidBridge';
 import { ModelManagementDrawer } from '../../solid/components/ModelSelector/ModelManagementDrawer.solid';
@@ -43,6 +43,9 @@ const ModelManagementDialogSolid: React.FC<ModelManagementDialogSolidProps> = ({
   const theme = useTheme();
   const [loading, setLoading] = useState<boolean>(false);
   const [models, setModels] = useState<Model[]>([]);
+  // 单调递增的请求序号，用来丢弃乱序回来的旧请求结果，避免快速重开/切换 provider
+  // 时旧响应覆盖新响应
+  const latestRequestRef = useRef(0);
 
   // 注册返回键处理，使手机系统返回键关闭此抽屉而非导航回上一页
   useDialogBackHandler('model-management-drawer', open, onClose);
@@ -50,15 +53,20 @@ const ModelManagementDialogSolid: React.FC<ModelManagementDialogSolidProps> = ({
   // 加载模型列表
   const loadModels = async () => {
     if (!provider) return;
+    const requestId = ++latestRequestRef.current;
+    setLoading(true);
     try {
-      setLoading(true);
       const fetchedModels = await fetchModels(provider);
+      if (requestId !== latestRequestRef.current) return;
       setModels(fetchedModels);
     } catch (error) {
+      if (requestId !== latestRequestRef.current) return;
       console.error('加载模型失败:', error);
       setModels([]);
     } finally {
-      setLoading(false);
+      if (requestId === latestRequestRef.current) {
+        setLoading(false);
+      }
     }
   };
 


### PR DESCRIPTION
The model management dialog uses a ref to cache the provider it was first opened with, which prevents `loadModels` from running again on subsequent opens of the same provider. The parent only toggles `open` (the dialog stays mounted), so users had to leave the provider settings page and come back to get fresh results.

Drop the ref-based gate and trigger `loadModels` whenever the dialog opens or the provider's identity/baseUrl/apiKey changes.

Fixes the 'fetch button only works once' issue reported on the provider settings page.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Model list now refreshes every time the management dialog opens and when provider settings change.
  * Loading state and results are more reliable—stale or out-of-order responses are ignored to ensure consistent model listings.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/1600822305/AetherLink/pull/71?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->