### PR TITLE
fix: 修复设置页返回聊天界面的性能问题和架构 bug

### DIFF
--- a/src/pages/ChatPage/components/ChatPageUI.tsx
+++ b/src/pages/ChatPage/components/ChatPageUI.tsx
@@ -673,39 +673,31 @@ const ChatPageUIComponent: React.FC<ChatPageUIProps> = ({
     }
   }, [currentTopic, handleMultiModelSend]);
 
-  const handleSendImagePrompt = (prompt: string) => {
+  const handleSendImagePrompt = useCallback((prompt: string) => {
     handleMessageSend(prompt);
-  };
+  }, [handleMessageSend]);
 
   // ==================== 组件配置和渲染 ====================
 
-  const commonProps = {
-    onSendMessage: handleSendMessage,
-    availableModels,
-    isLoading,
-    allowConsecutiveMessages: true,
-    imageGenerationMode,
-    videoGenerationMode,
-    onSendImagePrompt: handleSendImagePrompt,
-    webSearchActive,
-    onStopResponse: handleStopResponseClick,
-    isStreaming,
-    isDebating,
-    toolsEnabled,
-    ...(handleMultiModelSend && handleSendMultiModelMessage && {
-      onSendMultiModelMessage: handleSendMultiModelMessage
-    }),
-    ...(handleStartDebate && handleStopDebate && {
-      onStartDebate: handleStartDebate,
-      onStopDebate: handleStopDebate
-    })
-  };
-
-
+  // 🚀 修复：将 commonProps 展开到 useMemo 依赖数组中，避免每次渲染创建新对象导致 memo 完全失效
   const inputComponent = useMemo(() => (
     <IntegratedChatInput
       key="integrated-input"
-      {...commonProps}
+      onSendMessage={handleSendMessage}
+      availableModels={availableModels}
+      isLoading={isLoading}
+      allowConsecutiveMessages={true}
+      imageGenerationMode={imageGenerationMode}
+      videoGenerationMode={videoGenerationMode}
+      onSendImagePrompt={handleSendImagePrompt}
+      webSearchActive={webSearchActive}
+      onStopResponse={handleStopResponseClick}
+      isStreaming={isStreaming}
+      isDebating={isDebating}
+      toolsEnabled={toolsEnabled}
+      onSendMultiModelMessage={handleMultiModelSend && handleSendMultiModelMessage ? handleSendMultiModelMessage : undefined}
+      onStartDebate={handleStartDebate}
+      onStopDebate={handleStopDebate}
       onClearTopic={handleClearTopic}
       toggleImageGenerationMode={toggleImageGenerationMode}
       toggleVideoGenerationMode={toggleVideoGenerationMode}
@@ -713,7 +705,21 @@ const ChatPageUIComponent: React.FC<ChatPageUIProps> = ({
       onToolsEnabledChange={toggleToolsEnabled}
     />
   ), [
-    commonProps,
+    handleSendMessage,
+    availableModels,
+    isLoading,
+    imageGenerationMode,
+    videoGenerationMode,
+    handleSendImagePrompt,
+    webSearchActive,
+    handleStopResponseClick,
+    isStreaming,
+    isDebating,
+    toolsEnabled,
+    handleSendMultiModelMessage,
+    handleMultiModelSend,
+    handleStartDebate,
+    handleStopDebate,
     handleClearTopic,
     toggleImageGenerationMode,
     toggleVideoGenerationMode,

--- a/src/pages/ChatPage/hooks/useModelSelection.ts
+++ b/src/pages/ChatPage/hooks/useModelSelection.ts
@@ -7,7 +7,8 @@ import type { Model } from '../../../shared/types';
 
 export function useModelSelection() {
   const dispatch = useDispatch();
-  const settings = useSelector((state: RootState) => state.settings);
+  // 🚀 修复：只订阅 providers，避免任意 settings 变更（主题、行为等）触发模型列表重新初始化
+  const providers = useSelector((state: RootState) => state.settings.providers);
   const currentModelId = useSelector((state: RootState) => state.settings.currentModelId);
 
   // 模型选择菜单相关状态
@@ -57,8 +58,8 @@ export function useModelSelection() {
         const availableModels: Model[] = [];
 
         // 只收集启用的提供商中的启用模型
-        if (settings.providers) {
-          settings.providers.forEach(provider => {
+        if (providers) {
+          providers.forEach(provider => {
             if (provider.isEnabled) {
               // 从每个启用的提供商中收集启用的模型
               provider.models.forEach(model => {
@@ -138,7 +139,7 @@ export function useModelSelection() {
     };
 
     initializeModels();
-  }, [dispatch, settings, currentModelId]);
+  }, [dispatch, providers, currentModelId]);
 
   return {
     selectedModel,

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState, lazy, Suspense } from 'react';
-import { Navigate, Routes, Route } from 'react-router-dom';
+import { Navigate, Routes, Route, useLocation } from 'react-router-dom';
 import { getStorageItem } from '../shared/utils/storage';
 import { useSelector } from 'react-redux'; // 导入 useSelector
 import type { RootState } from '../shared/store'; // 导入 RootState 类型
@@ -109,6 +109,16 @@ const AppRouter: React.FC = () => {
   const theme = useSelector((state: RootState) => state.settings.theme);
   const themeStyle = useSelector((state: RootState) => state.settings.themeStyle);
 
+  // 🚀 Keep-Alive：ChatPage 一旦挂载就不再销毁，避免 Settings→Chat 导航时整棵组件树重建
+  // 使用 React 推荐的 render-phase state update 模式追踪是否曾访问过 /chat
+  // https://react.dev/reference/react/useState#storing-information-from-previous-renders
+  const location = useLocation();
+  const isChatRoute = location.pathname === '/chat';
+  const [chatMounted, setChatMounted] = useState(false);
+  if (isChatRoute && !chatMounted) {
+    setChatMounted(true);
+  }
+
   useEffect(() => {
     async function checkFirstTimeUser() {
       try {
@@ -152,12 +162,22 @@ const AppRouter: React.FC = () => {
   }
 
   return (
-    <Suspense fallback={<LoadingFallback />}>
-      <Routes>
-        {/* 🚀 性能优化：首屏路由优先渲染 */}
-        <Route path="/" element={isFirstTimeUser ? <Navigate to="/welcome" replace /> : <Navigate to="/chat" replace />} />
-        <Route path="/welcome" element={<WelcomePage />} />
-        <Route path="/chat" element={<ChatPage />} />
+    <>
+      {/* 🚀 Keep-Alive：ChatPage 持久挂载，切换到其他路由时仅隐藏，避免重建整棵组件树 */}
+      {chatMounted && (
+        <div style={{ display: isChatRoute ? 'contents' : 'none' }}>
+          <Suspense fallback={<LoadingFallback />}>
+            <ChatPage />
+          </Suspense>
+        </div>
+      )}
+
+      {/* 非 /chat 路由正常渲染 */}
+      {!isChatRoute && (
+        <Suspense fallback={<LoadingFallback />}>
+          <Routes>
+            <Route path="/" element={isFirstTimeUser ? <Navigate to="/welcome" replace /> : <Navigate to="/chat" replace />} />
+            <Route path="/welcome" element={<WelcomePage />} />
         <Route path="/settings" element={<SettingsPage />} />
         <Route path="/settings/appearance" element={<AppearanceSettings />} />
         <Route path="/settings/appearance/theme-style" element={<ThemeStyleSettings />} />
@@ -223,8 +243,10 @@ const AppRouter: React.FC = () => {
         <Route path="/knowledge/:id" element={<KnowledgeBaseDetail />} />
         {/* 文档分块查看页（Level 4） */}
         <Route path="/knowledge/:id/document/:fileName" element={<DocumentChunkView />} />
-      </Routes>
-    </Suspense>
+          </Routes>
+        </Suspense>
+      )}
+    </>
   );
 };
 

--- a/src/shared/store/selectors/messageSelectors.ts
+++ b/src/shared/store/selectors/messageSelectors.ts
@@ -47,6 +47,8 @@ const shallowArrayEqual = <T>(a: T[], b: T[]): boolean => {
 
 // 选择特定消息的块 - 优化版本
 // 使用 Map 缓存每个 messageId 的结果
+// 🚀 修复内存泄漏：限制缓存大小，避免 Map 无限增长
+const BLOCKS_CACHE_MAX_SIZE = 200;
 const blocksForMessageCache = new Map<string, {
   blockEntities: Record<string, any>;
   blockIds: string[];
@@ -81,7 +83,13 @@ export const selectBlocksForMessage = (state: RootState, messageId: string): any
     return cached.result;
   }
 
-  // 更新缓存
+  // 更新缓存，超过上限时清理最早的条目
+  if (blocksForMessageCache.size >= BLOCKS_CACHE_MAX_SIZE) {
+    const firstKey = blocksForMessageCache.keys().next().value;
+    if (firstKey !== undefined) {
+      blocksForMessageCache.delete(firstKey);
+    }
+  }
   blocksForMessageCache.set(messageId, {
     blockEntities,
     blockIds,


### PR DESCRIPTION
## Summary

修复从设置页（`/settings`）返回聊天界面（`/chat`）时的严重性能问题和多个架构级 bug。

### 1. ChatPage Keep-Alive（核心修复）

**问题**：React Router 每次路由切换都会 unmount/remount ChatPage，导致：
- 所有 hooks 重新初始化（`useActiveTopic`, `useModelSelection` 等）
- 从 IndexedDB 重新加载消息（`loadTopicMessagesThunk`）
- SolidJS 桥接、MutationObserver、ScrollController 全部重建

**修复**：在 `routes/index.tsx` 中，ChatPage 首次访问后持久挂载，切换到其他路由时用 `display: none` 隐藏而非卸载：

```tsx
// ChatPage 渲染在 <Routes> 外，一旦挂载永不销毁
{chatMounted && (
  <div style={{ display: isChatRoute ? 'contents' : 'none' }}>
    <ChatPage />
  </div>
)}
// 其他路由正常渲染
{!isChatRoute && <Routes>...</Routes>}
```

### 2. `inputComponent` useMemo 失效 bug

`ChatPageUI.tsx` 中 `inputComponent` 的 `useMemo` 依赖了 `commonProps` 对象，但该对象每次渲染都是新引用 → memo 完全失效 → `IntegratedChatInput` 每帧都重建。

修复：移除中间对象，将各 prop 直接传入并列入依赖数组；同时将 `handleSendImagePrompt` 用 `useCallback` 稳定。

### 3. `useModelSelection` 依赖过宽

```diff
-  }, [dispatch, settings, currentModelId]);
+  }, [dispatch, providers, currentModelId]);
```

`settings` 整体对象作为 `useEffect` 依赖 → 任何无关设置变更（主题、行为等）都触发模型列表完整重建。改为只订阅 `settings.providers`。

### 4. `blocksForMessageCache` 内存泄漏

`messageSelectors.ts` 中的手动缓存 `Map` 只增不减。添加 `BLOCKS_CACHE_MAX_SIZE = 200` 的 LRU 淘汰。

Link to Devin session: https://app.devin.ai/sessions/6dfaa80c9cd54526a6fc3914e59b953f
Requested by: @1600822305