### PR TITLE
refactor: 重构模型组合页面 UI 为清爽风格

### DIFF
--- a/src/i18n/locales/en-US/modelSettings.json
+++ b/src/i18n/locales/en-US/modelSettings.json
@@ -145,6 +145,9 @@
     "noComboYet": "No combos created yet",
     "createComboDesc": "Create combos for routing, ensemble and more",
     "createFirst": "Create First",
+    "create": "New Combo",
+    "enabledChip": "Enabled",
+    "disabledChip": "Disabled",
     "modelCount": "{{count}} model(s)",
     "strategy": {
       "routing": "Smart Routing (WIP)",

--- a/src/i18n/locales/zh-CN/modelSettings.json
+++ b/src/i18n/locales/zh-CN/modelSettings.json
@@ -145,6 +145,9 @@
     "noComboYet": "还没有创建任何模型组合",
     "createComboDesc": "创建模型组合来实现智能路由、模型集成等高级功能",
     "createFirst": "创建第一个组合",
+    "create": "新建组合",
+    "enabledChip": "已启用",
+    "disabledChip": "已停用",
     "modelCount": "{{count}} 个模型",
     "strategy": {
       "routing": "智能路由 (开发中)",

--- a/src/pages/Settings/ModelComboEditPage.tsx
+++ b/src/pages/Settings/ModelComboEditPage.tsx
@@ -1,25 +1,18 @@
 import React, { useState, useEffect, useMemo } from 'react';
 import {
   Box,
-  AppBar,
-  Toolbar,
-  IconButton,
   Typography,
+  IconButton,
   TextField,
   FormControl,
-  InputLabel,
   Select,
   MenuItem,
-  FormControlLabel,
-  Card,
-  CardContent,
   Button,
-  Alert,
-  Divider,
-  alpha
+  alpha,
+  useTheme,
 } from '@mui/material';
 import { useNavigate, useParams } from 'react-router-dom';
-import { ArrowLeft, Plus as AddIcon, Trash2 as DeleteIcon, Brain, Sparkles, ArrowRight, GitCompare, Save } from 'lucide-react';
+import { Plus as AddIcon, Trash2 as DeleteIcon, Brain, Sparkles, ArrowRight, GitCompare, Save } from 'lucide-react';
 import { useSelector } from 'react-redux';
 import type { RootState } from '../../shared/store';
 import DropdownModelSelector from '../ChatPage/components/DropdownModelSelector';
@@ -28,16 +21,24 @@ import CustomSwitch from '../../components/CustomSwitch';
 import { useTranslation } from 'react-i18next';
 import { modelComboService } from '../../shared/services/ai/ModelComboService';
 import { useModelComboSync } from '../../shared/hooks/useModelComboSync';
-import { SafeAreaContainer } from '../../components/settings/SettingComponents';
+import {
+  SafeAreaContainer,
+  Container,
+  HeaderBar,
+  SettingGroup,
+  Row,
+  YStack,
+} from '../../components/settings/SettingComponents';
 
 import type { ModelComboStrategy, ModelComboFormData } from '../../shared/types/ModelCombo';
 
 const ModelComboEditPage: React.FC = () => {
   const { t } = useTranslation();
   const navigate = useNavigate();
+  const theme = useTheme();
   const { comboId } = useParams<{ comboId: string }>();
   const isEditing = comboId && comboId !== 'new';
-  
+
   const { syncModelCombos } = useModelComboSync();
 
   const [formData, setFormData] = useState<ModelComboFormData>({
@@ -133,7 +134,7 @@ const ModelComboEditPage: React.FC = () => {
           role: m.role as 'primary' | 'secondary' | 'thinking' | 'generating' | 'fallback'
         }))
       };
-      
+
       if (isEditing && comboId) {
         await modelComboService.updateCombo(comboId, dataToSave);
       } else {
@@ -226,10 +227,10 @@ const ModelComboEditPage: React.FC = () => {
   const getModelLabel = (index: number) => {
     if (formData.strategy === 'sequential') {
       return index === 0
-        ? { icon: <Brain size={20} />, label: t('modelSettings.combo.thinkingModel', '推理模型'), color: '#9c27b0', desc: '负责深度思考和推理' }
-        : { icon: <Sparkles size={20} />, label: t('modelSettings.combo.generatingModel', '生成模型'), color: '#2196f3', desc: '基于推理结果生成最终答案' };
+        ? { icon: <Brain size={18} />, label: t('modelSettings.combo.thinkingModel', '推理模型'), color: theme.palette.secondary.main, desc: '负责深度思考和推理' }
+        : { icon: <Sparkles size={18} />, label: t('modelSettings.combo.generatingModel', '生成模型'), color: theme.palette.primary.main, desc: '基于推理结果生成最终答案' };
     }
-    return { icon: <GitCompare size={20} />, label: `${t('modelSettings.combo.model', '模型')} ${index + 1}`, color: '#757575', desc: '' };
+    return { icon: <GitCompare size={18} />, label: `${t('modelSettings.combo.model', '模型')} ${index + 1}`, color: theme.palette.text.secondary, desc: '' };
   };
 
   const isFormValid = () => {
@@ -238,238 +239,187 @@ const ModelComboEditPage: React.FC = () => {
            formData.models.every(m => m.modelId.trim() !== '');
   };
 
-  return (
-    <SafeAreaContainer>
-      <AppBar
-        position="static"
-        elevation={0}
+  const renderModelCard = (index: number, removable: boolean) => {
+    const labelInfo = getModelLabel(index);
+    const model = formData.models[index];
+    return (
+      <Box
+        key={index}
         sx={{
-          bgcolor: 'background.paper',
-          color: 'text.primary',
-          borderBottom: 1,
-          borderColor: 'divider',
+          borderRadius: 2,
+          border: '1px solid',
+          borderColor: alpha(labelInfo.color, 0.35),
+          bgcolor: alpha(labelInfo.color, 0.04),
+          p: 1.5,
         }}
       >
-        <Toolbar>
-          <IconButton edge="start" onClick={handleBack} sx={{ color: 'primary.main' }}>
-            <ArrowLeft size={24} />
-          </IconButton>
-          <Typography variant="h6" sx={{ flexGrow: 1, fontWeight: 600 }}>
-            {isEditing ? t('modelSettings.combo.editCombo', '编辑模型组合') : t('modelSettings.combo.createCombo', '创建模型组合')}
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 1, color: labelInfo.color }}>
+          {labelInfo.icon}
+          <Typography variant="subtitle2" fontWeight={600} color="inherit" sx={{ flex: 1 }}>
+            {labelInfo.label}
           </Typography>
+          {removable && (
+            <IconButton size="small" onClick={() => handleRemoveModel(index)} sx={{ color: 'text.secondary', '&:hover': { color: 'error.main' } }}>
+              <DeleteIcon size={16} />
+            </IconButton>
+          )}
+        </Box>
+        {labelInfo.desc && (
+          <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mb: 1 }}>
+            {labelInfo.desc}
+          </Typography>
+        )}
+        <DropdownModelSelector
+          selectedModel={
+            model.modelId
+              ? availableModels.find(m =>
+                  modelMatchesIdentity(m, parseModelIdentityKey(model.modelId), m.provider)
+                ) || null
+              : null
+          }
+          availableModels={availableModels}
+          handleModelSelect={(selectedModel) => {
+            handleModelChange(
+              index,
+              'modelId',
+              selectedModel
+                ? getModelIdentityKey({
+                    id: selectedModel.id,
+                    provider: selectedModel.provider || (selectedModel as any).providerId
+                  })
+                : ''
+            );
+          }}
+        />
+      </Box>
+    );
+  };
+
+  return (
+    <SafeAreaContainer>
+      <HeaderBar
+        title={isEditing ? t('modelSettings.combo.editCombo', '编辑模型组合') : t('modelSettings.combo.createCombo', '创建模型组合')}
+        onBackPress={handleBack}
+        rightButton={
           <Button
             variant="contained"
-            startIcon={<Save size={18} />}
+            disableElevation
+            size="small"
+            startIcon={<Save size={16} />}
             onClick={handleSave}
             disabled={!isFormValid() || loading}
+            sx={{ textTransform: 'none', borderRadius: 2 }}
           >
             {t('common.save', '保存')}
           </Button>
-        </Toolbar>
-      </AppBar>
+        }
+      />
+      <Container>
+        <Box sx={{ maxWidth: 640, width: '100%', mx: 'auto', display: 'flex', flexDirection: 'column', gap: 3 }}>
 
-      <Box sx={{ flexGrow: 1, overflow: 'auto', p: 2, pb: 'var(--content-bottom-padding)' }}>
-        <Box sx={{ maxWidth: 600, mx: 'auto', display: 'flex', flexDirection: 'column', gap: 3 }}>
-          {/* 基本信息 */}
-          <Card variant="outlined">
-            <CardContent>
-              <Typography variant="subtitle1" fontWeight={600} gutterBottom>
-                {t('modelSettings.combo.basicInfo', '基本信息')}
+          {/* ==================== 基本信息 ==================== */}
+          <SettingGroup title={t('modelSettings.combo.basicInfo', '基本信息')}>
+            <Row sx={{ flexDirection: 'column', alignItems: 'stretch', gap: 2 }}>
+              <TextField
+                fullWidth
+                size="small"
+                label={t('modelSettings.combo.comboName', '组合名称')}
+                value={formData.name}
+                onChange={(e) => setFormData(prev => ({ ...prev, name: e.target.value }))}
+                required
+                placeholder="例如：DeepClaude 组合"
+              />
+              <TextField
+                fullWidth
+                size="small"
+                label={t('modelSettings.combo.description', '描述')}
+                value={formData.description}
+                onChange={(e) => setFormData(prev => ({ ...prev, description: e.target.value }))}
+                multiline
+                rows={2}
+                placeholder="描述这个模型组合的用途"
+              />
+            </Row>
+            <Row>
+              <Typography sx={{ flex: 1 }}>{t('modelSettings.combo.enableCombo', '启用此组合')}</Typography>
+              <CustomSwitch
+                checked={formData.enabled}
+                onChange={(e) => setFormData(prev => ({ ...prev, enabled: e.target.checked }))}
+              />
+            </Row>
+          </SettingGroup>
+
+          {/* ==================== 组合策略 ==================== */}
+          <SettingGroup title={t('modelSettings.combo.strategy.label', '组合策略')}>
+            <Row>
+              <Typography sx={{ flex: 1 }}>{t('modelSettings.combo.strategy.label', '组合策略')}</Typography>
+              <FormControl size="small" sx={{ minWidth: 180 }}>
+                <Select
+                  value={formData.strategy}
+                  onChange={(e) => handleStrategyChange(e.target.value as ModelComboStrategy)}
+                >
+                  <MenuItem value="sequential">
+                    <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                      <ArrowRight size={16} />
+                      {t('modelSettings.combo.strategy.sequential', '顺序执行')}
+                    </Box>
+                  </MenuItem>
+                  <MenuItem value="comparison">
+                    <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                      <GitCompare size={16} />
+                      {t('modelSettings.combo.strategy.comparison', '对比分析')}
+                    </Box>
+                  </MenuItem>
+                </Select>
+              </FormControl>
+            </Row>
+            <Box sx={{ px: 2, pb: 2 }}>
+              <Typography variant="caption" color="text.secondary">
+                {getStrategyDescription(formData.strategy)}
               </Typography>
-              <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2, mt: 2 }}>
-                <TextField
-                  fullWidth
-                  label={t('modelSettings.combo.comboName', '组合名称')}
-                  value={formData.name}
-                  onChange={(e) => setFormData(prev => ({ ...prev, name: e.target.value }))}
-                  required
-                  placeholder="例如：DeepClaude 组合"
-                />
-                <TextField
-                  fullWidth
-                  label={t('modelSettings.combo.description', '描述')}
-                  value={formData.description}
-                  onChange={(e) => setFormData(prev => ({ ...prev, description: e.target.value }))}
-                  multiline
-                  rows={2}
-                  placeholder="描述这个模型组合的用途"
-                />
-                <FormControlLabel
-                  control={
-                    <CustomSwitch
-                      checked={formData.enabled}
-                      onChange={(e) => setFormData(prev => ({ ...prev, enabled: e.target.checked }))}
-                    />
-                  }
-                  label={t('modelSettings.combo.enableCombo', '启用此组合')}
-                />
-              </Box>
-            </CardContent>
-          </Card>
+            </Box>
+          </SettingGroup>
 
-          {/* 策略选择 */}
-          <Card variant="outlined">
-            <CardContent>
-              <Typography variant="subtitle1" fontWeight={600} gutterBottom>
-                {t('modelSettings.combo.strategy.label', '组合策略')}
-              </Typography>
-              <Box sx={{ mt: 2 }}>
-                <FormControl fullWidth>
-                  <InputLabel>{t('modelSettings.combo.strategy.label', '组合策略')}</InputLabel>
-                  <Select
-                    value={formData.strategy}
-                    onChange={(e) => handleStrategyChange(e.target.value as ModelComboStrategy)}
-                    label={t('modelSettings.combo.strategy.label', '组合策略')}
-                  >
-                    <MenuItem value="sequential">
-                      <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-                        <ArrowRight size={18} />
-                        {t('modelSettings.combo.strategy.sequential', '顺序执行')}
-                      </Box>
-                    </MenuItem>
-                    <MenuItem value="comparison">
-                      <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-                        <GitCompare size={18} />
-                        {t('modelSettings.combo.strategy.comparison', '对比分析')}
-                      </Box>
-                    </MenuItem>
-                  </Select>
-                </FormControl>
-                <Alert severity="info" sx={{ mt: 2 }}>
-                  {getStrategyDescription(formData.strategy)}
-                </Alert>
-              </Box>
-            </CardContent>
-          </Card>
+          {/* ==================== 配置模型 ==================== */}
+          <SettingGroup title={t('modelSettings.combo.configModels', '配置模型')}>
+            <Box sx={{ p: 2 }}>
+              <YStack sx={{ gap: 1.5 }}>
+                {formData.models.map((_, index) =>
+                  renderModelCard(
+                    index,
+                    formData.strategy === 'comparison' && formData.models.length > 2
+                  )
+                )}
 
-          {/* 模型配置 */}
-          <Card variant="outlined">
-            <CardContent>
-              <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 2 }}>
-                <Typography variant="subtitle1" fontWeight={600}>
-                  {t('modelSettings.combo.configModels', '配置模型')}
-                </Typography>
+                {formData.strategy === 'sequential' && (
+                  <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 1, color: 'text.secondary', py: 0.5 }}>
+                    <Brain size={15} color={theme.palette.secondary.main} />
+                    <ArrowRight size={15} />
+                    <Sparkles size={15} color={theme.palette.primary.main} />
+                    <Typography variant="caption" sx={{ ml: 0.5 }}>
+                      {t('modelSettings.combo.sequentialFlow', '推理 → 生成')}
+                    </Typography>
+                  </Box>
+                )}
+
                 {formData.strategy === 'comparison' && (
-                  <Button startIcon={<AddIcon size={18} />} onClick={handleAddModel} size="small">
+                  <Button
+                    fullWidth
+                    variant="outlined"
+                    size="small"
+                    startIcon={<AddIcon size={16} />}
+                    onClick={handleAddModel}
+                    sx={{ textTransform: 'none', borderRadius: 2, borderStyle: 'dashed' }}
+                  >
                     {t('modelSettings.combo.addModel', '添加模型')}
                   </Button>
                 )}
