### PR TITLE
Phase 1 — 版本对齐：ai/@ai-sdk 升级到最新稳定 v6 并锁版本

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,9 @@
       "version": "0.6.3",
       "hasInstallScript": true,
       "dependencies": {
-        "@ai-sdk/anthropic": "^3.0.47",
-        "@ai-sdk/google": "^3.0.33",
-        "@ai-sdk/openai": "^3.0.33",
+        "@ai-sdk/anthropic": "3.0.81",
+        "@ai-sdk/google": "3.0.80",
+        "@ai-sdk/openai": "3.0.68",
         "@capacitor-community/file-opener": "^7.0.1",
         "@capacitor-community/speech-recognition": "^7.0.0",
         "@capacitor-community/text-to-speech": "^6.1.0",
@@ -84,7 +84,7 @@
         "@uiw/codemirror-theme-vscode": "^4.25.3",
         "@uiw/react-codemirror": "^4.23.13",
         "@use-gesture/react": "^10.3.1",
-        "ai": "^6.0.103",
+        "ai": "6.0.197",
         "axios": "^1.13.5",
         "buffer": "6.0.3",
         "capacitor-advanced-file-manager": "^2.1.2",
@@ -187,13 +187,13 @@
       }
     },
     "node_modules/@ai-sdk/anthropic": {
-      "version": "3.0.47",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/anthropic/-/anthropic-3.0.47.tgz",
-      "integrity": "sha512-E6Z3i/xvxGDxRskMMbuX9+xDK4l5LesrP2O7YQ0CcbAkYP25qTo/kYGf/AsJrLkNIY23HeO/kheUWtG1XZllDA==",
+      "version": "3.0.81",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/anthropic/-/anthropic-3.0.81.tgz",
+      "integrity": "sha512-B1JDd9Ugq9R5AgIaW3674lhGCMMYJcPUxnrZh8fzbGojgg4QvHFRv6eZahGQAUsmGHbcf74G9bdSBDLWQGY2GA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/provider": "3.0.8",
-        "@ai-sdk/provider-utils": "4.0.15"
+        "@ai-sdk/provider": "3.0.10",
+        "@ai-sdk/provider-utils": "4.0.27"
       },
       "engines": {
         "node": ">=18"
@@ -203,14 +203,14 @@
       }
     },
     "node_modules/@ai-sdk/gateway": {
-      "version": "3.0.57",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-3.0.57.tgz",
-      "integrity": "sha512-3MugqOlGfCOjlsBGGARJ5Zrioh78X3+rulHCayCMPySYKY+wc8GGFlFCCh4mleWQFShjMyqWT7eeLTuVSj/WSg==",
+      "version": "3.0.125",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-3.0.125.tgz",
+      "integrity": "sha512-tocl7cUDoTpmhZqeW8XVKMMznZQwwQAEunF0VyNKmf64qt8NbMIAEiet/vRMzh7Jr9WcFeb6EZjmhLTP4Qx2Og==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/provider": "3.0.8",
-        "@ai-sdk/provider-utils": "4.0.15",
-        "@vercel/oidc": "3.1.0"
+        "@ai-sdk/provider": "3.0.10",
+        "@ai-sdk/provider-utils": "4.0.27",
+        "@vercel/oidc": "3.2.0"
       },
       "engines": {
         "node": ">=18"
@@ -220,13 +220,13 @@
       }
     },
     "node_modules/@ai-sdk/google": {
-      "version": "3.0.33",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/google/-/google-3.0.33.tgz",
-      "integrity": "sha512-ElHkhMGMJ1MY5AlwLljWWE1jj+Bs3cMyq0KbeWUu2H89OsMAORiE4cB3xhfLlSIEnVmVKx/YHjoW3bN+DFI24A==",
+      "version": "3.0.80",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/google/-/google-3.0.80.tgz",
+      "integrity": "sha512-5ORbm/yFUPO0MEvZsxBMN0cdKw2+lwU/wVn5KN3KF8Dmk1LughuDuUohMh/7iU/XFTiyB0OvmTW/tdV/J7O9zg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/provider": "3.0.8",
-        "@ai-sdk/provider-utils": "4.0.15"
+        "@ai-sdk/provider": "3.0.10",
+        "@ai-sdk/provider-utils": "4.0.27"
       },
       "engines": {
         "node": ">=18"
@@ -236,13 +236,13 @@
       }
     },
     "node_modules/@ai-sdk/openai": {
-      "version": "3.0.35",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/openai/-/openai-3.0.35.tgz",
-      "integrity": "sha512-8NH21ctpFCbcfP15G7phkscFIrcfHnh0d2RZugsS/59j/rvyXmkf+Ogom+oWM8aaVgMNsNhmwaBD2TBqjm4FUg==",
+      "version": "3.0.68",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/openai/-/openai-3.0.68.tgz",
+      "integrity": "sha512-FCs/DPr4M95UyZ/ABHJmTmCEYRCka/4J0Bna0nsd78QCdGIS0X/zhn+fVzB7mZJo7464uOWYUjROx9PGNGOb0w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/provider": "3.0.8",
-        "@ai-sdk/provider-utils": "4.0.15"
+        "@ai-sdk/provider": "3.0.10",
+        "@ai-sdk/provider-utils": "4.0.27"
       },
       "engines": {
         "node": ">=18"
@@ -252,9 +252,9 @@
       }
     },
     "node_modules/@ai-sdk/provider": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.8.tgz",
