### PR TITLE
Phase 3b — 立契约：AIProvider / ProviderApi 强类型接口（现状面，零逻辑改动）

### DIFF
--- a/src/shared/ai/core/types.ts
+++ b/src/shared/ai/core/types.ts
@@ -1,0 +1,65 @@
+/**
+ * AI 供应商调用链 —— 强类型契约（Phase 3b 立契约）
+ *
+ * 本文件刻画的是「现状实际被调用的最小公共面」，把工厂 `getProviderApi` 的
+ * `any` 返回与各 provider 之间的隐式约定显式化，**零行为改动**。
+ *
+ * 与 README §4.1 的关系：§4.1 描述的归一化目标契约（`chat(params): ChatResult`）
+ * 是更后续阶段的迁移终态。这里先用「现状面契约」把当前真实接口钉死，作为合并基类
+ * （Phase 3c）与收紧工厂返回类型（Phase 3d）的承载，后续再向 §4.1 演进，互不冲突。
+ */
+import type { Message, MCPTool, Model } from '../../types';
+import type { Chunk } from '../../types/chunk';
+
+/**
+ * `sendChatMessage` / `sendChatRequest` 的可选项
+ * 字段与现有各 provider 实现保持一致。
+ */
+export interface ChatOptions {
+  onChunk?: (chunk: Chunk) => void;
+  enableWebSearch?: boolean;
+  enableThinking?: boolean;
+  enableTools?: boolean;
+  tools?: string[];
+  mcpTools?: MCPTool[];
+  systemPrompt?: string;
+  abortSignal?: AbortSignal;
+}
+
+/**
+ * 聊天返回（现状 union 形态）
+ * Phase 3b 仅如实刻画，归一为 README §4.1 的 `ChatResult` 留待后续阶段。
+ */
+export type ChatMessageResult =
+  | string
+  | { content: string; reasoning?: string; reasoningTime?: number };
+
+/**
+ * AI Provider 类实例契约
+ *
+ * 由 `AbstractBaseProvider`（api/baseProvider.ts）及其所有子类实现：
+ * openai / openai-aisdk / anthropic-aisdk / gemini-aisdk / dashscope。
+ */
+export interface AIProvider {
+  /** 发送聊天消息（支持流式 onChunk 回调） */
+  sendChatMessage(messages: Message[], options?: ChatOptions): Promise<ChatMessageResult>;
+  /** 测试 API 连接 */
+  testConnection(): Promise<boolean>;
+  /** 将 MCP 工具转换为供应商特定的工具格式 */
+  convertMcpTools<T>(mcpTools: MCPTool[]): T[];
+}
+
+/**
+ * 工厂 `getProviderApi(model)` 的返回契约
+ *
+ * 刻画现状两种返回形状（内联适配对象 / `openaiApi` 命名空间）共同满足的最小面。
+ * Phase 3d 会把 `getProviderApi` 的返回类型从 `any` 收紧为本接口，逼出隐藏耦合。
+ */
+export interface ProviderApi {
+  /** 发送聊天请求 */
+  sendChatRequest(messages: any[], model: Model, options?: ChatOptions): Promise<ChatMessageResult>;
+  /** 测试 API 连接 */
+  testConnection(model: Model): Promise<boolean>;
+  /** 拉取模型列表（部分供应商提供） */
+  fetchModels?: (...args: any[]) => Promise<any>;
+}

--- a/src/shared/api/baseProvider.ts
+++ b/src/shared/api/baseProvider.ts
@@ -3,6 +3,7 @@
  * 定义了所有AI提供者必须实现的方法，并提供 MCP 工具调用的通用功能
  */
 import type { Message, MCPTool, Model } from '../types';
+import type { AIProvider } from '../ai/core/types';
 import { buildSystemPrompt, type WorkspaceInfo } from '../utils/mcpPrompt';
 import { workspaceService } from '../services/files/WorkspaceService';
 
@@ -41,7 +42,7 @@ sendChatMessage(
  * 抽象基础提供者类
  * 提供 MCP 工具调用的通用功能和智能切换机制
  */
-export abstract class AbstractBaseProvider implements BaseProvider {
+export abstract class AbstractBaseProvider implements BaseProvider, AIProvider {
   // 工具数量阈值：超过此数量将强制使用系统提示词模式
   private static readonly SYSTEM_PROMPT_THRESHOLD: number = 128;
 


### PR DESCRIPTION
## Summary

Phase 3 第二步：为「一个 AI 供应商能做什么」立显式强类型契约，把工厂 `getProviderApi` 的 `any` 返回与各 provider 之间的隐式约定显式化。**纯加类型，零运行逻辑改动**，作为后续合并基类（3c）、收紧工厂返回类型（3d）的承载。

> 基于 PR #92（3a）。3a 合并后本 PR base 会自动指向 main。

### 新增 `src/shared/ai/core/types.ts`

```ts
export interface ChatOptions { onChunk?; enableWebSearch?; enableThinking?; enableTools?; tools?; mcpTools?; systemPrompt?; abortSignal? }
export type ChatMessageResult = string | { content: string; reasoning?: string; reasoningTime?: number };

// provider 类实例契约（AbstractBaseProvider 及其 5 个子类实现）
export interface AIProvider {
  sendChatMessage(messages: Message[], options?: ChatOptions): Promise<ChatMessageResult>;
  testConnection(): Promise<boolean>;
  convertMcpTools<T>(mcpTools: MCPTool[]): T[];
}

// getProviderApi(model) 的返回契约（3d 用它替换 any）
export interface ProviderApi {
  sendChatRequest(messages: any[], model: Model, options?: ChatOptions): Promise<ChatMessageResult>;
  testConnection(model: Model): Promise<boolean>;
  fetchModels?: (...args: any[]) => Promise<any>;
}
```

### 应用

- `AbstractBaseProvider` 增加 `implements AIProvider`（原 `implements BaseProvider` → `implements BaseProvider, AIProvider`）。这一步**编译期证明** openai / openai-aisdk / anthropic-aisdk / gemini-aisdk / dashscope 五个在用主 provider 都符合契约，否则 `tsc` 会报错。

### 关于 README §4.1 的取舍（需你知悉）

README §4.1 草拟的是**归一化目标契约** `chat(params): Promise<ChatResult>`——那是把所有 provider 的方法名与返回类型统一重写的**终态**，属行为/接口改动，不符合本阶段「重构 PR 行为不变」。因此本 PR 立的是**现状面契约**（`sendChatMessage` + union 返回），先把当前真实接口钉死；向 §4.1 的 `chat()/ChatResult` 归一留待后续阶段（届时配特征测试兜底）。如果你希望直接上 §4.1 的归一化 API，请告诉我，我会改为分多步迁移而非一次性。

## 验证

- `npm run type-check:tsc` ✅（`implements AIProvider` 编译通过 = 5 个主 provider 符合契约）
- `npm test`（32/32）✅
- `npm run build` ✅

净变更：+67 / -1，新增 1 个类型文件 + 1 处 `implements` 标注，无运行逻辑改动。


Link to Devin session: https://app.devin.ai/sessions/8005d246a76840daa71de00d6da0d0bd
Requested by: @1600822305