-              </Box>
+              </YStack>
+            </Box>
+          </SettingGroup>
 
-              {/* 顺序策略 */}
-              {formData.strategy === 'sequential' && (
-                <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
-                  {formData.models.map((model, index) => {
-                    const labelInfo = getModelLabel(index);
-                    return (
-                      <Card
-                        key={index}
-                        variant="outlined"
-                        sx={{
-                          borderColor: alpha(labelInfo.color, 0.5),
-                          bgcolor: alpha(labelInfo.color, 0.03)
-                        }}
-                      >
-                        <CardContent>
-                          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 1, color: labelInfo.color }}>
-                            {labelInfo.icon}
-                            <Typography variant="subtitle2" fontWeight={600} color="inherit">
-                              {labelInfo.label}
-                            </Typography>
-                          </Box>
-                          {labelInfo.desc && (
-                            <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mb: 1.5 }}>
-                              {labelInfo.desc}
-                            </Typography>
-                          )}
-                          <DropdownModelSelector
-                            selectedModel={
-                              model.modelId
-                                ? availableModels.find(m =>
-                                    modelMatchesIdentity(m, parseModelIdentityKey(model.modelId), m.provider)
-                                  ) || null
-                                : null
-                            }
-                            availableModels={availableModels}
-                            handleModelSelect={(selectedModel) => {
-                              handleModelChange(
-                                index,
-                                'modelId',
-                                selectedModel
-                                  ? getModelIdentityKey({
-                                      id: selectedModel.id,
-                                      provider: selectedModel.provider || (selectedModel as any).providerId
-                                    })
-                                  : ''
-                              );
-                            }}
-                          />
-                        </CardContent>
-                      </Card>
-                    );
-                  })}
-                  
-                  {/* 流程指示 */}
-                  <Divider sx={{ my: 1 }}>
-                    <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, color: 'text.secondary', px: 2 }}>
-                      <Brain size={16} color="#9c27b0" />
-                      <ArrowRight size={16} />
-                      <Sparkles size={16} color="#2196f3" />
-                      <Typography variant="caption" sx={{ ml: 1 }}>
-                        {t('modelSettings.combo.sequentialFlow', '推理 → 生成')}
-                      </Typography>
-                    </Box>
-                  </Divider>
-                </Box>
-              )}
-
-              {/* 对比策略 */}
-              {formData.strategy === 'comparison' && (
-                <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
-                  {formData.models.map((model, index) => (
-                    <Card key={index} variant="outlined">
-                      <CardContent>
-                        <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 1.5 }}>
-                          <Typography variant="subtitle2" fontWeight={500}>
-                            {t('modelSettings.combo.model', '模型')} {index + 1}
-                          </Typography>
-                          {formData.models.length > 2 && (
-                            <IconButton size="small" onClick={() => handleRemoveModel(index)} color="error">
-                              <DeleteIcon size={18} />
-                            </IconButton>
-                          )}
-                        </Box>
-                        <DropdownModelSelector
-                          selectedModel={
-                            model.modelId
-                              ? availableModels.find(m =>
-                                  modelMatchesIdentity(m, parseModelIdentityKey(model.modelId), m.provider)
-                                ) || null
-                              : null
-                          }
-                          availableModels={availableModels}
-                          handleModelSelect={(selectedModel) => {
-                            handleModelChange(
-                              index,
-                              'modelId',
-                              selectedModel
-                                ? getModelIdentityKey({
-                                    id: selectedModel.id,
-                                    provider: selectedModel.provider || (selectedModel as any).providerId
-                                  })
-                                : ''
-                            );
-                          }}
-                        />
-                      </CardContent>
-                    </Card>
-                  ))}
-                </Box>
-              )}
-            </CardContent>
-          </Card>
         </Box>
