### PR TITLE
chore: bump version to 0.6.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 **A Cross-Platform AI Assistant Application**
 
 [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/1600822305/CS-LLM-house)
-[![Version](https://img.shields.io/badge/version-0.6.4-blue.svg?style=flat-square)](https://github.com/1600822305/AetherLink/releases)
+[![Version](https://img.shields.io/badge/version-0.6.5-blue.svg?style=flat-square)](https://github.com/1600822305/AetherLink/releases)
 [![License: AGPL v3](https://img.shields.io/badge/License-AGPLv3-important.svg?style=flat-square&logo=gnu)](https://www.gnu.org/licenses/agpl-3.0)
 [![License: Commercial](https://img.shields.io/badge/License-Commercial-blue.svg?style=flat-square)](mailto:1600822305@qq.com?subject=AetherLink%20Commercial%20License%20Inquiry)
 

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -14,8 +14,8 @@ android {
         applicationId "com.llmhouse.app"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 8
-        versionName "0.6.4"
+        versionCode 9
+        versionName "0.6.5"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         aaptOptions {
              // Files and dirs to omit from the packaged assets dir, modified to accommodate modern web apps.

--- a/ios/App/App.xcodeproj/project.pbxproj
+++ b/ios/App/App.xcodeproj/project.pbxproj
@@ -348,11 +348,11 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 8;
+				CURRENT_PROJECT_VERSION = 9;
 				INFOPLIST_FILE = App/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				MARKETING_VERSION = 0.6.4;
+				MARKETING_VERSION = 0.6.5;
 				OTHER_SWIFT_FLAGS = "$(inherited) \"-D\" \"COCOAPODS\" \"-DDEBUG\"";
 				PRODUCT_BUNDLE_IDENTIFIER = com.llmhouse.app;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -368,11 +368,11 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 8;
+				CURRENT_PROJECT_VERSION = 9;
 				INFOPLIST_FILE = App/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				MARKETING_VERSION = 0.6.4;
+				MARKETING_VERSION = 0.6.5;
 				PRODUCT_BUNDLE_IDENTIFIER = com.llmhouse.app;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "";

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aetherlink",
-  "version": "0.6.4",
+  "version": "0.6.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aetherlink",
-      "version": "0.6.4",
+      "version": "0.6.5",
       "hasInstallScript": true,
       "dependencies": {
         "@ai-sdk/anthropic": "^3.0.47",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "aetherlink",
   "private": true,
-  "version": "0.6.4",
+  "version": "0.6.5",
   "type": "module",
   "engines": {
     "node": ">=22.0.0",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aetherlink"
-version = "0.6.4"
+version = "0.6.5"
 description = "AetherLink - AI-powered chat assistant with advanced features"
 authors = ["AetherLink Team"]
 license = "MIT"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "AetherLink",
-  "version": "0.6.4",
+  "version": "0.6.5",
   "identifier": "com.aetherlink.app",
   "build": {
     "beforeDevCommand": "npm run dev -- --host",

--- a/src/pages/Settings/AboutPage.tsx
+++ b/src/pages/Settings/AboutPage.tsx
@@ -20,7 +20,7 @@ import {
 import { useTranslation } from '../../i18n';
 
 // 应用版本号
-const APP_VERSION = '0.6.4';
+const APP_VERSION = '0.6.5';
 
 // QQ群链接
 const QQ_GROUP_URL = 'http://qm.qq.com/cgi-bin/qm/qr?_wv=1027&k=V-b46WoBNLIM4oc34JMULwoyJ3hyrKac&authKey=q%2FSwCcxda4e55ygtwp3h9adQXhqBLZ9wJdvM0QxTjXQkbxAa2tHoraOGy2fiibyY&noverify=0&group_code=930126592';


### PR DESCRIPTION
## Summary
将应用版本从 0.6.4 升级到 0.6.5，与之前的版本升级 PR（#140）保持相同的文件范围：

- `package.json` / `package-lock.json` / `src-tauri/Cargo.toml` / `src-tauri/tauri.conf.json`：`0.6.4` → `0.6.5`
- `android/app/build.gradle`：`versionCode 8 → 9`，`versionName "0.6.5"`
- `ios/App/App.xcodeproj/project.pbxproj`：`CURRENT_PROJECT_VERSION 8 → 9`，`MARKETING_VERSION 0.6.5`
- `README.md` 版本徽章、`src/pages/Settings/AboutPage.tsx` 中 `APP_VERSION`

Link to Devin session: https://app.devin.ai/sessions/4c173ee94f604e238c31c7ad9aff0297
Requested by: @1600822305