### PR TITLE
fix: 修复版本切换后思考过程块顺序错乱

### DIFF
--- a/src/shared/services/messages/VersionService.ts
+++ b/src/shared/services/messages/VersionService.ts
@@ -47,7 +47,8 @@ class VersionService {
         throw new Error(`消息 ${messageId} 不存在`);
       }
 
-      const messageBlocks = await dexieStorage.getMessageBlocksByMessageId(messageId);
+      // 按 message.blocks 顺序获取块，保证版本克隆后显示顺序一致
+      const messageBlocks = await dexieStorage.getMessageBlocksByIds(message.blocks || []);
 
       // 如果没有提供内容，从消息块中获取
       let versionContent = content;


### PR DESCRIPTION
## Summary

切换到历史版本后，思考过程（thinking block）跑到消息底部。

原因：`saveCurrentAsVersion` 用 `getMessageBlocksByMessageId(messageId)` 获取块，返回顺序由 Dexie `messageId` 索引决定，不保证和 `message.blocks[]` 的显示顺序一致。克隆后版本的 `blocks` 数组顺序错乱。

```diff
- const messageBlocks = await dexieStorage.getMessageBlocksByMessageId(messageId);
+ const messageBlocks = await dexieStorage.getMessageBlocksByIds(message.blocks || []);
```

`getMessageBlocksByIds` (Dexie `bulkGet`) 按输入数组顺序返回结果，保证和 `message.blocks` 显示顺序一致。

Link to Devin session: https://app.devin.ai/sessions/6dfaa80c9cd54526a6fc3914e59b953f
Requested by: @1600822305