-      </Box>
+      </Container>
     </SafeAreaContainer>
   );
 };

--- a/src/pages/Settings/ModelComboSettings.tsx
+++ b/src/pages/Settings/ModelComboSettings.tsx
@@ -1,30 +1,21 @@
 import React, { useState, useEffect } from 'react';
 import {
   Box,
-  AppBar,
-  Toolbar,
-  IconButton,
   Typography,
-  Paper,
+  IconButton,
   Button,
-  Card,
-  CardContent,
-  CardActions,
   Chip,
   DialogTitle,
   DialogContent,
   DialogActions,
-  Fab,
   alpha,
-  useMediaQuery,
-  useTheme
+  useTheme,
 } from '@mui/material';
 import BackButtonDialog from '../../components/common/BackButtonDialog';
 import { useNavigate, useLocation } from 'react-router-dom';
 import {
-  ArrowLeft,
   Plus,
-  Edit,
+  Pencil,
   Trash2,
   Bot,
   Wand2,
@@ -38,22 +29,23 @@ import type { ModelComboConfig, ModelComboTemplate, ModelComboStrategy } from '.
 import { useModelComboSync } from '../../shared/hooks/useModelComboSync';
 import { useTranslation } from 'react-i18next';
 import useScrollPosition from '../../hooks/useScrollPosition';
-import { SafeAreaContainer } from '../../components/settings/SettingComponents';
+import {
+  SafeAreaContainer,
+  Container,
+  HeaderBar,
+  YStack,
+  GroupTitle,
+  Group,
+} from '../../components/settings/SettingComponents';
 
 const ModelComboSettings: React.FC = () => {
   const { t } = useTranslation();
   const navigate = useNavigate();
   const theme = useTheme();
-  const isMobile = useMediaQuery(theme.breakpoints.down('md')); // 小于960px为移动端
-  const isSmallMobile = useMediaQuery(theme.breakpoints.down('sm')); // 小于600px为小屏手机
 
-  // 使用滚动位置保存功能
-  const {
-    containerRef,
-    handleScroll
-  } = useScrollPosition('settings-model-combo', {
+  const { containerRef, handleScroll } = useScrollPosition('settings-model-combo', {
     autoRestore: true,
-    restoreDelay: 0
+    restoreDelay: 0,
   });
 
   const [combos, setCombos] = useState<ModelComboConfig[]>([]);
@@ -62,13 +54,7 @@ const ModelComboSettings: React.FC = () => {
   const [comboToDelete, setComboToDelete] = useState<ModelComboConfig | null>(null);
   const location = useLocation();
 
-  // 使用同步Hook来自动同步模型组合到Redux store
   const { syncModelCombos } = useModelComboSync();
-
-  // 加载数据，当从编辑页面返回时也会刷新
-  useEffect(() => {
-    loadData();
-  }, [location.key]);
 
   const loadData = async () => {
     try {
@@ -82,6 +68,11 @@ const ModelComboSettings: React.FC = () => {
       console.error('加载模型组合数据失败:', error);
     }
   };
+
+  useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    void loadData();
+  }, [location.key]);
 
   const handleBack = () => {
     navigate('/settings');
@@ -123,21 +114,20 @@ const ModelComboSettings: React.FC = () => {
       };
       await modelComboService.createCombo(comboData);
       await loadData();
-      // 触发同步到Redux store
       await syncModelCombos();
     } catch (error) {
       console.error('从模板创建模型组合失败:', error);
     }
   };
 
-  const getStrategyIcon = (strategy: ModelComboStrategy) => {
+  const getStrategyIcon = (strategy: ModelComboStrategy, size = 14) => {
     switch (strategy) {
-      case 'routing': return <Bot size={20} />;
-      case 'ensemble': return <GitBranch size={20} />;
-      case 'comparison': return <ArrowLeftRight size={20} />;
-      case 'cascade': return <Wand2 size={20} />;
-      case 'sequential': return <ArrowRight size={20} />;
-      default: return <Bot size={20} />;
+      case 'routing': return <Bot size={size} />;
+      case 'ensemble': return <GitBranch size={size} />;
+      case 'comparison': return <ArrowLeftRight size={size} />;
+      case 'cascade': return <Wand2 size={size} />;
+      case 'sequential': return <ArrowRight size={size} />;
+      default: return <Bot size={size} />;
     }
   };
 
@@ -154,359 +144,230 @@ const ModelComboSettings: React.FC = () => {
 
   const getStrategyColor = (strategy: ModelComboStrategy) => {
     switch (strategy) {
-      case 'routing': return '#2196f3';
-      case 'ensemble': return '#4caf50';
-      case 'comparison': return '#ff9800';
-      case 'cascade': return '#9c27b0';
-      case 'sequential': return '#f44336';
-      default: return '#757575';
+      case 'routing': return theme.palette.info.main;
+      case 'ensemble': return theme.palette.success.main;
+      case 'comparison': return theme.palette.warning.main;
+      case 'cascade': return theme.palette.secondary.main;
+      case 'sequential': return theme.palette.primary.main;
+      default: return theme.palette.text.secondary;
     }
   };
 
+  const strategyChip = (strategy: ModelComboStrategy) => (
+    <Chip
+      icon={getStrategyIcon(strategy)}
+      label={getStrategyLabel(strategy)}
+      size="small"
+      sx={{
+        bgcolor: alpha(getStrategyColor(strategy), 0.1),
+        color: getStrategyColor(strategy),
+        fontWeight: 600,
+        height: 24,
+        '& .MuiChip-icon': { color: 'inherit' },
+      }}
+    />
+  );
+
   return (
     <SafeAreaContainer>
-      <AppBar
-        position="static"
-        elevation={0}
-        sx={{
-          bgcolor: 'background.paper',
-          color: 'text.primary',
-          borderBottom: 1,
-          borderColor: 'divider',
-          backdropFilter: 'blur(8px)',
-        }}
-      >
-        <Toolbar>
-          <IconButton
-            edge="start"
-            onClick={handleBack}
-            aria-label="back"
-            sx={{ color: (theme) => theme.palette.primary.main }}
+      <HeaderBar
+        title={t('modelSettings.combo.title')}
+        onBackPress={handleBack}
+        rightButton={
+          <Button
+            variant="outlined"
+            size="small"
+            startIcon={<Plus size={16} />}
+            onClick={handleCreateCombo}
+            sx={{ textTransform: 'none', borderRadius: 2 }}
           >
-            <ArrowLeft size={24} />
-          </IconButton>
-          <Typography
-            variant="h6"
-            component="div"
-              sx={{
-                flexGrow: 1,
-                fontWeight: 600,
-              }}
-            >
-            {t('modelSettings.combo.title')}
-          </Typography>
-        </Toolbar>
-      </AppBar>
+            {t('modelSettings.combo.create', '新建组合')}
+          </Button>
+        }
+      />
+      <Container ref={containerRef} onScroll={handleScroll}>
 
-      <Box
-        ref={containerRef}
-        onScroll={handleScroll}
-        sx={{
-          flexGrow: 1,
-          overflow: 'auto',
-          px: isMobile ? 1 : 2,
-          py: isMobile ? 1 : 2,
-          pb: 'var(--content-bottom-padding)',
-        }}
-      >
-        {/* 预设模板区域 */}
-        {templates.length > 0 && (
-          <Box sx={{ mb: isMobile ? 2 : 4 }}>
-            <Typography
-              variant={isMobile ? "subtitle1" : "h6"}
-              sx={{
-                mb: isMobile ? 1 : 2,
-                fontWeight: 600,
-                fontSize: isMobile ? '1.1rem' : undefined
-              }}
-            >
-              {t('modelSettings.combo.presetTemplates')}
-            </Typography>
-            <Box sx={{
-              display: 'grid',
-              gridTemplateColumns: {
-                xs: '1fr',
-                sm: isSmallMobile ? '1fr' : 'repeat(2, 1fr)',
-                md: 'repeat(2, 1fr)',
-                lg: 'repeat(3, 1fr)'
-              },
-              gap: isMobile ? 1 : 2
-            }}>
-              {templates.map((template) => (
-                <Box key={template.id}>
-                  <Card
-                    sx={{
-                      height: '100%',
-                      display: 'flex',
-                      flexDirection: 'column',
-                      border: '1px solid',
-                      borderColor: 'divider',
-                      '&:hover': {
-                        borderColor: 'primary.main',
-                        transform: isMobile ? 'none' : 'translateY(-2px)',
-                        boxShadow: isMobile ? 1 : 2,
-                      },
-                      transition: 'all 0.2s ease-in-out',
-                    }}
-                  >
-                    <CardContent sx={{
-                      flexGrow: 1,
-                      p: isMobile ? 1.5 : 2,
-                      '&:last-child': { pb: isMobile ? 1.5 : 2 }
-                    }}>
-                      <Box sx={{ display: 'flex', alignItems: 'center', mb: isMobile ? 0.5 : 1 }}>
-                        <Box sx={{
-                          mr: 1,
-                          fontSize: isMobile ? '1.2rem' : '1.5rem'
-                        }}>
-                          {template.icon}
-                        </Box>
-                        <Typography
-                          variant={isMobile ? "subtitle1" : "h6"}
-                          component="div"
-                          sx={{
-                            fontWeight: 600,
-                            fontSize: isMobile ? '1rem' : undefined
-                          }}
-                        >
-                          {template.name}
-                        </Typography>
-                      </Box>
-                      <Typography
-                        variant="body2"
-                        color="text.secondary"
-                        sx={{
-                          mb: isMobile ? 1 : 2,
-                          fontSize: isMobile ? '0.8rem' : undefined,
-                          lineHeight: isMobile ? 1.3 : undefined
-                        }}
-                      >
-                        {template.description}
-                      </Typography>
-                      <Chip
-                        icon={getStrategyIcon(template.strategy)}
-                        label={getStrategyLabel(template.strategy)}
-                        size="small"
-                        sx={{
-                          bgcolor: alpha(getStrategyColor(template.strategy), 0.1),
-                          color: getStrategyColor(template.strategy),
-                          fontSize: isMobile ? '0.7rem' : undefined,
-                          height: isMobile ? 24 : undefined,
-                          '& .MuiChip-icon': {
-                            fontSize: isMobile ? '0.9rem' : undefined
-                          }
-                        }}
-                      />
-                    </CardContent>
-                    <CardActions sx={{
-                      p: isMobile ? 1 : 2,
-                      pt: 0
-                    }}>
-                      <Button
-                        size={isMobile ? "small" : "small"}
-                        startIcon={<Plus size={16} />}
-                        onClick={() => handleCreateFromTemplate(template)}
-                        sx={{
-                          ml: 'auto',
-                          fontSize: isMobile ? '0.75rem' : undefined,
-                          px: isMobile ? 1 : undefined
-                        }}
-                      >
-                        {t('modelSettings.combo.useTemplate')}
-                      </Button>
-                    </CardActions>
-                  </Card>
-                </Box>
-              ))}
-            </Box>
-          </Box>
-        )}
-
-        {/* 我的组合区域 */}
-        <Box>
-          <Typography
-            variant={isMobile ? "subtitle1" : "h6"}
-            sx={{
-              mb: isMobile ? 1 : 2,
-              fontWeight: 600,
-              fontSize: isMobile ? '1.1rem' : undefined
-            }}
-          >
-            {t('modelSettings.combo.myCombos')}
-          </Typography>
+        {/* ==================== 我的组合 ==================== */}
+        <YStack sx={{ gap: 1 }}>
+          <GroupTitle>{t('modelSettings.combo.myCombos')}</GroupTitle>
 
           {combos.length === 0 ? (
-            <Paper
+            <Group sx={{ p: 4, textAlign: 'center' }}>
+              <YStack sx={{ alignItems: 'center', gap: 1 }}>
+                <Box
+                  sx={{
+                    width: 56,
+                    height: 56,
+                    borderRadius: '50%',
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    bgcolor: alpha(theme.palette.primary.main, 0.08),
+                    color: 'primary.main',
+                    mb: 0.5,
+                  }}
+                >
+                  <GitBranch size={26} />
+                </Box>
+                <Typography sx={{ fontWeight: 600 }}>
+                  {t('modelSettings.combo.noComboYet')}
+                </Typography>
+                <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
+                  {t('modelSettings.combo.createComboDesc')}
+                </Typography>
+                <Button
+                  variant="contained"
+                  disableElevation
+                  startIcon={<Plus size={16} />}
+                  onClick={handleCreateCombo}
+                  sx={{ textTransform: 'none', borderRadius: 2 }}
+                >
+                  {t('modelSettings.combo.createFirst')}
+                </Button>
+              </YStack>
+            </Group>
+          ) : (
+            <Box
               sx={{
-                p: isMobile ? 2 : 4,
-                textAlign: 'center',
-                border: '2px dashed',
-                borderColor: 'divider',
+                display: 'grid',
+                gridTemplateColumns: { xs: '1fr', sm: 'repeat(2, 1fr)', lg: 'repeat(3, 1fr)' },
+                gap: 1.5,
               }}
             >
-              <Bot
-                size={isMobile ? 36 : 48}
-                color="currentColor"
-                style={{
-                  color: 'var(--mui-palette-text-secondary)',
-                  marginBottom: isMobile ? 8 : 16
-                }}
-              />
-              <Typography
-                variant={isMobile ? "subtitle1" : "h6"}
-                color="text.secondary"
-                gutterBottom
-                sx={{ fontSize: isMobile ? '1rem' : undefined }}
-              >
-                {t('modelSettings.combo.noComboYet')}
-              </Typography>
-              <Typography
-                variant="body2"
-                color="text.secondary"
-                sx={{
-                  mb: isMobile ? 2 : 3,
-                  fontSize: isMobile ? '0.8rem' : undefined
-                }}
-              >
-                {t('modelSettings.combo.createComboDesc')}
-              </Typography>
-              <Button
-                variant="contained"
-                startIcon={<Plus size={16} />}
-                onClick={handleCreateCombo}
-                size={isMobile ? "small" : "medium"}
-                sx={{ fontSize: isMobile ? '0.8rem' : undefined }}
-              >
-                {t('modelSettings.combo.createFirst')}
-              </Button>
-            </Paper>
-          ) : (
-            <Box sx={{
-              display: 'grid',
-              gridTemplateColumns: {
-                xs: '1fr',
-                sm: isSmallMobile ? '1fr' : 'repeat(2, 1fr)',
-                md: 'repeat(2, 1fr)',
-                lg: 'repeat(3, 1fr)'
-              },
-              gap: isMobile ? 1 : 2
-            }}>
               {combos.map((combo) => (
-                <Box key={combo.id}>
-                  <Card
-                    sx={{
-                      height: '100%',
-                      display: 'flex',
-                      flexDirection: 'column',
-                      border: '1px solid',
-                      borderColor: combo.enabled ? 'success.main' : 'divider',
-                      opacity: combo.enabled ? 1 : 0.7,
-                    }}
-                  >
-                    <CardContent sx={{
-                      flexGrow: 1,
-                      p: isMobile ? 1.5 : 2,
-                      '&:last-child': { pb: isMobile ? 1.5 : 2 }
-                    }}>
-                      <Typography
-                        variant={isMobile ? "subtitle1" : "h6"}
-                        component="div"
-                        sx={{
-                          fontWeight: 600,
-                          mb: isMobile ? 0.5 : 1,
-                          fontSize: isMobile ? '1rem' : undefined
-                        }}
-                      >
-                        {combo.name}
-                      </Typography>
-                      <Typography
-                        variant="body2"
-                        color="text.secondary"
-                        sx={{
-                          mb: isMobile ? 1 : 2,
-                          fontSize: isMobile ? '0.8rem' : undefined,
-                          lineHeight: isMobile ? 1.3 : undefined
-                        }}
-                      >
-                        {combo.description}
-                      </Typography>
-                      <Chip
-                        icon={getStrategyIcon(combo.strategy)}
-                        label={getStrategyLabel(combo.strategy)}
-                        size="small"
-                        sx={{
-                          bgcolor: alpha(getStrategyColor(combo.strategy), 0.1),
-                          color: getStrategyColor(combo.strategy),
-                          mb: isMobile ? 0.5 : 1,
-                          fontSize: isMobile ? '0.7rem' : undefined,
-                          height: isMobile ? 24 : undefined,
-                          '& .MuiChip-icon': {
-                            fontSize: isMobile ? '0.9rem' : undefined
-                          }
-                        }}
-                      />
-                      <Typography
-                        variant="caption"
-                        display="block"
-                        color="text.secondary"
-                        sx={{ fontSize: isMobile ? '0.7rem' : undefined }}
-                      >
-                        {t('modelSettings.combo.modelCount', { count: combo.models.length })}
-                      </Typography>
-                    </CardContent>
-                    <CardActions sx={{
-                      p: isMobile ? 1.5 : 2,
-                      pt: 0,
-                      justifyContent: 'flex-end',
-                      gap: 1
-                    }}>
-                      <IconButton
-                        size="medium"
-                        onClick={() => handleEditCombo(combo)}
-                        color="primary"
-                        sx={{
-                          bgcolor: 'action.hover',
-                          '&:hover': { bgcolor: 'primary.main', color: 'white' }
-                        }}
-                      >
-                        <Edit size={isMobile ? 18 : 22} />
-                      </IconButton>
-                      <IconButton
-                        size="medium"
-                        onClick={() => handleDeleteCombo(combo)}
-                        color="error"
-                        sx={{
-                          bgcolor: 'action.hover',
-                          '&:hover': { bgcolor: 'error.main', color: 'white' }
-                        }}
-                      >
-                        <Trash2 size={isMobile ? 18 : 22} />
-                      </IconButton>
-                    </CardActions>
-                  </Card>
-                </Box>
+                <Group
+                  key={combo.id}
+                  sx={{
+                    p: 2,
+                    display: 'flex',
+                    flexDirection: 'column',
+                    gap: 1,
+                    transition: 'border-color 0.2s ease, box-shadow 0.2s ease',
+                    '&:hover': {
+                      borderColor: 'primary.main',
+                      boxShadow: `0 4px 16px ${alpha(theme.palette.primary.main, 0.08)}`,
+                    },
+                  }}
+                >
+                  <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                    <Typography sx={{ fontWeight: 600, flex: 1, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                      {combo.name}
+                    </Typography>
+                    <Chip
+                      label={combo.enabled
+                        ? t('modelSettings.combo.enabledChip', '已启用')
+                        : t('modelSettings.combo.disabledChip', '已停用')}
+                      size="small"
+                      sx={{
+                        height: 20,
+                        fontSize: '0.7rem',
+                        fontWeight: 600,
+                        bgcolor: combo.enabled
+                          ? alpha(theme.palette.success.main, 0.12)
+                          : alpha(theme.palette.text.secondary, 0.1),
+                        color: combo.enabled ? 'success.main' : 'text.secondary',
+                      }}
+                    />
+                  </Box>
+
+                  {combo.description && (
+                    <Typography
+                      variant="body2"
+                      color="text.secondary"
+                      sx={{
+                        display: '-webkit-box',
+                        WebkitLineClamp: 2,
+                        WebkitBoxOrient: 'vertical',
+                        overflow: 'hidden',
+                        minHeight: '2.6em',
+                      }}
+                    >
+                      {combo.description}
+                    </Typography>
+                  )}
+
+                  <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mt: 'auto' }}>
+                    {strategyChip(combo.strategy)}
+                    <Typography variant="caption" color="text.secondary" sx={{ flex: 1 }}>
+                      {t('modelSettings.combo.modelCount', { count: combo.models.length })}
+                    </Typography>
+                    <IconButton size="small" onClick={() => handleEditCombo(combo)} sx={{ color: 'text.secondary' }}>
+                      <Pencil size={16} />
+                    </IconButton>
+                    <IconButton size="small" onClick={() => handleDeleteCombo(combo)} sx={{ color: 'text.secondary', '&:hover': { color: 'error.main' } }}>
+                      <Trash2 size={16} />
+                    </IconButton>
+                  </Box>
+                </Group>
               ))}
             </Box>
           )}
-        </Box>
-      </Box>
+        </YStack>
 
-      {/* 浮动添加按钮 */}
-      <Fab
-        color="primary"
-        aria-label="add"
-        size={isMobile ? "medium" : "large"}
-        sx={{
-          position: 'fixed',
-          bottom: `calc(${isMobile ? 12 : 16}px + var(--safe-area-bottom-computed, 0px))`,
-          right: isMobile ? 12 : 16,
-          width: isMobile ? 48 : undefined,
-          height: isMobile ? 48 : undefined
-        }}
-        onClick={handleCreateCombo}
-      >
-        <Plus size={isMobile ? 20 : 24} />
-      </Fab>
+        {/* ==================== 预设模板 ==================== */}
+        {templates.length > 0 && (
+          <YStack sx={{ gap: 1 }}>
+            <GroupTitle>{t('modelSettings.combo.presetTemplates')}</GroupTitle>
+            <Box
+              sx={{
+                display: 'grid',
+                gridTemplateColumns: { xs: '1fr', sm: 'repeat(2, 1fr)', lg: 'repeat(3, 1fr)' },
+                gap: 1.5,
+              }}
+            >
+              {templates.map((template) => (
+                <Group
+                  key={template.id}
+                  sx={{
+                    p: 2,
+                    display: 'flex',
+                    flexDirection: 'column',
+                    gap: 1,
+                    transition: 'border-color 0.2s ease, box-shadow 0.2s ease',
+                    '&:hover': {
+                      borderColor: 'primary.main',
+                      boxShadow: `0 4px 16px ${alpha(theme.palette.primary.main, 0.08)}`,
+                    },
+                  }}
+                >
+                  <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                    <Box sx={{ fontSize: '1.25rem', lineHeight: 1 }}>{template.icon}</Box>
+                    <Typography sx={{ fontWeight: 600, flex: 1 }}>{template.name}</Typography>
+                  </Box>
+
+                  <Typography
+                    variant="body2"
+                    color="text.secondary"
+                    sx={{
+                      display: '-webkit-box',
+                      WebkitLineClamp: 2,
+                      WebkitBoxOrient: 'vertical',
+                      overflow: 'hidden',
+                      minHeight: '2.6em',
+                    }}
+                  >
+                    {template.description}
+                  </Typography>
+
+                  <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mt: 'auto' }}>
+                    {strategyChip(template.strategy)}
+                    <Box sx={{ flex: 1 }} />
+                    <Button
+                      size="small"
+                      startIcon={<Plus size={14} />}
+                      onClick={() => handleCreateFromTemplate(template)}
+                      sx={{ textTransform: 'none' }}
+                    >
+                      {t('modelSettings.combo.useTemplate')}
+                    </Button>
+                  </Box>
+                </Group>
+              ))}
+            </Box>
+          </YStack>
+        )}
+
+      </Container>
 
       {/* 删除确认对话框 */}
       <BackButtonDialog open={deleteDialogOpen} onClose={() => setDeleteDialogOpen(false)}>
@@ -518,7 +379,7 @@ const ModelComboSettings: React.FC = () => {
         </DialogContent>
         <DialogActions>
           <Button onClick={() => setDeleteDialogOpen(false)}>{t('common.cancel')}</Button>
-          <Button onClick={confirmDelete} color="error" variant="contained">
+          <Button onClick={confirmDelete} color="error" variant="contained" disableElevation>
             {t('common.delete')}
           </Button>
         </DialogActions>


### PR DESCRIPTION
## Summary
重做「模型组合」列表页与编辑页 UI，统一为 `SettingComponents`（`HeaderBar`/`SettingGroup`/`Group`）清爽风格，与近期重构的辅助模型设置页保持一致。纯 UI 改动，数据加载、保存、策略切换等逻辑不变。

**列表页 `ModelComboSettings.tsx`**
- 老式 `AppBar`+`Card`/`CardActions` → `HeaderBar` + `Group` 卡片网格
- 移除右下角 `Fab` 浮动按钮，改为 HeaderBar 右侧「新建组合」按钮
- 硬编码 Material 颜色（`#2196f3` 等）→ `theme.palette.*`，策略 chip 与启用状态 chip 随主题联动
- 清理满屏 `isMobile ? x : y` 三元样式，改用 sx 响应式断点；空状态改为居中圆形图标样式
- 「我的组合」移到「预设模板」之前
- 修复 `loadData` 在声明前被 `useEffect` 引用导致的 lint 报错（main 上已存在）

**编辑页 `ModelComboEditPage.tsx`**
- `Card`+`InputLabel` 外壳 → `SettingGroup`/`Row`；保存按钮移入 `HeaderBar` 右侧
- 顺序/对比两种策略的模型卡片合并为统一的 `renderModelCard(index, removable)`，颜色取自主题色
- 策略说明从 `Alert` 改为分组内 caption 文本；「添加模型」改为虚线全宽按钮

新增 i18n key：`modelSettings.combo.create` / `enabledChip` / `disabledChip`（zh-CN + en-US）。

已通过 `tsc --noEmit`、`eslint`、`vite build`。


Link to Devin session: https://app.devin.ai/sessions/aae58b28d4db4c069d7ba5ecd15b54ca
Requested by: @1600822305