### PR TITLE
fix: 排查并修复所有依赖块显示顺序的 getMessageBlocksByMessageId 调用

### DIFF
--- a/src/components/message/MessageEditor.tsx
+++ b/src/components/message/MessageEditor.tsx
@@ -114,7 +114,8 @@ const MessageEditor: React.FC<MessageEditorProps> = ({ message, topicId, open, o
 
     // 从数据库批量加载所有消息块
     try {
-      let messageBlocks = await dexieStorage.getMessageBlocksByMessageId(message.id);
+      // 按 message.blocks 顺序获取块，保证编辑顺序和显示顺序一致
+      let messageBlocks = await dexieStorage.getMessageBlocksByIds(message.blocks);
 
       if (messageBlocks.length === 0) {
         // 如果批量获取失败，尝试逐个获取

--- a/src/pages/Settings/DataSettings/utils/backupUtils.ts
+++ b/src/pages/Settings/DataSettings/utils/backupUtils.ts
@@ -410,7 +410,10 @@ export async function prepareBasicBackupData(): Promise<{
         for (const message of topic.messages) {
           if (message && message.id) {
             try {
-              const blocks = await dexieStorage.getMessageBlocksByMessageId(message.id);
+              // 按 message.blocks 顺序获取块，保证备份恢复后顺序一致
+              const blocks = Array.isArray((message as any).blocks) && (message as any).blocks.length > 0
+                ? await dexieStorage.getMessageBlocksByIds((message as any).blocks)
+                : await dexieStorage.getMessageBlocksByMessageId(message.id);
               (message as any).blocks = blocks;
             } catch (error) {
               console.error(`加载消息 ${message.id} 的块失败:`, error);

--- a/src/utils/exportUtils.ts
+++ b/src/utils/exportUtils.ts
@@ -620,8 +620,8 @@ export async function topicToMarkdown(topic: ChatTopic, exportReasoning = false)
     const messagesWithBlocks = [];
     for (const message of messages) {
       if (message.blocks && message.blocks.length > 0) {
-        // 获取消息的所有块
-        const blocks = await dexieStorage.getMessageBlocksByMessageId(message.id);
+        // 按 message.blocks 顺序获取块，保证导出顺序和显示顺序一致
+        const blocks = await dexieStorage.getMessageBlocksByIds(message.blocks);
         // 创建完整的消息对象，包含块对象而不是块ID
         const messageWithBlocks = {
           ...message,
@@ -815,7 +815,7 @@ export async function exportTopicAsDocx(topic: ChatTopic, exportReasoning = fals
     const messagesWithBlocks = [];
     for (const message of messages) {
       if (message.blocks && message.blocks.length > 0) {
-        const blocks = await dexieStorage.getMessageBlocksByMessageId(message.id);
+        const blocks = await dexieStorage.getMessageBlocksByIds(message.blocks);
         messagesWithBlocks.push({
           ...message,
           blockObjects: blocks

--- a/src/utils/notionExport.ts
+++ b/src/utils/notionExport.ts
@@ -471,9 +471,11 @@ async function topicToMarkdownForNotion(topic: ChatTopic, exportReasoning = fals
     }
 
     // 批量获取所有消息的块数据，避免循环查询
-    const messageIds = messages.filter(msg => msg.blocks && msg.blocks.length > 0).map(msg => msg.id);
-    const allBlocks = messageIds.length > 0
-      ? await Promise.all(messageIds.map(id => dexieStorage.getMessageBlocksByMessageId(id)))
+    const messagesWithBlockIds = messages.filter(msg => msg.blocks && msg.blocks.length > 0);
+    const messageIds = messagesWithBlockIds.map(msg => msg.id);
+    // 按 message.blocks 顺序获取块，保证导出顺序和显示顺序一致
+    const allBlocks = messagesWithBlockIds.length > 0
+      ? await Promise.all(messagesWithBlockIds.map(msg => dexieStorage.getMessageBlocksByIds(msg.blocks!)))
       : [];
 
     // 创建块数据映射表，转换类型以兼容


### PR DESCRIPTION
## Summary

#220 / #222 之后对全代码库做了系统排查：`getMessageBlocksByMessageId` 按 Dexie `messageId` 索引顺序返回块，不保证和 `message.blocks[]` 显示顺序一致。所有"顺序敏感"的调用点统一改为 `getMessageBlocksByIds(message.blocks)`（Dexie `bulkGet` 按输入顺序返回）。

**本次修复（顺序敏感）：**

| 调用点 | 影响 |
|---|---|
| `exportUtils.ts` ×2 | Markdown/文档导出时思考过程/正文顺序可能错乱 |
| `notionExport.ts` | Notion 导出同上 |
| `MessageEditor.tsx` | 编辑器中文本块顺序可能和显示不一致 |
| `backupUtils.ts` | 备份嵌入的块顺序错乱，恢复后显示错乱 |

**审查后保持不变（顺序无关）：**
- `messageOperations.ts` deleteMessage、`deleteMessageBlocksByMessageId`（删除操作）
- `TopicNamingService` / `webSearchTool` / `harvestStage`（仅查找 main_text 内容）
- `newMessagesSlice` loadTopicMessages（块存入 Redux entities，显示顺序由 message.blocks 决定）
- `TopicService.getMessageBlocks` / `DataRepository.blocks.getByMessageId`（无调用方的通用 getter）

Link to Devin session: https://app.devin.ai/sessions/6dfaa80c9cd54526a6fc3914e59b953f
Requested by: @1600822305