-      "integrity": "sha512-oGMAgGoQdBXbZqNG0Ze56CHjDZ1IDYOwGYxYjO5KLSlz5HiNQ9udIXsPZ61VWaHGZ5XW/jyjmr6t2xz2jGVwbQ==",
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.10.tgz",
+      "integrity": "sha512-Q3BZ27qfpYqnCYGvE3vt+Qi6LGOF9R5Nmzn+9JoM1lCRsD9mYaIhfJLkSunN48nfGXJ6n+XNV0J/XVpqGQl7Dw==",
       "license": "Apache-2.0",
       "dependencies": {
         "json-schema": "^0.4.0"
@@ -264,14 +264,14 @@
       }
     },
     "node_modules/@ai-sdk/provider-utils": {
-      "version": "4.0.15",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-4.0.15.tgz",
-      "integrity": "sha512-8XiKWbemmCbvNN0CLR9u3PQiet4gtEVIrX4zzLxnCj06AwsEDJwJVBbKrEI4t6qE8XRSIvU2irka0dcpziKW6w==",
+      "version": "4.0.27",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-4.0.27.tgz",
+      "integrity": "sha512-ubkAJ+xODouwtmN1tYlvTPphH1hPOBfZaEQe8U7skGvFAnIRs9PPpsq57bC2+Ky/MB4yzhd6YOsxTAx9sGpazw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/provider": "3.0.8",
+        "@ai-sdk/provider": "3.0.10",
         "@standard-schema/spec": "^1.1.0",
-        "eventsource-parser": "^3.0.6"
+        "eventsource-parser": "^3.0.8"
       },
       "engines": {
         "node": ">=18"
@@ -6509,9 +6509,9 @@
       }
     },
     "node_modules/@vercel/oidc": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@vercel/oidc/-/oidc-3.1.0.tgz",
-      "integrity": "sha512-Fw28YZpRnA3cAHHDlkt7xQHiJ0fcL+NRcIqsocZQUSmbzeIKRpwttJjik5ZGanXP+vlA4SbTg+AbA3bP363l+w==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@vercel/oidc/-/oidc-3.2.0.tgz",
+      "integrity": "sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">= 20"
@@ -6777,15 +6777,15 @@
       }
     },
     "node_modules/ai": {
-      "version": "6.0.103",
-      "resolved": "https://registry.npmjs.org/ai/-/ai-6.0.103.tgz",
-      "integrity": "sha512-4eY6Ut4u41zKH+P2S/oLlZrwxeWQh4kIV1FjE34Jhoiwg+v1AyfSYM8FslXk9rTAtIIaOBimrCUqXacC5RBqJw==",
+      "version": "6.0.197",
+      "resolved": "https://registry.npmjs.org/ai/-/ai-6.0.197.tgz",
+      "integrity": "sha512-U3KsjkqwQXGHC0u0VeUDqUaNaBS/uQc7v4Vj92Cjv5lPx5DIyRBQYk4Hipy5vwD9AQKIG8uRvdaN9R+pAvrtcQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/gateway": "3.0.57",
-        "@ai-sdk/provider": "3.0.8",
-        "@ai-sdk/provider-utils": "4.0.15",
-        "@opentelemetry/api": "1.9.0"
+        "@ai-sdk/gateway": "3.0.125",
+        "@ai-sdk/provider": "3.0.10",
+        "@ai-sdk/provider-utils": "4.0.27",
+        "@opentelemetry/api": "^1.9.0"
       },
       "engines": {
         "node": ">=18"
@@ -9996,9 +9996,9 @@
       }
     },
     "node_modules/eventsource-parser": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.6.tgz",
