### PR TITLE
Phase 4e — openai-aisdk 接私有参数：修复 web search 私有字段被丢弃，透传到 providerOptions

### DIFF
--- a/src/shared/api/openai-aisdk/__tests__/web-search-params.test.ts
+++ b/src/shared/api/openai-aisdk/__tests__/web-search-params.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Phase 4e — 回归测试：openai-aisdk 路径的 web search 私有参数透传
+//
+// 背景（见 plans/ai-provider-refactor/phase4e-analysis.md 发现 B）：
+// OpenAIAISDKProvider.sendChatMessage 曾算出 webSearchParams 却在
+// handleStreamResponse 里被丢弃（签名声明、函数体未消费），导致 dashscope
+// `enable_search` / openrouter `plugins` / openai `web_search_options` 等私有
+// body 字段在 AI SDK 路径完全失效。修复后这些字段应并入 extraBody，由
+// stream.ts 落到 providerOptions.openai 透传进请求体。
+//
+// 这里 mock `./stream` 捕获 streamCompletion / nonStreamCompletion 收到的
+// additionalParams.extraBody，断言 web search 私有字段确实被透传。
+// ---------------------------------------------------------------------------
+
+const streamCompletionMock = vi.fn();
+const nonStreamCompletionMock = vi.fn();
+
+vi.mock('../stream', () => ({
+  streamCompletion: (...a: unknown[]) => streamCompletionMock(...a),
+  nonStreamCompletion: (...a: unknown[]) => nonStreamCompletionMock(...a),
+}));
+// provider.ts 经 baseProvider → ai/core/BaseProvider 间接依赖 store / 服务，
+// mock 掉避免测试在模块加载期触网/触 IndexedDB。
+vi.mock('../../../store', () => ({ default: { getState: () => ({ settings: { providers: [] } }) } }));
+vi.mock('../../../services/files/WorkspaceService', () => ({ workspaceService: { getWorkspaces: () => [] } }));
+vi.mock('../../../services/infra/LoggerService', () => ({ logApiRequest: vi.fn() }));
+
+import { OpenAIAISDKProvider } from '../provider';
+import type { Model } from '../../../types';
+
+/**
+ * 用 Object.create 跳过构造器（构造器只建真实 AI SDK 客户端 + 参数管理器，
+ * 与本测试无关），手动注入 model 并覆写 sendChatMessage 依赖的协作方法，
+ * 只保留待测的 webSearchParams → extraBody 合并逻辑。
+ */
+function makeProvider(model: Model, stream: boolean) {
+  const p = Object.create(OpenAIAISDKProvider.prototype) as any;
+  p.model = model;
+  p.client = { chat: () => ({}), responses: () => ({}) };
+  // 覆写协作方法（均非本次被测逻辑）
+  p.setupToolsConfig = () => ({ tools: [] });
+  p.prepareAPIMessages = async (m: unknown[]) => m;
+  p.getApiParams = () => ({
+    unified: { stream },
+    apiParams: { temperature: 0.7, max_tokens: 100 },
+  });
+  p.getUseSystemPromptForTools = () => false;
+  return p;
+}
+
+function extraBodyFromStream() {
+  // streamCompletion(client, modelId, messages, temperature, maxTokens, additionalParams, onChunk)
+  const call = streamCompletionMock.mock.calls[0];
+  return call?.[5]?.extraBody as Record<string, any> | undefined;
+}
+function extraBodyFromNonStream() {
+  const call = nonStreamCompletionMock.mock.calls[0];
+  return call?.[5]?.extraBody as Record<string, any> | undefined;
+}
+
+beforeEach(() => {
+  streamCompletionMock.mockReset();
+  nonStreamCompletionMock.mockReset();
+  // 默认无工具调用，sendChatMessage 一轮即返回
+  streamCompletionMock.mockResolvedValue({ content: 'ok', hasToolCalls: false });
+  nonStreamCompletionMock.mockResolvedValue({ content: 'ok', hasToolCalls: false });
+});
+
+const webSearchModel = (provider: string): Model =>
+  ({ id: 'gpt-4o', provider, apiKey: 'sk-x', capabilities: { webSearch: true } } as unknown as Model);
+
+describe('OpenAIAISDKProvider — web search 私有参数透传到 extraBody', () => {
+  it('openrouter: enableWebSearch 时 plugins 进入 extraBody（流式）', async () => {
+    const p = makeProvider(webSearchModel('openrouter'), true);
+    await p.sendChatMessage([{ role: 'user', content: 'hi' }], { enableWebSearch: true });
+
+    const extraBody = extraBodyFromStream();
+    expect(extraBody).toBeDefined();
+    expect(extraBody!.plugins).toEqual([{ id: 'web', search_prompts: ['Search the web for...'] }]);
+    // apiParams 仍保留（合并而非覆盖）
+    expect(extraBody!.temperature).toBe(0.7);
+  });
+
+  it('openai: enableWebSearch 时 web_search_options 进入 extraBody（流式）', async () => {
+    const p = makeProvider(webSearchModel('openai'), true);
+    await p.sendChatMessage([{ role: 'user', content: 'hi' }], { enableWebSearch: true });
+
+    const extraBody = extraBodyFromStream();
+    expect(extraBody!.web_search_options).toEqual({});
+  });
+
+  it('非流式路径同样透传 web search 私有参数', async () => {
+    const p = makeProvider(webSearchModel('dashscope'), false);
+    await p.sendChatMessage([{ role: 'user', content: 'hi' }], { enableWebSearch: true });
+
+    const extraBody = extraBodyFromNonStream();
+    expect(extraBody!.enable_search).toBe(true);
+    expect(extraBody!.search_options).toEqual({ forced_search: true });
+  });
+
+  it('enableWebSearch=false 时不注入任何 web search 字段（extraBody 仅含 apiParams）', async () => {
+    const p = makeProvider(webSearchModel('openrouter'), true);
+    await p.sendChatMessage([{ role: 'user', content: 'hi' }], { enableWebSearch: false });
+
+    const extraBody = extraBodyFromStream();
+    expect(extraBody!.plugins).toBeUndefined();
+    expect(extraBody!.web_search_options).toBeUndefined();
+    expect(extraBody!.temperature).toBe(0.7);
+  });
+
+  it('模型不支持 web search 时即使 enableWebSearch=true 也不注入', async () => {
+    const noSearch = { id: 'gpt-4o', provider: 'openrouter', apiKey: 'sk-x', capabilities: {} } as unknown as Model;
+    const p = makeProvider(noSearch, true);
+    await p.sendChatMessage([{ role: 'user', content: 'hi' }], { enableWebSearch: true });
+
+    const extraBody = extraBodyFromStream();
+    expect(extraBody!.plugins).toBeUndefined();
+  });
+});

