### PR TITLE
fix: 修复消息版本历史功能 - 版本块被误删导致版本切换失败

### DIFF
--- a/src/shared/services/messages/VersionService.ts
+++ b/src/shared/services/messages/VersionService.ts
@@ -78,7 +78,7 @@ class VersionService {
       const now = new Date().toISOString();
 
       // 克隆所有当前块，生成独立的块副本供版本持有
-      // 这样 resetAssistantMessageForRegenerate 删除当前块时不会影响版本数据
+      // 使用 version_ 前缀的 messageId 隔离版本块，防止 getMessageBlocksByMessageId 误删
       const clonedBlockIds: string[] = [];
       if (messageBlocks.length > 0) {
         const clonedBlocks: MessageBlock[] = messageBlocks.map(block => {
@@ -87,6 +87,7 @@ class VersionService {
           return {
             ...block,
             id: newBlockId,
+            messageId: `version_${versionId}`,
             createdAt: now,
             updatedAt: now
           };
@@ -218,7 +219,7 @@ class VersionService {
       const originalModelKey = `original_model_${messageId}`;
       const originalThinkingKey = `original_thinking_blocks_${messageId}`;
       const originalBlockOrderKey = `original_block_order_${messageId}`;
-      const currentBlocks = await dexieStorage.getMessageBlocksByMessageId(messageId);
+      const currentBlocks = await dexieStorage.getMessageBlocksByIds(targetMessage.blocks || []);
       const thinkingBlocks = currentBlocks.filter(block => block.type === 'thinking');
       
       // 获取版本内容
@@ -281,7 +282,7 @@ class VersionService {
         for (const block of versionBlocks) {
           const newId = uuid();
           newCurrentBlockIds.push(newId);
-          newCurrentBlocks.push({ ...block, id: newId, updatedAt: new Date().toISOString() });
+          newCurrentBlocks.push({ ...block, id: newId, messageId, updatedAt: new Date().toISOString() });
         }
         await dexieStorage.bulkSaveMessageBlocks(newCurrentBlocks);
         store.dispatch(upsertManyBlocks(newCurrentBlocks));
@@ -396,8 +397,8 @@ class VersionService {
       
       console.log(`[VersionService] 已找到原始内容备份，长度: ${originalContent.length}`);
       
-      // 更新消息块内容
-      const blocks = await dexieStorage.getMessageBlocksByMessageId(messageId);
+      // 更新消息块内容（只获取消息自身引用的块，避免误取版本克隆块）
+      const blocks = await dexieStorage.getMessageBlocksByIds(message.blocks || []);
       const mainTextBlock = blocks.find(block => block.type === 'main_text');
       
       if (mainTextBlock) {
@@ -537,8 +538,9 @@ class VersionService {
         return false;
       }
       
-      // 更新消息块内容
-      const blocks = await dexieStorage.getMessageBlocksByMessageId(messageId);
+      // 更新消息块内容（只获取消息自身引用的块）
+      const msg = await dexieStorage.getMessage(messageId);
+      const blocks = await dexieStorage.getMessageBlocksByIds(msg?.blocks || []);
       const mainTextBlock = blocks.find(block => block.type === 'main_text');
       
       if (mainTextBlock) {
@@ -678,7 +680,9 @@ class VersionService {
    */
   async getMessageContent(messageId: string): Promise<string> {
     try {
-      const blocks = await dexieStorage.getMessageBlocksByMessageId(messageId);
+      const message = await dexieStorage.getMessage(messageId);
+      if (!message) return '';
+      const blocks = await dexieStorage.getMessageBlocksByIds(message.blocks || []);
       const mainTextBlock = blocks.find(block => block.type === 'main_text');
       return (mainTextBlock as any)?.content || '';
     } catch (error) {

--- a/src/shared/store/thunks/message/messageOperations.ts
+++ b/src/shared/store/thunks/message/messageOperations.ts
@@ -278,9 +278,8 @@ async function resetAssistantMessageForRegenerate(
   model: Model,
   dispatch: AppDispatch
 ): Promise<Message> {
-  // 获取并删除旧的消息块
-  const blocks = await dexieStorage.getMessageBlocksByMessageId(message.id);
-  const blockIds = blocks.map(block => block.id);
+  // 只删除消息自身引用的块，不删除版本克隆块（版本块使用独立的 messageId）
+  const blockIds = [...(message.blocks || [])];
 
   if (blockIds.length > 0) {
     dispatch(removeManyBlocks(blockIds));


### PR DESCRIPTION
## Summary

版本历史功能不可用的根本原因：**版本克隆块与原始消息块共享相同的 `messageId` 字段**，导致所有通过 `getMessageBlocksByMessageId(messageId)` 查询的地方会同时返回版本克隆块和当前块，进而在重新生成或版本切换时将版本块一并删除。

### 核心问题

`saveCurrentAsVersion` 克隆块时使用 `{ ...block, id: newId }` 展开原始块，`messageId` 被原样复制。而 Dexie 的 `message_blocks` 表有 `messageId` 索引，`getMessageBlocksByMessageId` 查询会返回所有共享该 messageId 的块（包括版本克隆块）。

受影响的关键路径：
- `resetAssistantMessageForRegenerate` → 重新生成时删除所有块（含版本块）
- `switchToVersion` → 获取"当前块"时混入版本块，然后全部删除
- `switchToLatest` / `fallbackToLatestContent` / `getMessageContent` → 同理

### 修复

```diff
# saveCurrentAsVersion: 隔离版本块的 messageId
- return { ...block, id: newBlockId, createdAt: now, updatedAt: now };
+ return { ...block, id: newBlockId, messageId: `version_${versionId}`, ... };

# switchToVersion / switchToLatest: 按消息引用查询，不按 messageId 索引
- const currentBlocks = await dexieStorage.getMessageBlocksByMessageId(messageId);
+ const currentBlocks = await dexieStorage.getMessageBlocksByIds(targetMessage.blocks || []);

# resetAssistantMessageForRegenerate: 只删消息自身引用的块
- const blocks = await dexieStorage.getMessageBlocksByMessageId(message.id);
- const blockIds = blocks.map(block => block.id);
+ const blockIds = [...(message.blocks || [])];
```

Link to Devin session: https://app.devin.ai/sessions/6dfaa80c9cd54526a6fc3914e59b953f
Requested by: @1600822305