### PR TITLE
Phase 3d — 收紧工厂返回类型：getProviderApi any → ProviderApi（零行为改动）

### DIFF
--- a/src/shared/ai/core/types.ts
+++ b/src/shared/ai/core/types.ts
@@ -58,8 +58,8 @@ export interface AIProvider {
 export interface ProviderApi {
   /** 发送聊天请求 */
   sendChatRequest(messages: any[], model: Model, options?: ChatOptions): Promise<ChatMessageResult>;
-  /** 测试 API 连接 */
-  testConnection(model: Model): Promise<boolean>;
+  /** 测试 API 连接（model-combo 等聚合实现不提供，故可选） */
+  testConnection?: (model: Model) => Promise<boolean>;
   /** 拉取模型列表（部分供应商提供） */
   fetchModels?: (...args: any[]) => Promise<any>;
 }

--- a/src/shared/services/ai/ProviderFactory.ts
+++ b/src/shared/services/ai/ProviderFactory.ts
@@ -3,6 +3,7 @@
  * 负责根据供应商类型返回适当的API处理模块
  */
 import type { Model } from '../../types';
+import type { ProviderApi } from '../../ai/core/types';
 import * as openaiApi from '../../api/openai';
 import { parseModelsResponse, normalizeModel } from '../../api/openai/models';
 import * as anthropicApi from '../../api/anthropic-aisdk';
@@ -96,7 +97,7 @@ function isAzureOpenAI(model: Model): boolean {
  * @param model 模型配置
  * @returns 供应商API模块
  */
-export function getProviderApi(model: Model): any {
+export function getProviderApi(model: Model): ProviderApi {
   const providerType = getActualProviderType(model);
 
   // 扩展的Provider选择逻辑，支持Azure OpenAI和模型组合
@@ -209,6 +210,10 @@ export function getProviderApi(model: Model): any {
 export async function testConnection(model: Model): Promise<boolean> {
   try {
     const api = getProviderApi(model);
+    if (!api.testConnection) {
+      console.warn('[ProviderFactory.testConnection] 当前供应商 API 不支持连接测试');
+      return false;
+    }
     return await api.testConnection(model);
   } catch (error) {
     console.error('API连接测试失败:', error);


### PR DESCRIPTION
## Summary

Phase 3 收尾：把工厂 `getProviderApi(model)` 的返回类型从 `any` 收紧为 3b 立的 `ProviderApi` 契约，让「工厂返回面」从隐式约定变成编译期可校验的强类型。**零运行行为改动。**

> 基于 PR #94（3c）→ #93（3b）→ #92（3a）。前序合并后本 PR base 会自动指向 main。

### 改动

```diff
- export function getProviderApi(model: Model): any {
+ export function getProviderApi(model: Model): ProviderApi {
```

收紧后逼出一处真实的隐藏耦合：

```ts
// model-combo 分支只返回 { sendChatRequest }，没有 testConnection
case 'model-combo':
  return { sendChatRequest: async (messages, model) => handleModelComboRequest(...) };
```

模型组合是多模型聚合，**没有「单一连接」可测**，所以它本就不提供 `testConnection`。据此把契约改成诚实的形状：

```diff
  interface ProviderApi {
    sendChatRequest(messages, model, options?): Promise<ChatMessageResult>;
-   testConnection(model: Model): Promise<boolean>;
+   testConnection?: (model: Model) => Promise<boolean>;   // model-combo 等聚合实现不提供
    fetchModels?: (...args) => Promise<any>;
  }
```

并对唯一直接调用该可选方法的地方加守卫（行为等价）：

```diff
  const api = getProviderApi(model);
+ if (!api.testConnection) return false;   // 与旧行为一致：model-combo 此前 undefined() 抛错→catch→false
  return await api.testConnection(model);
```

### 校验过的契约符合性

- 两种返回形状均满足 `ProviderApi`：内联适配对象（anthropic / gemini / openai-aisdk / gemini-aisdk / dashscope / model-combo）与 `openaiApi` 命名空间（azure / openai / default 等）。
- 全部 4 处调用方（`ProviderFactory.testConnection`、`ProviderFactory.sendChatRequest`、`api/index.ts` 的 testApiConnection 与 processModelRequest）只用到 `sendChatRequest` / `testConnection`，无人依赖 `openaiApi` 命名空间的额外成员 —— 收紧不破坏任何下游。

## 验证

- `npm run type-check:tsc` ✅（收紧后 0 错误 = 工厂返回面已被契约完整覆盖）
- `npm test`（32/32 Chunk 契约护栏）✅
- `npm run build` ✅

净变更：+8 / -3。


Link to Devin session: https://app.devin.ai/sessions/8005d246a76840daa71de00d6da0d0bd
Requested by: @1600822305