--- a/src/shared/api/openai-aisdk/provider.ts
+++ b/src/shared/api/openai-aisdk/provider.ts
@@ -333,10 +333,16 @@ export class OpenAIAISDKProvider extends BaseOpenAIAISDKProvider {
       throw new Error('API 密钥未设置，请在设置中配置 OpenAI API 密钥');
     }
 
-    // 添加网页搜索参数
+    // 添加网页搜索参数：把各供应商私有 body 字段（dashscope enable_search /
+    // openrouter plugins / openai web_search_options 等，见 client.getWebSearchParams）
+    // 与 apiParams 合并为统一 extraBody，由 stream.ts 落到 providerOptions.openai
+    // 透传进请求体（web search 字段优先，与官方 openai 路径 Object.assign 语义一致）。
     const webSearchParams = enableWebSearch && this.supportsWebSearch()
       ? getWebSearchParams(this.model, enableWebSearch)
       : {};
+    const extraBody = Object.keys(webSearchParams).length > 0
+      ? { ...apiParams, ...webSearchParams }
+      : apiParams;
 
     try {
       if (streamEnabled) {
@@ -348,8 +354,7 @@ export class OpenAIAISDKProvider extends BaseOpenAIAISDKProvider {
           mcpMode,
           onChunk,
           abortSignal,
-          webSearchParams,
-          extraBody: apiParams
+          extraBody
         });
       } else {
         return await this.handleNonStreamResponse(apiMessages, {
@@ -360,7 +365,7 @@ export class OpenAIAISDKProvider extends BaseOpenAIAISDKProvider {
           mcpMode,
           onChunk,
           abortSignal,
-          extraBody: apiParams
+          extraBody
         });
       }
     } catch (error: any) {
@@ -392,7 +397,6 @@ export class OpenAIAISDKProvider extends BaseOpenAIAISDKProvider {
       mcpMode: 'prompt' | 'function';
       onChunk?: (chunk: Chunk) => void;
       abortSignal?: AbortSignal;
-      webSearchParams?: any;
       extraBody?: Record<string, any>;
     }
   ): Promise<string | { content: string; reasoning?: string; reasoningTime?: number }> {


### PR DESCRIPTION
## Summary

Phase 4e 第一步（**不切默认引擎、不需 key、对现网零影响**）：修复 `OpenAIAISDKProvider` 的一处**静默丢弃 bug** —— web search 私有参数算出来却没接上。

`sendChatMessage` 调用 `getWebSearchParams(model, enableWebSearch)` 得到各供应商私有 body 字段（dashscope `enable_search` / openrouter `plugins` / openai `web_search_options` / hunyuan `enable_enhancement` 等），把它放进 `webSearchParams` 传给 `handleStreamResponse`。但 `handleStreamResponse` 的函数体**从未解构/消费** `webSearchParams`（只是在 options 类型里声明了），且 `handleNonStreamResponse` 压根没收到它。结果：AI SDK 路径上这些私有字段**全部丢失**。

对照官方 openai 路径（`api/openai/provider.ts`）是 `Object.assign(requestParams, getWebSearchParams(...))` 直接进 body。本 PR 让 AI SDK 路径行为对齐：把 web search 字段并入 `extraBody`，由 `stream.ts` 已有的 `extraBody → providerOptions.openai` 通道透传进请求体。

```diff
- const webSearchParams = enableWebSearch && this.supportsWebSearch()
-   ? getWebSearchParams(this.model, enableWebSearch) : {};
- // stream:    { ..., webSearchParams, extraBody: apiParams }   // webSearchParams 被丢弃
- // nonStream: { ..., extraBody: apiParams }                    // 根本没传
+ const webSearchParams = enableWebSearch && this.supportsWebSearch()
+   ? getWebSearchParams(this.model, enableWebSearch) : {};
+ const extraBody = Object.keys(webSearchParams).length > 0
+   ? { ...apiParams, ...webSearchParams }   // web search 字段优先，对齐官方 Object.assign
+   : apiParams;
+ // stream & nonStream 都传 { ..., extraBody }
```

同时移除 `handleStreamResponse` options 里那个已无用的 `webSearchParams?: any` 死字段。

**为什么零现网影响**：app 默认聊天引擎仍是官方 `OpenAIProvider`（`services/messages/ApiProvider.ts` 的 default case），`OpenAIAISDKProvider` 仅在用户显式把 `providerType` 设为 `openai-aisdk` 时才走到。把默认引擎切到 AI SDK 是后续 4f/4g 的事（需 live key 逐家回归）。本 PR 只是把 AI SDK 引擎"补齐到可切换状态"。

## 测试

新增 `openai-aisdk/__tests__/web-search-params.test.ts`（5 用例），mock `./stream` 捕获 `streamCompletion`/`nonStreamCompletion` 收到的 `extraBody`，钉死：
- openrouter `plugins` / openai `web_search_options` / dashscope `enable_search`+`search_options` 确实进入 `extraBody`（流式 + 非流式）；
- web search 字段与 `apiParams` 合并（`temperature` 仍在），不互相覆盖；
- `enableWebSearch=false` 或模型不支持 web search 时不注入任何字段。

本机全绿：`type-check` ✅ / `test` **46/46**（原 41 + 新 5）✅ / `build` ✅。零行为改动针对默认路径。

> 说明：`provider.ts:379` 有一条 `preserve-caught-error` lint error，属**搬运前就存在**的旧代码（本 PR 未触碰该 catch 块），且 lint 当前非 PR 门禁（存量 230 errors，留 Phase 6 设基线）。新增测试文件 eslint 0 问题。

Link to Devin session: https://app.devin.ai/sessions/8005d246a76840daa71de00d6da0d0bd
Requested by: @1600822305