### PR TITLE
Phase 4d — 去重：抽取三家 *-aisdk stream.ts 共享逻辑到 ai/adapters/shared/streamShared.ts（零行为改动）

### DIFF
--- a/src/shared/ai/adapters/shared/streamShared.ts
+++ b/src/shared/ai/adapters/shared/streamShared.ts
@@ -1,0 +1,266 @@
+/**
+ * AI SDK 适配器共享流式工具（Phase 4 去重）
+ *
+ * 把三家 *-aisdk 的 stream.ts 中**逐字重复**的部分抽到这里（单一副本）：
+ * ThinkTagParser、基础类型、供应商配置读取、工具调用累积、全局事件 emit、
+ * 防幻觉 stopSequences。各家 stream.ts 的 fullStream 循环（推理/思考时机差异）
+ * 仍保留在各自文件中——这是有意为之，不强行合并真差异。
+ */
+import { EventEmitter, EVENT_NAMES } from '../../../services/infra/EventEmitter';
+import { hasToolUseTags } from '../../../utils/mcpToolParser';
+import { ChunkType, type Chunk } from '../../../types/chunk';
+import type { ReasoningTag } from '../../../config/reasoningTags';
+import type { Model, MCPTool } from '../../../types';
+import type { ModelProvider } from '../../../config/defaultModels';
+import store from '../../../store';
+
+/**
+ * 解析推理标签内容
+ * 支持动态配置的开始/结束标签
+ */
+export class ThinkTagParser {
+  private contentBuffer = '';
+  private isInThinkTag = false;
+  private thinkBuffer = '';
+  private reasoningStartTime = 0;
+  private hasReasoningContent = false;
+  private openingTag: string;
+  private closingTag: string;
+
+  constructor(tag?: ReasoningTag) {
+    // 支持动态配置的推理标签
+    this.openingTag = tag?.openingTag || '<think>';
+    this.closingTag = tag?.closingTag || '</think>';
+  }
+
+  /**
+   * 处理文本块
+   * @returns { normalText: string, thinkText: string, isThinking: boolean }
+   */
+  processChunk(text: string): { normalText: string; thinkText: string; isThinking: boolean } {
+    this.contentBuffer += text;
+
+    let normalText = '';
+    let thinkText = '';
+    let processedAny = true;
+
+    while (processedAny && this.contentBuffer.length > 0) {
+      processedAny = false;
+
+      if (!this.isInThinkTag) {
+        // 查找开始标签
+        const thinkStartIndex = this.contentBuffer.indexOf(this.openingTag);
+        if (thinkStartIndex !== -1) {
+          // 处理开始标签之前的普通内容
+          normalText += this.contentBuffer.substring(0, thinkStartIndex);
+
+          // 进入思考模式
+          this.isInThinkTag = true;
+          if (!this.hasReasoningContent) {
+            this.hasReasoningContent = true;
+            this.reasoningStartTime = Date.now();
+          }
+
+          this.contentBuffer = this.contentBuffer.substring(thinkStartIndex + this.openingTag.length);
+          processedAny = true;
+        } else if (this.contentBuffer.length > this.openingTag.length + 5) {
+          // 没有找到开始标签，输出安全的内容
+          const safeLength = this.contentBuffer.length - (this.openingTag.length + 5);
+          const safeContent = this.contentBuffer.substring(0, safeLength);
+          normalText += safeContent;
+          this.contentBuffer = this.contentBuffer.substring(safeLength);
+          processedAny = true;
+        }
+      } else {
+        // 在思考标签内，查找结束标签
+        const thinkEndIndex = this.contentBuffer.indexOf(this.closingTag);
+        if (thinkEndIndex !== -1) {
+          // 处理思考内容
+          thinkText += this.contentBuffer.substring(0, thinkEndIndex);
+          this.thinkBuffer += this.contentBuffer.substring(0, thinkEndIndex);
+
+          // 退出思考模式
+          this.isInThinkTag = false;
+          this.contentBuffer = this.contentBuffer.substring(thinkEndIndex + this.closingTag.length);
+          processedAny = true;
+        } else if (this.contentBuffer.length > this.closingTag.length + 5) {
+          // 没有找到结束标签，输出安全的思考内容
+          const safeLength = this.contentBuffer.length - (this.closingTag.length + 5);
+          const safeThinkContent = this.contentBuffer.substring(0, safeLength);
+          thinkText += safeThinkContent;
+          this.thinkBuffer += safeThinkContent;
+          this.contentBuffer = this.contentBuffer.substring(safeLength);
+          processedAny = true;
+        }
+      }
+    }
+
+    return { normalText, thinkText, isThinking: this.isInThinkTag };
+  }
+
+  /**
+   * 流结束时处理剩余内容
+   */
+  flush(): { normalText: string; thinkText: string } {
+    let normalText = '';
+    let thinkText = '';
+
+    if (this.contentBuffer.length > 0) {
+      if (this.isInThinkTag) {
+        thinkText = this.contentBuffer;
+        this.thinkBuffer += this.contentBuffer;
+      } else {
+        normalText = this.contentBuffer;
+      }
+      this.contentBuffer = '';
+    }
+
+    return { normalText, thinkText };
+  }
+
+  getFullThinkContent(): string {
+    return this.thinkBuffer;
+  }
+
+  getReasoningTime(): number {
+    return this.hasReasoningContent ? Date.now() - this.reasoningStartTime : 0;
+  }
+}
+
+/**
+ * 流式响应结果基础类型（各家可 extends 扩展私有字段）
+ */
+export interface BaseStreamResult {
+  content: string;
+  reasoning?: string;
+  reasoningTime?: number;
+  hasToolCalls?: boolean;
+  nativeToolCalls?: any[];
+}
+
+/**
+ * 流式请求参数基础类型（各家可 extends 扩展私有字段）
+ */
+export interface BaseStreamParams {
+  messages?: any[];
+  temperature?: number;
+  max_tokens?: number;
+  top_p?: number;
+  tools?: any[];
+  tool_choice?: any;
+  signal?: AbortSignal;
+  enableTools?: boolean;
+  mcpTools?: MCPTool[];
+  mcpMode?: 'prompt' | 'function';
+  model?: Model;
+  /** 自定义请求体参数（优先级：模型级别 > 供应商级别） */
+  extraBody?: Record<string, any>;
+}
+
+/**
+ * 获取模型对应的供应商配置
+ */
+export function getProviderConfigFromStore(model: Model): ModelProvider | null {
+  try {
+    const state = store.getState();
+    const providers = state.settings?.providers;
+
+    if (!providers || !Array.isArray(providers)) {
+      return null;
+    }
+
+    // 根据模型的 provider 字段查找对应的供应商
+    const provider = providers.find((p: ModelProvider) => p.id === model.provider);
+    return provider || null;
+  } catch (error) {
+    console.error('[AI SDK Stream] 获取供应商配置失败:', error);
+    return null;
+  }
+}
+
+/**
+ * 累积一个 AI SDK `tool-call` part：推入 toolCalls 数组并发出 MCP_TOOL_CREATED。
+ * @param opts.includeToolUseId 是否额外带 toolUseId 字段（Anthropic 需要）
+ */
+export function accumulateToolCall(
+  part: any,
+  toolCalls: any[],
+  onChunk?: (chunk: Chunk) => void,
+  opts?: { includeToolUseId?: boolean }
+): void {
+  // AI SDK v6 使用 input 而不是 args
+  const toolInput = part.input || part.args || {};
+  const entry: any = {
+    id: part.toolCallId,
+    type: 'function',
+    function: {
+      name: part.toolName,
+      arguments: JSON.stringify(toolInput)
+    }
+  };
+  if (opts?.includeToolUseId) {
+    entry.toolUseId = part.toolCallId;
+  }
+  toolCalls.push(entry);
+
+  // 使用 MCP_TOOL_CREATED 类型
+  onChunk?.({
+    type: ChunkType.MCP_TOOL_CREATED,
+    responses: [{
+      id: part.toolCallId,
+      name: part.toolName,
+      arguments: toolInput,
+      status: 'pending'
+    }]
+  });
+}
+
+/**
+ * 发送流式完成的全局事件
+ */
+export function emitStreamComplete(
+  provider: string,
+  modelId: string,
+  content: string,
+  reasoning: string
+): void {
+  EventEmitter.emit(EVENT_NAMES.STREAM_COMPLETE, {
+    provider,
+    model: modelId,
+    content,
+    reasoning,
+    timestamp: Date.now()
+  });
+}
+
+/**
+ * 发送流式错误的全局事件
+ */
+export function emitStreamError(provider: string, modelId: string, error: any): void {
+  EventEmitter.emit(EVENT_NAMES.STREAM_ERROR, {
+    provider,
+    model: modelId,
+    error: error?.message,
+    timestamp: Date.now()
+  });
+}
+
+/**
+ * 检查内容里的 XML 工具使用标签，命中则发出 TOOL_USE_DETECTED 全局事件
+ */
+export function detectAndEmitToolUseTags(content: string, modelId: string, logLabel: string): void {
+  if (hasToolUseTags(content)) {
+    console.log(`[${logLabel}] 检测到 XML 工具使用标签`);
+    EventEmitter.emit(EVENT_NAMES.TOOL_USE_DETECTED, {
+      content,
+      model: modelId
+    });
+  }
+}
+
+/**
+ * 🛡️ Prompt 模式防幻觉的 stop sequence
+ * 当工具通过系统提示词注入（非原生函数调用）时，模型可能在 </tool_use> 后
+ * 继续生成 <tool_use_result> 幻觉内容。添加 stop sequence 强制模型停止。
+ */
+export const PROMPT_MODE_STOP_SEQUENCES = ['<tool_use_result'];

