### PR TITLE
fix: 模型组合编辑页改用统一 ModelSelector，支持全屏选择器

### DIFF
--- a/src/pages/Settings/ModelComboEditPage.tsx
+++ b/src/pages/Settings/ModelComboEditPage.tsx
@@ -15,7 +15,7 @@ import { useNavigate, useParams } from 'react-router-dom';
 import { Plus as AddIcon, Trash2 as DeleteIcon, Brain, Sparkles, ArrowRight, GitCompare, Save } from 'lucide-react';
 import { useSelector } from 'react-redux';
 import type { RootState } from '../../shared/store';
-import DropdownModelSelector from '../ChatPage/components/DropdownModelSelector';
+import { ModelSelector } from '../ChatPage/components/ModelSelector';
 import { getModelIdentityKey, modelMatchesIdentity, parseModelIdentityKey } from '../../shared/utils/modelUtils';
 import CustomSwitch from '../../components/CustomSwitch';
 import { useTranslation } from 'react-i18next';
@@ -52,6 +52,10 @@ const ModelComboEditPage: React.FC = () => {
     ]
   });
   const [loading, setLoading] = useState(false);
+  const [openSelectorIndex, setOpenSelectorIndex] = useState<number | null>(null);
+
+  const modelSelectorStyle = useSelector((state: RootState) => state.settings.modelSelectorStyle);
+  const isDialogStyle = modelSelectorStyle !== 'dropdown';
 
   // 获取所有可用模型
   const providers = useSelector((state: RootState) => state.settings.providers);
@@ -242,6 +246,11 @@ const ModelComboEditPage: React.FC = () => {
   const renderModelCard = (index: number, removable: boolean) => {
     const labelInfo = getModelLabel(index);
     const model = formData.models[index];
+    const selectedModel = model.modelId
+      ? availableModels.find(m =>
+          modelMatchesIdentity(m, parseModelIdentityKey(model.modelId), m.provider)
+        ) || null
+      : null;
     return (
       <Box
         key={index}
@@ -269,27 +278,46 @@ const ModelComboEditPage: React.FC = () => {
             {labelInfo.desc}
           </Typography>
         )}
-        <DropdownModelSelector
-          selectedModel={
-            model.modelId
-              ? availableModels.find(m =>
-                  modelMatchesIdentity(m, parseModelIdentityKey(model.modelId), m.provider)
-                ) || null
-              : null
-          }
+        {isDialogStyle && (
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5 }}>
+            <Typography
+              variant="body2"
+              color={selectedModel ? 'text.primary' : 'text.secondary'}
+              sx={{ flex: 1, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}
+            >
+              {selectedModel
+                ? `${selectedModel.name || selectedModel.id}`
+                : t('modelSettings.defaultModel.notSelected', '未选择')}
+            </Typography>
+            <Button
+              variant="outlined"
+              size="small"
+              onClick={() => setOpenSelectorIndex(index)}
+              sx={{ textTransform: 'none', borderRadius: 2, flexShrink: 0 }}
+            >
+              {t('modelSettings.defaultModel.selectModel', '选择模型')}
+            </Button>
+          </Box>
+        )}
+        <ModelSelector
+          selectedModel={selectedModel}
           availableModels={availableModels}
-          handleModelSelect={(selectedModel) => {
+          handleModelSelect={(newModel) => {
             handleModelChange(
               index,
               'modelId',
-              selectedModel
+              newModel
                 ? getModelIdentityKey({
-                    id: selectedModel.id,
-                    provider: selectedModel.provider || (selectedModel as any).providerId
+                    id: newModel.id,
+                    provider: newModel.provider || (newModel as any).providerId
                   })
                 : ''
             );
+            setOpenSelectorIndex(null);
           }}
+          handleMenuClick={() => setOpenSelectorIndex(index)}
+          handleMenuClose={() => setOpenSelectorIndex(null)}
+          menuOpen={openSelectorIndex === index}
         />
       </Box>
     );


### PR DESCRIPTION
## Summary
模型组合编辑页配置模型时原来写死使用 `DropdownModelSelector`（下拉式），不走统一的 `ModelSelector` 入口，导致设置里的"模型选择器样式"（全屏 SolidJS 弹窗式）对该页面不生效。

改为统一的 `ModelSelector`：
- 每个模型卡片渲染 `<ModelSelector menuOpen={openSelectorIndex === index} ... />`，由 `openSelectorIndex` 状态控制打开哪一个
- 当样式为弹窗式（`modelSelectorStyle !== 'dropdown'`）时，卡片内额外显示"当前模型名 + 选择模型按钮"作为触发器（弹窗式的 ModelSelector 本身不渲染触发器）；下拉式时仍由 ModelSelector 内联渲染下拉框，与原行为一致
- 选择后写回 `modelId`（identity key）的逻辑不变

已通过 `tsc --noEmit`、`eslint`、`vite build`。


Link to Devin session: https://app.devin.ai/sessions/aae58b28d4db4c069d7ba5ecd15b54ca
Requested by: @1600822305