### PR TITLE
revert: 回退 Keep-Alive 路由方案，恢复原始路由结构

### DIFF
--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -1,12 +1,11 @@
 import React, { useEffect, useState, lazy, Suspense } from 'react';
-import { Navigate, Routes, Route, useLocation } from 'react-router-dom';
+import { Navigate, Routes, Route } from 'react-router-dom';
 import { getStorageItem } from '../shared/utils/storage';
 import { useSelector } from 'react-redux'; // 导入 useSelector
 import type { RootState } from '../shared/store'; // 导入 RootState 类型
 import { statusBarService } from '../shared/services/platform/StatusBarService'; // 导入 statusBarService
-// 🚀 ChatPage 预加载：模块解析时即开始加载 chunk，避免 Keep-Alive 首次渲染时 Suspense fallback 闪现
-const chatPageImport = import('../pages/ChatPage');
-const ChatPage = lazy(() => chatPageImport);
+// 使用懒加载导入组件
+const ChatPage = lazy(() => import('../pages/ChatPage'));
 const WelcomePage = lazy(() => import('../pages/WelcomePage'));
 const SettingsPage = lazy(() => import('../pages/Settings'));
 const AppearanceSettings = lazy(() => import('../pages/Settings/AppearanceSettings.tsx'));
@@ -110,16 +109,6 @@ const AppRouter: React.FC = () => {
   const theme = useSelector((state: RootState) => state.settings.theme);
   const themeStyle = useSelector((state: RootState) => state.settings.themeStyle);
 
-  // 🚀 Keep-Alive：ChatPage 一旦挂载就不再销毁，避免 Settings→Chat 导航时整棵组件树重建
-  // 使用 React 推荐的 render-phase state update 模式追踪是否曾访问过 /chat
-  // https://react.dev/reference/react/useState#storing-information-from-previous-renders
-  const location = useLocation();
-  const isChatRoute = location.pathname === '/chat';
-  const [chatMounted, setChatMounted] = useState(false);
-  if (isChatRoute && !chatMounted) {
-    setChatMounted(true);
-  }
-
   useEffect(() => {
     async function checkFirstTimeUser() {
       try {
@@ -163,22 +152,12 @@ const AppRouter: React.FC = () => {
   }
 
   return (
-    <>
-      {/* 🚀 Keep-Alive：ChatPage 持久挂载，切换到其他路由时仅隐藏，避免重建整棵组件树 */}
-      {chatMounted && (
-        <div style={{ display: isChatRoute ? 'contents' : 'none' }}>
-          <Suspense fallback={<LoadingFallback />}>
-            <ChatPage />
-          </Suspense>
-        </div>
-      )}
-
-      {/* 非 /chat 路由正常渲染 */}
-      {!isChatRoute && (
-        <Suspense fallback={<LoadingFallback />}>
-          <Routes>
-            <Route path="/" element={isFirstTimeUser ? <Navigate to="/welcome" replace /> : <Navigate to="/chat" replace />} />
-            <Route path="/welcome" element={<WelcomePage />} />
+    <Suspense fallback={<LoadingFallback />}>
+      <Routes>
+        {/* 🚀 性能优化：首屏路由优先渲染 */}
+        <Route path="/" element={isFirstTimeUser ? <Navigate to="/welcome" replace /> : <Navigate to="/chat" replace />} />
+        <Route path="/welcome" element={<WelcomePage />} />
+        <Route path="/chat" element={<ChatPage />} />
         <Route path="/settings" element={<SettingsPage />} />
         <Route path="/settings/appearance" element={<AppearanceSettings />} />
         <Route path="/settings/appearance/theme-style" element={<ThemeStyleSettings />} />
@@ -244,10 +223,8 @@ const AppRouter: React.FC = () => {
         <Route path="/knowledge/:id" element={<KnowledgeBaseDetail />} />
         {/* 文档分块查看页（Level 4） */}
         <Route path="/knowledge/:id/document/:fileName" element={<DocumentChunkView />} />
-          </Routes>
-        </Suspense>
-      )}
-    </>
+      </Routes>
+    </Suspense>
   );
 };
 


### PR DESCRIPTION
## Summary

回退 PR #214 和 #215 中引入的 Keep-Alive 路由方案，恢复 `routes/index.tsx` 为标准 React Router 结构。

Keep-Alive 方案将 ChatPage 渲染在 `<Routes>` 外用 `display: none` 隐藏，导致：
1. **布局泄漏**：桌面端侧边栏在设置页中仍然可见
2. **加载闪烁**：新建的 Suspense 边界每次都显示 "加载中..." fallback
3. **桌面端异常**：侧边栏打开设置时出现异常行为

回退后 ChatPage 回到 `<Routes>` 内正常路由，由统一的 `<Suspense>` 包裹。

PR #214 的其他 3 个修复保留不变：
- `useModelSelection`: `settings` → `providers` 精确依赖
- `ChatPageUI`: `commonProps` useMemo 依赖修复
- `messageSelectors`: `blocksForMessageCache` LRU 淘汰

Link to Devin session: https://app.devin.ai/sessions/6dfaa80c9cd54526a6fc3914e59b953f
Requested by: @1600822305