--- a/src/shared/api/anthropic-aisdk/stream.ts
+++ b/src/shared/api/anthropic-aisdk/stream.ts
@@ -6,135 +6,32 @@
 import { streamText, generateText } from 'ai';
 import type { AnthropicProvider as AISDKAnthropicProvider } from '@ai-sdk/anthropic';
 import { logApiRequest } from '../../services/infra/LoggerService';
-import { EventEmitter, EVENT_NAMES } from '../../services/infra/EventEmitter';
 import { hasToolUseTags } from '../../utils/mcpToolParser';
 import { ChunkType, type Chunk } from '../../types/chunk';
-import type { Model, MCPTool } from '../../types';
+import type { Model } from '../../types';
 import { convertMcpToolsToAISDK } from './tools';
 import { supportsExtendedThinking, isClaudeReasoningModel } from './client';
-import { getAppropriateTag, type ReasoningTag, DEFAULT_REASONING_TAGS } from '../../config/reasoningTags';
-
-/**
- * 解析推理标签内容（用于兼容非原生推理模式）
- */
-class ThinkTagParser {
-  private contentBuffer = '';
-  private isInThinkTag = false;
-  private thinkBuffer = '';
-  private reasoningStartTime = 0;
-  private hasReasoningContent = false;
-  private openingTag: string;
-  private closingTag: string;
-
-  constructor(tag?: ReasoningTag) {
-    this.openingTag = tag?.openingTag || '<thinking>';
-    this.closingTag = tag?.closingTag || '</thinking>';
-  }
-
-  processChunk(text: string): { normalText: string; thinkText: string; isThinking: boolean } {
-    this.contentBuffer += text;
-    
-    let normalText = '';
-    let thinkText = '';
-    let processedAny = true;
-
-    while (processedAny && this.contentBuffer.length > 0) {
-      processedAny = false;
-
-      if (!this.isInThinkTag) {
-        const thinkStartIndex = this.contentBuffer.indexOf(this.openingTag);
-        if (thinkStartIndex !== -1) {
-          normalText += this.contentBuffer.substring(0, thinkStartIndex);
-          this.isInThinkTag = true;
-          if (!this.hasReasoningContent) {
-            this.hasReasoningContent = true;
-            this.reasoningStartTime = Date.now();
-          }
-          this.contentBuffer = this.contentBuffer.substring(thinkStartIndex + this.openingTag.length);
-          processedAny = true;
-        } else if (this.contentBuffer.length > this.openingTag.length + 5) {
-          const safeLength = this.contentBuffer.length - (this.openingTag.length + 5);
-          const safeContent = this.contentBuffer.substring(0, safeLength);
-          normalText += safeContent;
-          this.contentBuffer = this.contentBuffer.substring(safeLength);
-          processedAny = true;
-        }
-      } else {
-        const thinkEndIndex = this.contentBuffer.indexOf(this.closingTag);
-        if (thinkEndIndex !== -1) {
-          thinkText += this.contentBuffer.substring(0, thinkEndIndex);
-          this.thinkBuffer += this.contentBuffer.substring(0, thinkEndIndex);
-          this.isInThinkTag = false;
-          this.contentBuffer = this.contentBuffer.substring(thinkEndIndex + this.closingTag.length);
-          processedAny = true;
-        } else if (this.contentBuffer.length > this.closingTag.length + 5) {
-          const safeLength = this.contentBuffer.length - (this.closingTag.length + 5);
-          const safeThinkContent = this.contentBuffer.substring(0, safeLength);
-          thinkText += safeThinkContent;
-          this.thinkBuffer += safeThinkContent;
-          this.contentBuffer = this.contentBuffer.substring(safeLength);
-          processedAny = true;
-        }
-      }
-    }
-
-    return { normalText, thinkText, isThinking: this.isInThinkTag };
-  }
-
-  flush(): { normalText: string; thinkText: string } {
-    let normalText = '';
-    let thinkText = '';
-
-    if (this.contentBuffer.length > 0) {
-      if (this.isInThinkTag) {
-        thinkText = this.contentBuffer;
-        this.thinkBuffer += this.contentBuffer;
-      } else {
-        normalText = this.contentBuffer;
-      }
-      this.contentBuffer = '';
-    }
-
-    return { normalText, thinkText };
-  }
-
-  getFullThinkContent(): string {
-    return this.thinkBuffer;
-  }
-
-  getReasoningTime(): number {
-    return this.hasReasoningContent ? Date.now() - this.reasoningStartTime : 0;
-  }
-}
+import { getAppropriateTag, DEFAULT_REASONING_TAGS } from '../../config/reasoningTags';
+import {
+  ThinkTagParser,
+  accumulateToolCall,
+  emitStreamComplete,
+  emitStreamError,
+  detectAndEmitToolUseTags,
+  PROMPT_MODE_STOP_SEQUENCES,
+  type BaseStreamResult,
+  type BaseStreamParams,
+} from '../../ai/adapters/shared/streamShared';
 
 /**
  * 流式响应结果类型
  */
