### PR TITLE
fix: 预加载 ChatPage chunk 消除首次导航时的"加载中"闪烁

### DIFF
--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -4,8 +4,9 @@ import { getStorageItem } from '../shared/utils/storage';
 import { useSelector } from 'react-redux'; // 导入 useSelector
 import type { RootState } from '../shared/store'; // 导入 RootState 类型
 import { statusBarService } from '../shared/services/platform/StatusBarService'; // 导入 statusBarService
-// 使用懒加载导入组件
-const ChatPage = lazy(() => import('../pages/ChatPage'));
+// 🚀 ChatPage 预加载：模块解析时即开始加载 chunk，避免 Keep-Alive 首次渲染时 Suspense fallback 闪现
+const chatPageImport = import('../pages/ChatPage');
+const ChatPage = lazy(() => chatPageImport);
 const WelcomePage = lazy(() => import('../pages/WelcomePage'));
 const SettingsPage = lazy(() => import('../pages/Settings'));
 const AppearanceSettings = lazy(() => import('../pages/Settings/AppearanceSettings.tsx'));


### PR DESCRIPTION
## Summary

修复 #214 引入的 Keep-Alive 模式下，首次导航到 `/chat` 时 Suspense fallback "加载中..." 闪现约 1 秒的问题。

原因：ChatPage 被移到 `<Routes>` 外独立渲染后，其 lazy chunk 要等到 `chatMounted` 变为 `true` 时才开始加载。之前在 `<Routes>` 内部时，Vite 的 modulepreload 会提前加载好。

```diff
-const ChatPage = lazy(() => import('../pages/ChatPage'));
+const chatPageImport = import('../pages/ChatPage');
+const ChatPage = lazy(() => chatPageImport);
```

将 `import()` 调用提前到模块顶层执行，浏览器在解析 routes 模块时就开始下载 ChatPage chunk，到路由重定向至 `/chat` 时 chunk 已就绪，Suspense 不再显示 fallback。

Link to Devin session: https://app.devin.ai/sessions/6dfaa80c9cd54526a6fc3914e59b953f
Requested by: @1600822305