### PR TITLE
fix: 消除版本切换时消息块的布局跳动

### DIFF
--- a/src/shared/services/messages/VersionService.ts
+++ b/src/shared/services/messages/VersionService.ts
@@ -200,19 +200,22 @@ class VersionService {
     currentBlockIds: string[],
     sourceBlocks: MessageBlock[]
   ): Promise<string[]> {
-    // 删除当前块
+    // Dexie: 删旧 + 写新（顺序无所谓，不影响 UI）
     if (currentBlockIds.length > 0) {
       await dexieStorage.deleteMessageBlocksByIds(currentBlockIds);
-      store.dispatch(removeManyBlocks(currentBlockIds));
     }
-    // 克隆源块为新的当前块
     const { blockIds, blocks } = await this.cloneBlocks(sourceBlocks, messageId);
+
+    // Redux: 先插入新块，再原子切换 message.blocks，最后清理旧块。
+    // 这样 selector 在任何中间帧都能映射到有效块，不会出现空帧导致布局跳动。
     if (blocks.length > 0) {
       store.dispatch(upsertManyBlocks(blocks));
     }
-    // 更新消息的 blocks
     await dexieStorage.updateMessage(messageId, { blocks: blockIds });
     store.dispatch(newMessagesActions.updateMessage({ id: messageId, changes: { blocks: blockIds } }));
+    if (currentBlockIds.length > 0) {
+      store.dispatch(removeManyBlocks(currentBlockIds));
+    }
     return blockIds;
   }
 


### PR DESCRIPTION
## Summary

版本切换时消息块会上下跳动，因为 `replaceCurrentBlocks` 先 dispatch `removeManyBlocks`（旧块消失 → 布局塌缩），再 dispatch `upsertManyBlocks`（新块出现 → 布局恢复）。两帧之间 selector 映射到 0 个块。

```diff
 // replaceCurrentBlocks 中的 Redux dispatch 顺序
- store.dispatch(removeManyBlocks(currentBlockIds));  // ← 先删 → 空帧
- store.dispatch(upsertManyBlocks(blocks));            // ← 后加
+ store.dispatch(upsertManyBlocks(blocks));            // ← 先加（新旧共存）
  store.dispatch(updateMessage({ blocks: blockIds })); // ← 原子切换引用
+ store.dispatch(removeManyBlocks(currentBlockIds));   // ← 最后清理旧块
```

这样 `selectBlocksForMessage` 在任何中间帧都能映射到有效块实体。

Link to Devin session: https://app.devin.ai/sessions/6dfaa80c9cd54526a6fc3914e59b953f
Requested by: @1600822305