### PR TITLE
fix: 修复创建分支后思考过程块顺序错乱

### DIFF
--- a/src/shared/services/topics/TopicService.ts
+++ b/src/shared/services/topics/TopicService.ts
@@ -883,7 +883,8 @@ export class TopicService {
 
       for (const originalMessage of messagesToClone) {
         const newMessageId = messageIdMap.get(originalMessage.id)!;
-        const originalBlocks = await dexieStorage.getMessageBlocksByMessageId(originalMessage.id);
+        // 按 message.blocks 顺序获取块，保证克隆后显示顺序一致
+        const originalBlocks = await dexieStorage.getMessageBlocksByIds(originalMessage.blocks || []);
 
         const clonedBlocks: MessageBlock[] = originalBlocks.map((block) => ({
           ...block,


### PR DESCRIPTION
## Summary

创建话题分支后，克隆消息里的思考过程块跑到消息底部。

和 #220 同一根因：`cloneMessagesToNewTopic` 用 `getMessageBlocksByMessageId` 获取源消息块，返回顺序由 Dexie 索引决定，不保证和 `message.blocks[]` 显示顺序一致，克隆后 `clonedMessage.blocks` 顺序错乱。

```diff
- const originalBlocks = await dexieStorage.getMessageBlocksByMessageId(originalMessage.id);
+ const originalBlocks = await dexieStorage.getMessageBlocksByIds(originalMessage.blocks || []);
```

Link to Devin session: https://app.devin.ai/sessions/6dfaa80c9cd54526a6fc3914e59b953f
Requested by: @1600822305