### PR TITLE
fix: 修复在历史版本上重新生成时版本错乱

### DIFF
--- a/src/shared/services/messages/VersionService.ts
+++ b/src/shared/services/messages/VersionService.ts
@@ -225,6 +225,83 @@ class VersionService {
   private latestModelKey(messageId: string) { return `latest_model_${messageId}`; }
 
   /**
+   * 重新生成前的版本处理。
+   * - 正在查看最新版本：把当前内容保存为新版本（原有行为）。
+   * - 正在查看历史版本：当前显示内容已存在于版本列表，不重复保存；
+   *   把 latest snapshot 转正为版本（保住旧最新内容），并清除 currentVersionId，
+   *   让新生成的内容成为新的最新版本。
+   */
+  async prepareForRegenerate(messageId: string, model?: any): Promise<void> {
+    const message = await dexieStorage.getMessage(messageId);
+    if (!message) return;
+
+    if (!message.currentVersionId) {
+      await this.saveCurrentAsVersion(messageId, undefined, model || message.model, 'regenerate');
+      return;
+    }
+
+    // ── 正在查看历史版本 ──
+    const latestBlockIds = await dexieStorage.getSetting(this.latestBlocksKey(messageId)) as string[] | null;
+    let versions: MessageVersion[] = [...(message.versions || [])];
+
+    if (latestBlockIds && latestBlockIds.length > 0) {
+      const results = await dexieStorage.message_blocks.bulkGet(latestBlockIds);
+      const snapshotBlocks = results.filter((b): b is MessageBlock => b !== undefined);
+      const mainText = (snapshotBlocks.find(b => b.type === 'main_text') as any)?.content || '';
+
+      if (mainText.trim()) {
+        // 把 snapshot 块直接转正为版本块（改 messageId 标记，无需再克隆）
+        const versionId = uuid();
+        const retagged = snapshotBlocks.map(b => ({ ...b, messageId: `version_${versionId}` }));
+        await dexieStorage.bulkSaveMessageBlocks(retagged);
+
+        let snapshotModel = message.model;
+        let snapshotModelId = message.modelId;
+        const modelInfo = await dexieStorage.getSetting(this.latestModelKey(messageId));
+        if (modelInfo) {
+          try {
+            const parsed = JSON.parse(modelInfo);
+            snapshotModel = parsed.model ?? snapshotModel;
+            snapshotModelId = parsed.modelId ?? snapshotModelId;
+          } catch { /* ignore */ }
+        }
+
+        versions.push({
+          id: versionId,
+          messageId,
+          blocks: retagged.map(b => b.id),
+          createdAt: new Date().toISOString(),
+          modelId: snapshotModelId,
+          model: snapshotModel,
+          isActive: false,
+          metadata: {
+            contentSnapshot: String(mainText),
+            source: 'regenerate',
+            timestamp: Date.now()
+          }
+        });
+        console.log(`[VersionService] latest snapshot 已转正为版本 ${versionId}`);
+      } else {
+        // snapshot 没有有效内容，直接丢弃
+        await dexieStorage.deleteMessageBlocksByIds(latestBlockIds);
+      }
+    }
+
+    await dexieStorage.deleteSetting(this.latestBlocksKey(messageId));
+    await dexieStorage.deleteSetting(this.latestModelKey(messageId));
+
+    // 清除 currentVersionId，新生成内容将成为新的 latest
+    await dexieStorage.updateMessage(messageId, {
+      versions,
+      currentVersionId: undefined
+    });
+    store.dispatch(newMessagesActions.updateMessage({
+      id: messageId,
+      changes: { versions, currentVersionId: undefined }
+    }));
+  }
+
+  /**
    * 切换到指定版本
    */
   async switchToVersion(versionId: string): Promise<boolean> {

--- a/src/shared/store/thunks/message/messageOperations.ts
+++ b/src/shared/store/thunks/message/messageOperations.ts
@@ -7,7 +7,6 @@ import { saveMessageAndBlocksToDB } from './utils';
 import { refreshTopicPreview } from '../../../services/topics/TopicPreviewService';
 import { processAssistantResponse } from './assistantResponse';
 import { versionService } from '../../../services/messages/VersionService';
-import { getMainTextContent } from '../../../utils/blockUtils';
 import { getModelIdentityKey } from '../../../utils/modelUtils';
 import type { Message } from '../../../types/newMessage';
 import type { Model } from '../../../types';
@@ -243,18 +242,12 @@ async function getTargetAssistantMessages(
  */
 async function saveMessageVersionIfNeeded(message: Message): Promise<Message> {
   try {
-    const currentContent = getMainTextContent(message);
-    if (!currentContent.trim()) {
-      return message;
-    }
-
-    await versionService.saveCurrentAsVersion(
+    // 区分两种场景：查看最新版本时保存当前内容为版本；
+    // 查看历史版本时把 latest snapshot 转正为版本并清除 currentVersionId
+    await versionService.prepareForRegenerate(
       message.id,
-      currentContent,
-      message.model || { id: message.modelId, provider: (message as any).model?.provider },
-      'regenerate'
+      message.model || { id: message.modelId, provider: (message as any).model?.provider }
     );
-    console.log(`[regenerateResponse] 版本已保存，内容长度: ${currentContent.length}`);
 
     // 重新获取消息以获取最新的版本信息
     const messageWithVersions = await dexieStorage.getMessage(message.id);
@@ -293,7 +286,8 @@ async function resetAssistantMessageForRegenerate(
     model: model,
     modelId: getModelIdentityKey({ id: model.id, provider: model.provider }),
     blocks: [],
-    versions: message.versions || []
+    versions: message.versions || [],
+    currentVersionId: undefined
   };
 
   console.log(`[regenerateResponse] 消息已重置`, {


### PR DESCRIPTION
## Summary

在历史版本上点"重新生成"时版本错乱：显示的版本内容被"覆盖"、版本编号整体偏移、旧最新内容丢失。

根本原因：重新生成流程没有区分"查看最新版本"和"查看历史版本"两种状态：
1. `saveMessageVersionIfNeeded` 把当前显示内容（V1，已是版本）重复存为新版本
2. latest snapshot（切走时保存的旧最新内容）永远没人恢复 → 丢失
3. `currentVersionId` 未清除 → 新生成内容显示时 UI 仍标记"版本1（当前）"，看起来像 V1 被覆盖

修复（新增 `VersionService.prepareForRegenerate`）：

```
prepareForRegenerate(messageId, model):
  if 查看最新版本:
    saveCurrentAsVersion(...)            // 原有行为
  else:  // 查看历史版本
    latest snapshot 块转正为新版本        // 旧最新内容保住，重打 version_ 标记
    不重复保存当前显示内容（已是版本）
    清除 currentVersionId + 清理 snapshot settings
```

`resetAssistantMessageForRegenerate` 也显式 `currentVersionId: undefined`。

效果：版本 [1, 2]，切到版本1后重新生成 → 版本1=原版本1，版本2=原版本2，版本3（最新）=新生成内容。

## 其他已审查的边界情况

- 删除正在查看的版本：`deleteVersion` 已先 `switchToLatest`，正常
- 流式生成中切换版本：UI 层在 streaming 时禁用按钮
- 多模型多助手消息：`regenerateResponse` 循环内逐条处理，同样适用

Link to Devin session: https://app.devin.ai/sessions/6dfaa80c9cd54526a6fc3914e59b953f
Requested by: @1600822305