-export interface StreamResult {
-  content: string;
-  reasoning?: string;
-  reasoningTime?: number;
-  hasToolCalls?: boolean;
-  nativeToolCalls?: any[];
-}
+export interface StreamResult extends BaseStreamResult {}
 
 /**
  * 流式请求参数
  */
-export interface StreamParams {
-  messages?: any[];
-  temperature?: number;
-  max_tokens?: number;
-  top_p?: number;
-  tools?: any[];
-  tool_choice?: any;
-  signal?: AbortSignal;
-  enableTools?: boolean;
-  mcpTools?: MCPTool[];
-  mcpMode?: 'prompt' | 'function';
-  model?: Model;
-  /** 自定义请求体参数 */
-  extraBody?: Record<string, any>;
+export interface StreamParams extends BaseStreamParams {
   /** 是否启用 Extended Thinking */
   enableThinking?: boolean;
   /** 思考预算 Token 数 */
@@ -203,7 +100,7 @@ export async function streamCompletion(
 
     // 🛡️ Prompt 模式防幻觉：添加 stopSequences
     const isPromptMode = !enableTools && mcpTools.length > 0;
-    const stopSequences = isPromptMode ? ['<tool_use_result'] : undefined;
+    const stopSequences = isPromptMode ? PROMPT_MODE_STOP_SEQUENCES : undefined;
 
     // 准备 providerOptions
     let providerOptions: Record<string, any> = {};
@@ -308,26 +205,7 @@ export async function streamCompletion(
 
         case 'tool-call':
           console.log(`[Anthropic SDK Stream] 检测到工具调用: ${part.toolName}`);
-          const toolInput = (part as any).input || (part as any).args || {};
-          toolCalls.push({
-            id: part.toolCallId,
-            toolUseId: part.toolCallId,
-            type: 'function',
-            function: {
-              name: part.toolName,
-              arguments: JSON.stringify(toolInput)
-            }
-          });
-          
-          onChunk?.({
-            type: ChunkType.MCP_TOOL_CREATED,
-            responses: [{
-              id: part.toolCallId,
-              name: part.toolName,
-              arguments: toolInput,
-              status: 'pending'
-            }]
-          });
+          accumulateToolCall(part, toolCalls, onChunk, { includeToolUseId: true });
           break;
 
         case 'finish':
@@ -370,22 +248,10 @@ export async function streamCompletion(
     }
 
     // 发送全局事件
-    EventEmitter.emit(EVENT_NAMES.STREAM_COMPLETE, {
-      provider: 'anthropic-aisdk',
-      model: modelId,
-      content: fullContent,
-      reasoning: fullReasoning,
-      timestamp: Date.now()
-    });
+    emitStreamComplete('anthropic-aisdk', modelId, fullContent, fullReasoning);
 
     // 检查工具使用标签（XML 模式）
-    if (hasToolUseTags(fullContent)) {
-      console.log(`[Anthropic SDK Stream] 检测到 XML 工具使用标签`);
-      EventEmitter.emit(EVENT_NAMES.TOOL_USE_DETECTED, {
-        content: fullContent,
-        model: modelId
-      });
-    }
+    detectAndEmitToolUseTags(fullContent, modelId, 'Anthropic SDK Stream');
 
     const endTime = Date.now();
     console.log(`[Anthropic SDK Stream] 完成，耗时: ${endTime - startTime}ms`);
@@ -400,14 +266,7 @@ export async function streamCompletion(
 
   } catch (error: any) {
     console.error('[Anthropic SDK Stream] 流式响应失败:', error);
-
-    EventEmitter.emit(EVENT_NAMES.STREAM_ERROR, {
-      provider: 'anthropic-aisdk',
-      model: modelId,
-      error: error.message,
-      timestamp: Date.now()
-    });
-
+    emitStreamError('anthropic-aisdk', modelId, error);
     throw error;
   }
 }
@@ -456,7 +315,7 @@ export async function nonStreamCompletion(
 
     // 🛡️ Prompt 模式防幻觉：添加 stopSequences
     const isPromptMode = !enableTools && mcpTools.length > 0;
-    const stopSequences = isPromptMode ? ['<tool_use_result'] : undefined;
+    const stopSequences = isPromptMode ? PROMPT_MODE_STOP_SEQUENCES : undefined;
 
     // 准备 providerOptions
     let providerOptions: Record<string, any> = {};

--- a/src/shared/api/gemini-aisdk/stream.ts
+++ b/src/shared/api/gemini-aisdk/stream.ts
@@ -6,44 +6,25 @@
 import { streamText, generateText } from 'ai';
 import type { GoogleGenerativeAIProvider } from '@ai-sdk/google';
 import { logApiRequest } from '../../services/infra/LoggerService';
-import { EventEmitter, EVENT_NAMES } from '../../services/infra/EventEmitter';
 import { hasToolUseTags } from '../../utils/mcpToolParser';
 import { ChunkType, type Chunk } from '../../types/chunk';
 // ThinkTagParser 不再需要，Gemini 启用 thinkingConfig 后思考内容通过 reasoning-delta 返回
-import type { Model, MCPTool } from '../../types';
-import type { ModelProvider } from '../../config/defaultModels';
 import { convertMcpToolsToAISDK, parseGroundingMetadata } from './tools';
-import store from '../../store';
-
-/**
- * 获取模型对应的供应商配置
- */
-function getProviderConfig(model: Model): ModelProvider | null {
-  try {
-    const state = store.getState();
-    const providers = state.settings?.providers;
-
-    if (!providers || !Array.isArray(providers)) {
-      return null;
-    }
-
-    const provider = providers.find((p: ModelProvider) => p.id === model.provider);
-    return provider || null;
-  } catch (error) {
-    console.error('[Gemini AI SDK Stream] 获取供应商配置失败:', error);
-    return null;
-  }
-}
+import {
+  getProviderConfigFromStore,
+  accumulateToolCall,
+  emitStreamComplete,
+  emitStreamError,
+  detectAndEmitToolUseTags,
+  PROMPT_MODE_STOP_SEQUENCES,
+  type BaseStreamResult,
+  type BaseStreamParams,
+} from '../../ai/adapters/shared/streamShared';
 
 /**
  * 流式响应结果类型
  */
-export interface StreamResult {
-  content: string;
-  reasoning?: string;
-  reasoningTime?: number;
-  hasToolCalls?: boolean;
-  nativeToolCalls?: any[];
+export interface StreamResult extends BaseStreamResult {
   /** Gemini 特有：搜索结果来源 */
   sources?: any[];
   /** Gemini 特有：grounding metadata */
@@ -53,20 +34,7 @@ export interface StreamResult {
 /**
  * 流式请求参数
  */
-export interface StreamParams {
-  messages?: any[];
-  temperature?: number;
-  max_tokens?: number;
-  top_p?: number;
-  tools?: any[];
-  tool_choice?: any;
-  signal?: AbortSignal;
-  enableTools?: boolean;
-  mcpTools?: MCPTool[];
-  mcpMode?: 'prompt' | 'function';
-  model?: Model;
-  /** 自定义请求体参数 */
-  extraBody?: Record<string, any>;
+export interface StreamParams extends BaseStreamParams {
   /** 是否启用 Google Search */
   enableGoogleSearch?: boolean;
   /** Gemini 思考预算配置 */
@@ -100,7 +68,7 @@ export async function streamCompletion(
   const enableGoogleSearch = additionalParams?.enableGoogleSearch || false;
 
   // 获取供应商配置和 extraBody
-  const providerConfig = model ? getProviderConfig(model) : null;
+  const providerConfig = model ? getProviderConfigFromStore(model) : null;
   const extraBody = additionalParams?.extraBody || 
                     providerConfig?.extraBody ||
                     (model as any)?.extraBody || 
@@ -195,7 +163,7 @@ export async function streamCompletion(
 
     // 🛡️ Prompt 模式防幻觉：添加 stopSequences
     const isPromptMode = !enableTools && mcpTools.length > 0;
-    const stopSequences = isPromptMode ? ['<tool_use_result'] : undefined;
+    const stopSequences = isPromptMode ? PROMPT_MODE_STOP_SEQUENCES : undefined;
 
     console.log(`[Gemini AI SDK Stream] 创建流式请求`);
 
@@ -248,25 +216,7 @@ export async function streamCompletion(
 
         case 'tool-call':
           console.log(`[Gemini AI SDK Stream] 检测到工具调用: ${part.toolName}`);
-          const toolInput = (part as any).input || (part as any).args || {};
-          toolCalls.push({
-            id: part.toolCallId,
-            type: 'function',
-            function: {
-              name: part.toolName,
-              arguments: JSON.stringify(toolInput)
-            }
-          });
-          
-          onChunk?.({
-            type: ChunkType.MCP_TOOL_CREATED,
-            responses: [{
-              id: part.toolCallId,
-              name: part.toolName,
-              arguments: toolInput,
-              status: 'pending'
-            }]
-          });
+          accumulateToolCall(part, toolCalls, onChunk);
           break;
 
         case 'reasoning-delta':
@@ -321,22 +271,10 @@ export async function streamCompletion(
     }
 
     // 发送全局事件
-    EventEmitter.emit(EVENT_NAMES.STREAM_COMPLETE, {
-      provider: 'gemini-aisdk',
-      model: modelId,
-      content: fullContent,
-      reasoning: fullReasoning,
-      timestamp: Date.now()
-    });
+    emitStreamComplete('gemini-aisdk', modelId, fullContent, fullReasoning);
 
     // 检查工具使用标签（XML 模式）
-    if (hasToolUseTags(fullContent)) {
-      console.log(`[Gemini AI SDK Stream] 检测到 XML 工具使用标签`);
-      EventEmitter.emit(EVENT_NAMES.TOOL_USE_DETECTED, {
-        content: fullContent,
-        model: modelId
-      });
-    }
+    detectAndEmitToolUseTags(fullContent, modelId, 'Gemini AI SDK Stream');
 
     const endTime = Date.now();
     console.log(`[Gemini AI SDK Stream] 完成，耗时: ${endTime - startTime}ms`);
@@ -353,14 +291,7 @@ export async function streamCompletion(
 
   } catch (error: any) {
     console.error('[Gemini AI SDK Stream] 流式响应失败:', error);
-
-    EventEmitter.emit(EVENT_NAMES.STREAM_ERROR, {
-      provider: 'gemini-aisdk',
-      model: modelId,
-      error: error.message,
-      timestamp: Date.now()
-    });
-
+    emitStreamError('gemini-aisdk', modelId, error);
     throw error;
   }
 }
@@ -454,7 +385,7 @@ export async function nonStreamCompletion(
 
     // 🛡️ Prompt 模式防幻觉：添加 stopSequences
     const isPromptMode = !enableTools && mcpTools.length > 0;
-    const stopSequences = isPromptMode ? ['<tool_use_result'] : undefined;
+    const stopSequences = isPromptMode ? PROMPT_MODE_STOP_SEQUENCES : undefined;
 
     const result = await generateText({
       model: client(modelId),

--- a/src/shared/api/openai-aisdk/stream.ts
+++ b/src/shared/api/openai-aisdk/stream.ts
@@ -6,179 +6,34 @@
 import { streamText, generateText } from 'ai';
 import type { OpenAIProvider as AISDKOpenAIProvider } from '@ai-sdk/openai';
 import { logApiRequest } from '../../services/infra/LoggerService';
-import { EventEmitter, EVENT_NAMES } from '../../services/infra/EventEmitter';
 import { hasToolUseTags } from '../../utils/mcpToolParser';
 import { ChunkType, type Chunk } from '../../types/chunk';
-import { getAppropriateTag, type ReasoningTag, DEFAULT_REASONING_TAGS } from '../../config/reasoningTags';
+import { getAppropriateTag, DEFAULT_REASONING_TAGS } from '../../config/reasoningTags';
 import type { Model, MCPTool } from '../../types';
-import type { ModelProvider } from '../../config/defaultModels';
 import { convertMcpToolsToAISDK } from './tools';
-import store from '../../store';
-
-/**
- * 获取模型对应的供应商配置
- */
-function getProviderConfig(model: Model): ModelProvider | null {
-  try {
-    const state = store.getState();
-    const providers = state.settings?.providers;
-
-    if (!providers || !Array.isArray(providers)) {
-      return null;
-    }
-
-    // 根据模型的 provider 字段查找对应的供应商
-    const provider = providers.find((p: ModelProvider) => p.id === model.provider);
-    return provider || null;
-  } catch (error) {
-    console.error('[AI SDK Stream] 获取供应商配置失败:', error);
-    return null;
-  }
-}
+import {
+  ThinkTagParser,
+  getProviderConfigFromStore,
+  accumulateToolCall,
+  emitStreamComplete,
+  emitStreamError,
+  detectAndEmitToolUseTags,
+  PROMPT_MODE_STOP_SEQUENCES,
+  type BaseStreamResult,
+  type BaseStreamParams,
+} from '../../ai/adapters/shared/streamShared';
 
 /**
  * 流式响应结果类型
  */
-export interface StreamResult {
-  content: string;
-  reasoning?: string;
-  reasoningTime?: number;
-  hasToolCalls?: boolean;
-  nativeToolCalls?: any[];
-}
+export interface StreamResult extends BaseStreamResult {}
 
 /**
  * 流式请求参数
  */
-export interface StreamParams {
-  messages?: any[];
-  temperature?: number;
-  max_tokens?: number;
-  top_p?: number;
-  tools?: any[];
-  tool_choice?: any;
-  signal?: AbortSignal;
-  enableTools?: boolean;
-  mcpTools?: MCPTool[];
-  mcpMode?: 'prompt' | 'function';
-  model?: Model;
-  /** 自定义请求体参数（优先级：模型级别 > 供应商级别） */
-  extraBody?: Record<string, any>;
+export interface StreamParams extends BaseStreamParams {
   /** 是否使用 Responses API（仅对 OpenAI 官方 API 有效） */
   useResponsesAPI?: boolean;
-}
-
-/**
- * 解析推理标签内容
- * 支持动态配置的开始/结束标签
- */
-class ThinkTagParser {
-  private contentBuffer = '';
-  private isInThinkTag = false;
-  private thinkBuffer = '';
-  private reasoningStartTime = 0;
-  private hasReasoningContent = false;
-  private openingTag: string;
-  private closingTag: string;
-
-  constructor(tag?: ReasoningTag) {
-    // 支持动态配置的推理标签
-    this.openingTag = tag?.openingTag || '<think>';
-    this.closingTag = tag?.closingTag || '</think>';
-  }
-
-  /**
-   * 处理文本块
-   * @returns { normalText: string, thinkText: string, isThinking: boolean }
-   */
-  processChunk(text: string): { normalText: string; thinkText: string; isThinking: boolean } {
-    this.contentBuffer += text;
-    
-    let normalText = '';
-    let thinkText = '';
-    let processedAny = true;
-
-    while (processedAny && this.contentBuffer.length > 0) {
-      processedAny = false;
-
-      if (!this.isInThinkTag) {
-        // 查找开始标签
-        const thinkStartIndex = this.contentBuffer.indexOf(this.openingTag);
-        if (thinkStartIndex !== -1) {
-          // 处理开始标签之前的普通内容
-          normalText += this.contentBuffer.substring(0, thinkStartIndex);
-          
-          // 进入思考模式
-          this.isInThinkTag = true;
-          if (!this.hasReasoningContent) {
-            this.hasReasoningContent = true;
-            this.reasoningStartTime = Date.now();
-          }
-          
-          this.contentBuffer = this.contentBuffer.substring(thinkStartIndex + this.openingTag.length);
-          processedAny = true;
-        } else if (this.contentBuffer.length > this.openingTag.length + 5) {
-          // 没有找到开始标签，输出安全的内容
-          const safeLength = this.contentBuffer.length - (this.openingTag.length + 5);
-          const safeContent = this.contentBuffer.substring(0, safeLength);
-          normalText += safeContent;
-          this.contentBuffer = this.contentBuffer.substring(safeLength);
-          processedAny = true;
-        }
-      } else {
-        // 在思考标签内，查找结束标签
-        const thinkEndIndex = this.contentBuffer.indexOf(this.closingTag);
-        if (thinkEndIndex !== -1) {
-          // 处理思考内容
-          thinkText += this.contentBuffer.substring(0, thinkEndIndex);
-          this.thinkBuffer += this.contentBuffer.substring(0, thinkEndIndex);
-          
-          // 退出思考模式
-          this.isInThinkTag = false;
-          this.contentBuffer = this.contentBuffer.substring(thinkEndIndex + this.closingTag.length);
-          processedAny = true;
-        } else if (this.contentBuffer.length > this.closingTag.length + 5) {
-          // 没有找到结束标签，输出安全的思考内容
-          const safeLength = this.contentBuffer.length - (this.closingTag.length + 5);
-          const safeThinkContent = this.contentBuffer.substring(0, safeLength);
-          thinkText += safeThinkContent;
-          this.thinkBuffer += safeThinkContent;
-          this.contentBuffer = this.contentBuffer.substring(safeLength);
-          processedAny = true;
-        }
-      }
-    }
-
-    return { normalText, thinkText, isThinking: this.isInThinkTag };
-  }
-
-  /**
-   * 流结束时处理剩余内容
-   */
-  flush(): { normalText: string; thinkText: string } {
-    let normalText = '';
-    let thinkText = '';
-
-    if (this.contentBuffer.length > 0) {
-      if (this.isInThinkTag) {
-        thinkText = this.contentBuffer;
-        this.thinkBuffer += this.contentBuffer;
-      } else {
-        normalText = this.contentBuffer;
-      }
-      this.contentBuffer = '';
-    }
-
-    return { normalText, thinkText };
-  }
-
-  getFullThinkContent(): string {
-    return this.thinkBuffer;
-  }
-
-  getReasoningTime(): number {
-    return this.hasReasoningContent ? Date.now() - this.reasoningStartTime : 0;
-  }
 }
 
 /**
@@ -209,7 +64,7 @@ export async function streamCompletion(
                     (model as any)?.providerExtraBody;
 
   // 获取 Responses API 开关配置（优先级：供应商配置 > 模型配置 > 默认关闭）
-  const providerConfig = model ? getProviderConfig(model) : null;
+  const providerConfig = model ? getProviderConfigFromStore(model) : null;
   const useResponsesAPI = providerConfig?.useResponsesAPI || 
                           additionalParams?.useResponsesAPI || 
                           (model as any)?.useResponsesAPI || 
@@ -271,7 +126,7 @@ export async function streamCompletion(
     // 继续生成 <tool_use_result> 幻觉内容。添加 stop sequence 强制模型停止，
     // 让多轮循环（provider.ts while loop）真正发挥作用
     const isPromptMode = !enableTools && mcpTools.length > 0;
-    const stopSequences = isPromptMode ? ['<tool_use_result'] : undefined;
+    const stopSequences = isPromptMode ? PROMPT_MODE_STOP_SEQUENCES : undefined;
 
     // 准备 providerOptions（用于传递 extraBody）
     let providerOptions: Record<string, any> | undefined;
@@ -336,27 +191,7 @@ export async function streamCompletion(
 
         case 'tool-call':
           console.log(`[AI SDK Stream] 检测到工具调用: ${part.toolName}`);
-          // AI SDK v6 使用 input 而不是 args
-          const toolInput = (part as any).input || (part as any).args || {};
-          toolCalls.push({
-            id: part.toolCallId,
-            type: 'function',
-            function: {
-              name: part.toolName,
-              arguments: JSON.stringify(toolInput)
-            }
-          });
-          
-          // 使用 MCP_TOOL_CREATED 类型
-          onChunk?.({
-            type: ChunkType.MCP_TOOL_CREATED,
-            responses: [{
-              id: part.toolCallId,
-              name: part.toolName,
-              arguments: toolInput,
-              status: 'pending'
-            }]
-          });
+          accumulateToolCall(part, toolCalls, onChunk);
           break;
 
         case 'reasoning-delta':
@@ -446,22 +281,10 @@ export async function streamCompletion(
     }
 
     // 发送全局事件
-    EventEmitter.emit(EVENT_NAMES.STREAM_COMPLETE, {
-      provider: 'openai-aisdk',
-      model: modelId,
-      content: fullContent,
-      reasoning: fullReasoning,
-      timestamp: Date.now()
-    });
+    emitStreamComplete('openai-aisdk', modelId, fullContent, fullReasoning);
 
     // 检查工具使用标签（XML 模式）
-    if (hasToolUseTags(fullContent)) {
-      console.log(`[AI SDK Stream] 检测到 XML 工具使用标签`);
-      EventEmitter.emit(EVENT_NAMES.TOOL_USE_DETECTED, {
-        content: fullContent,
-        model: modelId
-      });
-    }
+    detectAndEmitToolUseTags(fullContent, modelId, 'AI SDK Stream');
 
     const endTime = Date.now();
     console.log(`[AI SDK Stream] 完成，耗时: ${endTime - startTime}ms`);
@@ -477,14 +300,7 @@ export async function streamCompletion(
 
   } catch (error: any) {
     console.error('[AI SDK Stream] 流式响应失败:', error);
-
-    EventEmitter.emit(EVENT_NAMES.STREAM_ERROR, {
-      provider: 'openai-aisdk',
-      model: modelId,
-      error: error.message,
-      timestamp: Date.now()
-    });
-
+    emitStreamError('openai-aisdk', modelId, error);
     throw error;
   }
 }
@@ -515,7 +331,7 @@ export async function nonStreamCompletion(
                     (model as any)?.providerExtraBody;
 
   // 获取 Responses API 开关配置（优先级：供应商配置 > 模型配置 > 默认关闭）
-  const providerConfigNonStream = model ? getProviderConfig(model) : null;
+  const providerConfigNonStream = model ? getProviderConfigFromStore(model) : null;
   const useResponsesAPI = providerConfigNonStream?.useResponsesAPI || 
                           additionalParams?.useResponsesAPI || 
                           (model as any)?.useResponsesAPI || 
@@ -535,7 +351,7 @@ export async function nonStreamCompletion(
 
     // 🛡️ Prompt 模式防幻觉：添加 stopSequences
     const isPromptMode = !enableTools && mcpTools.length > 0;
-    const stopSequences = isPromptMode ? ['<tool_use_result'] : undefined;
+    const stopSequences = isPromptMode ? PROMPT_MODE_STOP_SEQUENCES : undefined;
 
     // 准备 providerOptions（用于传递 extraBody）
     let providerOptions: Record<string, any> | undefined;


### PR DESCRIPTION
## Summary
Phase 4 的关键前置步：把三家 `*-aisdk`（openai/anthropic/gemini）的 `stream.ts` 中**逐字重复**的部分抽到**单一共享件** `src/shared/ai/adapters/shared/streamShared.ts`，消除三处重复。**零行为改动**，三家同一个 PR 一起改（只改一家会让新共享件与未迁移版本重复，仍触发门禁）。

**为什么现在做**：上一轮 #98（直接 `git mv` 搬目录到 `ai/adapters/anthropic`）撞了 SonarCloud **新代码重复率门禁**（36.8% vs ≤3%）——搬动的 `stream.ts` 与另两家近乎逐字重复，被算成"新代码重复"。企业级"Clean as You Code" + DRY 的正解是**先抽公共去重、再搬目录**，而非把一坨重复代码原样挪位置。本 PR 完成去重后，后续目录收敛（4b/4c）才不会再触发门禁。

## 抽取边界（保守：只抽真重复，不强行合并真差异）
新建 `streamShared.ts`（单一副本），导出三家逐字重复的部分：
- `class ThinkTagParser` — `<think>` 标签流式解析（openai/anthropic 逻辑一致）
- `interface BaseStreamResult` / `BaseStreamParams` — 各家用 `extends` 扩展私有字段
- `getProviderConfigFromStore(model)` — 从 store 读供应商配置
- `accumulateToolCall(part, toolCalls, onChunk, opts?)` — 累积 `tool-call` part + 发 `MCP_TOOL_CREATED`
- `emitStreamComplete` / `emitStreamError` / `detectAndEmitToolUseTags` — 收尾全局事件
- `const PROMPT_MODE_STOP_SEQUENCES = ['<tool_use_result']` — Prompt 模式防幻觉 stop sequence

三家 `stream.ts`：删本地副本 → 改 `import`，**`fullStream` 循环原样保留不动**（推理/思考时机是真差异，尤其 Gemini 的 `THINKING_COMPLETE` 流中发，Phase 0 已钉死，不合并）。

```ts
// 各家 stream.ts
import { ThinkTagParser, getProviderConfigFromStore, accumulateToolCall,
         emitStreamComplete, emitStreamError, detectAndEmitToolUseTags,
         PROMPT_MODE_STOP_SEQUENCES, type BaseStreamResult, type BaseStreamParams }
  from '../../ai/adapters/shared/streamShared';

export interface StreamResult extends BaseStreamResult { /* 各家私有字段 */ }
export interface StreamParams extends BaseStreamParams { /* 各家私有字段 */ }
```

**各家差异点**（已正确处理）：
- Anthropic：`accumulateToolCall(part, toolCalls, onChunk, { includeToolUseId: true })` 保留其私有 `toolUseId` 字段
- OpenAI / Gemini：`accumulateToolCall(part, toolCalls, onChunk)` 标准调用，无需 opts

净变化：3 个 stream.ts 共 **-455 / +61 行**（约 -394 行重复），新增 1 个共享件。

## 验证
- `npm run type-check` ✅ 0 错误
- `npm test` ✅ **32/32**（Phase 0 特征测试 = 行为护栏，全绿 = 零回归）
- `npm run build` ✅ vite build 通过

## 不在本 PR 范围
- 目录收敛 `*-aisdk → ai/adapters/<vendor>`（4b/4c，去重合并后再做，届时不触发门禁）
- 引擎切换 / 删官方 openai 聊天（4e–4g，需 live key）

Link to Devin session: https://app.devin.ai/sessions/8005d246a76840daa71de00d6da0d0bd
Requested by: @1600822305