### PR TITLE
fix: 修复 MUI Select 空值选项显示空白的问题（共 6 处）

### DIFF
--- a/src/components/AIDebateButton.tsx
+++ b/src/components/AIDebateButton.tsx
@@ -425,11 +425,12 @@ const AIDebateButton: React.FC<AIDebateButtonProps> = ({
           {configGroups.length > 0 && (
             <Box sx={{ mb: 2 }}>
               <FormControl fullWidth size="small">
-                <InputLabel>{t('aiDebate.dialog.selectGroup')}</InputLabel>
+                <InputLabel shrink>{t('aiDebate.dialog.selectGroup')}</InputLabel>
                 <Select
                   value={selectedGroupId}
                   onChange={(e) => handleGroupSelect(e.target.value)}
                   label={t('aiDebate.dialog.selectGroup')}
+                  displayEmpty
                 >
                   <MenuItem value="">
                     <Box sx={{ display: 'flex', alignItems: 'center' }}>

--- a/src/components/VoiceRecognition/OpenAIWhisperTab.tsx
+++ b/src/components/VoiceRecognition/OpenAIWhisperTab.tsx
@@ -93,11 +93,12 @@ const OpenAIWhisperTab: React.FC<OpenAIWhisperTabProps> = ({ settings, onSetting
 
       {/* 语言选择 */}
       <FormControl fullWidth margin="normal" sx={{ mb: 3 }}>
-        <InputLabel>{t('settings.voice.tabSettings.whisper.language')}</InputLabel>
+        <InputLabel shrink>{t('settings.voice.tabSettings.whisper.language')}</InputLabel>
         <Select
           value={settings.language || ''}
           onChange={(e) => handleChange('language', e.target.value || undefined)}
           label={t('settings.voice.tabSettings.whisper.language')}
+          displayEmpty
         >
           <MenuItem value="">{t('settings.voice.tabSettings.whisper.languageAuto')}</MenuItem>
           <MenuItem value="zh">{t('settings.voice.tabSettings.whisper.languageZh')}</MenuItem>

--- a/src/components/settings/ModelDialog.tsx
+++ b/src/components/settings/ModelDialog.tsx
@@ -205,12 +205,13 @@ const ModelDialog: React.FC<ModelDialogProps> = ({
       <DialogContent>
         <Box sx={{ mb: 3, mt: 1 }}>
           <FormControl fullWidth sx={{ mb: 3 }}>
-            <InputLabel id="preset-model-label">预设模型</InputLabel>
+            <InputLabel id="preset-model-label" shrink>预设模型</InputLabel>
             <Select
               labelId="preset-model-label"
               value={selectedPreset?.id || ''}
               onChange={handlePresetChange}
               label="预设模型"
+              displayEmpty
               MenuProps={{
                 disableAutoFocus: true,
                 disableRestoreFocus: true

--- a/src/pages/Settings/KnowledgeSettings.tsx
+++ b/src/pages/Settings/KnowledgeSettings.tsx
@@ -463,11 +463,12 @@ const KnowledgeSettings: React.FC = () => {
         <SectionContent>
           <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
             <FormControl fullWidth size="small">
-              <InputLabel id="preprocess-provider-label">选择提供商</InputLabel>
+              <InputLabel id="preprocess-provider-label" shrink>选择提供商</InputLabel>
               <Select
                 labelId="preprocess-provider-label"
                 value={activeProviderId || ''}
                 label="选择提供商"
+                displayEmpty
                 onChange={(e) => {
                   const selectedId = e.target.value as PreprocessProviderId;
                   if (!selectedId) {

--- a/src/pages/Settings/SkillEditor.tsx
+++ b/src/pages/Settings/SkillEditor.tsx
@@ -425,11 +425,12 @@ const SkillEditor: React.FC = () => {
           </Typography>
 
           <FormControl fullWidth size="small">
-            <InputLabel>{t('settings.skillsSettings.editor.selectMcpServer')}</InputLabel>
+            <InputLabel shrink>{t('settings.skillsSettings.editor.selectMcpServer')}</InputLabel>
             <Select
               value={mcpServerId}
               label={t('settings.skillsSettings.editor.selectMcpServer')}
               onChange={(e) => setMcpServerId(e.target.value)}
+              displayEmpty
             >
               <MenuItem value="">
                 <em>{t('settings.skillsSettings.editor.mcpNone')}</em>

--- a/src/pages/Settings/VoiceSettingsV2/VolcanoTTSSettings.tsx
+++ b/src/pages/Settings/VoiceSettingsV2/VolcanoTTSSettings.tsx
@@ -530,6 +530,8 @@ const VolcanoTTSSettings: React.FC = () => {
                   value={settings.resourceId}
                   onChange={(e) => setSettings(prev => ({ ...prev, resourceId: e.target.value }))}
                   sx={{ mb: 2 }}
+                  SelectProps={{ displayEmpty: true }}
+                  InputLabelProps={{ shrink: true }}
                   helperText={t('settings.voice.tabSettings.volcano.resourceIdHelper')}
                 >
                   {RESOURCE_ID_OPTIONS.map(opt => (
@@ -546,6 +548,8 @@ const VolcanoTTSSettings: React.FC = () => {
                   value={settings.model}
                   onChange={(e) => setSettings(prev => ({ ...prev, model: e.target.value }))}
                   sx={{ mb: 2 }}
+                  SelectProps={{ displayEmpty: true }}
+                  InputLabelProps={{ shrink: true }}
                   helperText={t('settings.voice.tabSettings.volcano.modelHelper')}
                 >
                   {MODEL_OPTIONS.map(opt => (


### PR DESCRIPTION
## Summary
MUI Select 把空字符串 `""` 当作"未选择"，不渲染选中项文字。凡是用 `value=""` 作为"自动/默认/无"选项的下拉，选中该项时输入框显示空白。修复方式：Select 加 `displayEmpty`，配套 `InputLabel`/`InputLabelProps` 加 `shrink` 防止 label 与文字重叠。

全局扫描 `MenuItem value=""` 共发现 6 处受影响（另有 3 处已正确使用 `displayEmpty`，未改动）：

1. `VolcanoTTSSettings.tsx` — Resource ID（"自动"）与模型版本（"默认"）两个下拉（用户报告的问题）
2. `SkillEditor.tsx` — MCP 服务器关联（"无"）
3. `KnowledgeSettings.tsx` — PDF 预处理提供商（"未启用"）
4. `ModelDialog.tsx` — 预设模型（"自定义模型"）
5. `OpenAIWhisperTab.tsx` — Whisper 语言（"自动检测"）
6. `AIDebateButton.tsx` — 分组选择（"当前配置"）

注：eslint 在 `AIDebateButton.tsx` / `ModelDialog.tsx` / `SkillEditor.tsx` 报的 3 个 react-hooks 问题为 main 上已存在的问题（已对比验证），与本次改动无关。`npx tsc --noEmit --skipLibCheck` 通过。

Link to Devin session: https://app.devin.ai/sessions/e9c7bd0893934a078a8579a5f667768f
Requested by: @1600822305