-      "integrity": "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.0.tgz",
+      "integrity": "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==",
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"

--- a/package.json
+++ b/package.json
@@ -79,9 +79,9 @@
     "chevrotain": "11.0.3"
   },
   "dependencies": {
-    "@ai-sdk/anthropic": "^3.0.47",
-    "@ai-sdk/google": "^3.0.33",
-    "@ai-sdk/openai": "^3.0.33",
+    "@ai-sdk/anthropic": "3.0.81",
+    "@ai-sdk/google": "3.0.80",
+    "@ai-sdk/openai": "3.0.68",
     "@capacitor-community/file-opener": "^7.0.1",
     "@capacitor-community/speech-recognition": "^7.0.0",
     "@capacitor-community/text-to-speech": "^6.1.0",
@@ -154,7 +154,7 @@
     "@uiw/codemirror-theme-vscode": "^4.25.3",
     "@uiw/react-codemirror": "^4.23.13",
     "@use-gesture/react": "^10.3.1",
-    "ai": "^6.0.103",
+    "ai": "6.0.197",
     "axios": "^1.13.5",
     "buffer": "6.0.3",
     "capacitor-advanced-file-manager": "^2.1.2",

--- a/plans/ai-provider-refactor/README.md
+++ b/plans/ai-provider-refactor/README.md
@@ -243,7 +243,7 @@ src/shared/ai/
 |------:|------|:----:|----|----------|------|
 | — | 文档与计划（本文）| ✅ 完成 | 本 PR | 2026-06-08 | 建立 single source of truth |
 | 0 | 护栏（测试 + CI）| ✅ 完成 | #89 | 2026-06-08 | 4 条聊天路径 Chunk 契约特征测试（32 用例）+ PR Test(vitest) CI；CI 全绿（type-check/test/build/SonarCloud）；lint 因存量 230 errors 暂不门禁，留待 Phase 6 |
-| 1 | 版本对齐 v6 | ⬜ 未开始 | | | |
+| 1 | 版本对齐 v6 | ✅ 完成 | [#90](https://github.com/1600822305/AetherLink/pull/90) | 2026-06-08 | `ai`/`@ai-sdk/*` 升至最新稳定 v6 并 pin 精确版本；零架构改动；官方 `openai` 不动（Phase 4 删）；type-check/test(32)/build 全绿 |
 | 2 | 零风险清理 | ⬜ 未开始 | | | 删 `api/providerFactory.ts` |
 | 3 | 立契约 + 合并基类 | ⬜ 未开始 | | | |
 | 4 | 适配器化（逐家）| ⬜ 未开始 | | | 删 `api/openai`、接 openai-compatible |
@@ -260,6 +260,7 @@ src/shared/ai/
 - **2026-06-08** — 补充 §2 决策（保留 vs 删除官方 OpenAI：终态删、过渡先统一保留、例外按测试结果定）；新增 §2.5 `Chunk` 契约边界（论证 API 与信息块系统通过 Chunk 解耦，只要 Chunk 序列不变块系统不受影响，并列出高危改动让 Phase 0 测试覆盖）；新增 §2.6 信息块系统现状登记（~83 处 workaround，列为独立后续重构目标，不在本次 API 重构范围）。
 - **2026-06-08（Phase 0）** — 为四条聊天路径补齐 Chunk 契约特征测试（openai-aisdk 流式+非流式、官方 openai `UnifiedStreamProcessor`、anthropic-aisdk、gemini-aisdk），连同既有 tools 测试共 **33 用例全绿**；新增 `.github/workflows/pr-test.yml` 把 vitest 接入 PR CI（此前仅有 type-check 与 build）；用 DeepSeek 临时 key 跑通 live 基线，证实 `raw.reasoning_content` 推理映射与契约一致；评估 lint 门禁（存量 230 errors，暂缓）。详见 §6 Phase 0。
 - **2026-06-08（Phase 0 完成）** — 为通过 SonarCloud 新代码重复率门禁，将三家同构 AI SDK 测试（曾各自独立、重复率 48.8%）抽出共享参数化套件 `__tests__/shared/aisdkStreamContract.ts` 并合并进单文件 `__tests__/aisdk-stream.characterization.test.ts`（循环跑公共契约 + 各家特有推理用例），重复率降至达标；合并后 **32 用例全绿**，PR #89 CI 全绿（type-check / test / build / SonarCloud）。**Phase 0 标记完成**，可开始 Phase 1（版本对齐）。
+- **2026-06-08（Phase 1 完成）** — 版本对齐（零架构/逻辑改动）：把 `ai` `^6.0.103→6.0.197`、`@ai-sdk/openai` `^3.0.33→3.0.68`、`@ai-sdk/anthropic` `^3.0.47→3.0.81`、`@ai-sdk/google` `^3.0.33→3.0.80` 升至 npm 最新稳定 v6，并按"锁版本"要求 **pin 成精确版本（去 `^`）**；v7 仍 beta 未升。官方 `openai`（6.25.0）**保持不动**（Phase 4 删除目标，且本 Phase 范围仅含 `ai`/`@ai-sdk/*`）。`package-lock.json` 改动仅落在 `ai`/`@ai-sdk/*` 子树（含传递依赖 `@ai-sdk/provider`/`provider-utils`/`gateway`、`@vercel/oidc`、`eventsource-parser`），无不相关包变动。本机验证全绿：`type-check`（增量 + `tsc --noEmit` 全量）、`npm test` 32/32（Phase 0 Chunk 契约护栏未回归）、`vite build`（7990 modules）。PR [#90](https://github.com/1600822305/AetherLink/pull/90)。
 
 ---
 


### PR DESCRIPTION
## Summary

AI 供应商调用链重构 **Phase 1（版本对齐，零架构/逻辑改动）**。把聊天链路依赖的 `ai` + `@ai-sdk/*` 升级到 npm 最新稳定 **v6** 并 **pin 成精确版本**（按任务"锁版本"要求去掉 `^`）。v7 仍是 beta，不升。

仅 `package.json` + `package-lock.json` 改动，无任何源码改动 → 行为不变，Phase 0 的 32 个 Chunk 契约特征测试即回归护栏。

```diff
- "ai":               "^6.0.103"   →  "ai":               "6.0.197"
- "@ai-sdk/openai":   "^3.0.33"    →  "@ai-sdk/openai":   "3.0.68"
- "@ai-sdk/anthropic":"^3.0.47"    →  "@ai-sdk/anthropic":"3.0.81"
- "@ai-sdk/google":   "^3.0.33"    →  "@ai-sdk/google":   "3.0.80"
```

- **官方 `openai`（6.25.0）不动** —— 它是 Phase 4 的删除目标，且本 Phase 范围（§6）只含 `ai`/`@ai-sdk/*`。
- `package-lock.json` 改动全部落在 `ai`/`@ai-sdk/*` 依赖子树内（含其传递依赖 `@ai-sdk/provider`、`@ai-sdk/provider-utils`、`@ai-sdk/gateway`、`@vercel/oidc`、`eventsource-parser`），无任何不相关包变动。

## 验证

本机（`npm install` 后）全绿，且为非增量复核：
- `npm run type-check`（增量）✅ 与 `tsc --noEmit`（全量）✅
- `npm test` → 32/32 通过（Phase 0 Chunk 契约特征测试，回归护栏）✅
- `npm run build`（vite，7990 modules transformed）✅

均为 v6 大版本内的补丁/小版本号 bump，代码已使用 v6 写法（`streamText` + `result.fullStream` + parts），无预期 breaking。

## 文档

按重构铁律更新 `plans/ai-provider-refactor/README.md`：§7 进度表 Phase 1 → ✅ 完成（PR 链接 + 日期），§8 追加变更日志。

## 范围 / 非目标

- 不改 Chunk 产出逻辑、不碰信息块系统、不删任何 provider 目录（Phase 4）。
- 无 Gemini/Claude 官方 key，以 mock 特征测试兜底（已绿）。


Link to Devin session: https://app.devin.ai/sessions/8005d246a76840daa71de00d6da0d0bd
Requested by: @1600822305

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated AI SDK dependencies to stable pinned versions for improved stability.

* **Documentation**
  * Updated project roadmap marking Phase 1 completion for version alignment and stability verification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->