### PR TITLE
fix: 侧边栏宽度增加确认保存机制并限制最大宽度防止无法恢复

### DIFF
--- a/src/components/TopicManagement/SettingsTab/SidebarWidthDialog.tsx
+++ b/src/components/TopicManagement/SettingsTab/SidebarWidthDialog.tsx
@@ -1,17 +1,15 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { createPortal } from 'react-dom';
 import {
   Box,
+  Button,
   Typography,
   Slider,
   TextField,
   InputAdornment,
 } from '@mui/material';
 import { useDialogBackHandler } from '../../../hooks/useDialogBackHandler';
-
-// 侧边栏宽度限制
-const SIDEBAR_WIDTH_MIN = 340;
-const SIDEBAR_WIDTH_MAX = 800;
+import { SIDEBAR_WIDTH_MIN, getSafeMaxSidebarWidth } from '../sidebarOptimization';
 
 interface SidebarWidthDialogProps {
   open: boolean;
@@ -24,7 +22,7 @@ const DIALOG_ID = 'sidebar-width-dialog';
 
 /**
  * 侧边栏宽度调整对话框
- * 支持滑块、输入框和快捷预设
+ * 支持滑块、输入框和快捷预设；改动需点击"保存"后才会生效
  */
 const SidebarWidthDialog: React.FC<SidebarWidthDialogProps> = ({
   open,
@@ -35,16 +33,39 @@ const SidebarWidthDialog: React.FC<SidebarWidthDialogProps> = ({
   // 使用返回键处理
   const { handleClose } = useDialogBackHandler(DIALOG_ID, open, onClose);
 
-  const handleWidthChange = (newWidth: number) => {
-    const validWidth = Math.max(SIDEBAR_WIDTH_MIN, newWidth);
-    onWidthChange(validWidth);
+  // 当前屏幕允许的最大宽度（对话框打开时随当前视口实时计算）
+  const safeMaxWidth = getSafeMaxSidebarWidth();
+
+  const clamp = (value: number) =>
+    Math.min(safeMaxWidth, Math.max(SIDEBAR_WIDTH_MIN, value));
+
+  // 草稿宽度：仅在点击"保存"后才应用到实际设置
+  const [draftWidth, setDraftWidth] = useState(() => clamp(currentWidth));
+
+  // 每次打开对话框时同步当前宽度
+  useEffect(() => {
+    if (open) {
+      setDraftWidth(clamp(currentWidth));
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open, currentWidth]);
+
+  const handleDraftChange = (newWidth: number) => {
+    setDraftWidth(clamp(newWidth));
+  };
+
+  const handleSave = () => {
+    onWidthChange(clamp(draftWidth));
+    onClose();
   };
 
   if (!open) return null;
 
+  const presets = [340, 400, 500, 600].filter((p) => p <= safeMaxWidth);
+
   return createPortal(
     <>
-      {/* 点击外部关闭 */}
+      {/* 点击外部关闭（不保存） */}
       <Box
         onClick={handleClose}
         sx={{
@@ -76,16 +97,16 @@ const SidebarWidthDialog: React.FC<SidebarWidthDialogProps> = ({
           侧边栏宽度
         </Typography>
         <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mb: 1 }}>
-          最小 {SIDEBAR_WIDTH_MIN}px，可自定义输入更大值
+          范围 {SIDEBAR_WIDTH_MIN}–{safeMaxWidth}px，修改后点击"保存"生效
         </Typography>
         
         {/* 滑块 */}
         <Slider
-          value={currentWidth}
+          value={draftWidth}
           min={SIDEBAR_WIDTH_MIN}
-          max={SIDEBAR_WIDTH_MAX}
+          max={safeMaxWidth}
           step={10}
-          onChange={(_, value) => handleWidthChange(value as number)}
+          onChange={(_, value) => handleDraftChange(value as number)}
           sx={{
             mb: 2,
             '& .MuiSlider-thumb': {
@@ -99,36 +120,40 @@ const SidebarWidthDialog: React.FC<SidebarWidthDialogProps> = ({
         <TextField
           type="number"
           size="small"
-          value={currentWidth}
+          value={draftWidth}
           onChange={(e) => {
             const value = parseInt(e.target.value, 10);
             if (!isNaN(value)) {
-              handleWidthChange(value);
+              handleDraftChange(value);
             }
           }}
           InputProps={{
             endAdornment: <InputAdornment position="end">px</InputAdornment>,
-            inputProps: { min: SIDEBAR_WIDTH_MIN, style: { textAlign: 'center' } },
+            inputProps: {
+              min: SIDEBAR_WIDTH_MIN,
+              max: safeMaxWidth,
+              style: { textAlign: 'center' },
+            },
           }}
           sx={{ width: '100%' }}
         />
         
         {/* 快捷预设 */}
         <Box sx={{ display: 'flex', gap: 0.5, mt: 1.5, flexWrap: 'wrap' }}>
-          {[340, 400, 500, 600].map((preset) => (
+          {presets.map((preset) => (
             <Box
               key={preset}
-              onClick={() => handleWidthChange(preset)}
+              onClick={() => handleDraftChange(preset)}
               sx={{
                 px: 1.5,
                 py: 0.5,
                 borderRadius: 1,
                 fontSize: '0.75rem',
                 cursor: 'pointer',
-                bgcolor: currentWidth === preset ? 'primary.main' : 'action.hover',
-                color: currentWidth === preset ? 'primary.contrastText' : 'text.secondary',
+                bgcolor: draftWidth === preset ? 'primary.main' : 'action.hover',
+                color: draftWidth === preset ? 'primary.contrastText' : 'text.secondary',
                 '&:hover': {
-                  bgcolor: currentWidth === preset ? 'primary.dark' : 'action.selected',
+                  bgcolor: draftWidth === preset ? 'primary.dark' : 'action.selected',
                 },
                 transition: 'all 0.15s',
               }}
@@ -136,6 +161,16 @@ const SidebarWidthDialog: React.FC<SidebarWidthDialogProps> = ({
               {preset}
             </Box>
           ))}
+        </Box>
+
+        {/* 操作按钮 */}
+        <Box sx={{ display: 'flex', justifyContent: 'flex-end', gap: 1, mt: 2 }}>
+          <Button size="small" color="inherit" onClick={handleClose}>
+            取消
+          </Button>
+          <Button size="small" variant="contained" onClick={handleSave}>
+            保存
+          </Button>
         </Box>
       </Box>
     </>,

--- a/src/components/TopicManagement/SettingsTab/index.tsx
+++ b/src/components/TopicManagement/SettingsTab/index.tsx
@@ -24,6 +24,7 @@ import InputSettings from './InputSettings';
 import MathSettings from './MathSettings';
 import { useSettingsStorage, syncAssistantMaxTokens } from './hooks/useSettingsStorage';
 import SidebarWidthDialog from './SidebarWidthDialog';
+import { clampSidebarWidth } from '../sidebarOptimization';
 
 
 interface Setting {
@@ -95,7 +96,7 @@ export default function SettingsTab({
 
   // 侧边栏宽度控制
   const [widthDialogOpen, setWidthDialogOpen] = useState(false);
-  const currentWidth = getSetting('sidebarWidth', 350);
+  const currentWidth = clampSidebarWidth(getSetting('sidebarWidth', 350));
 
   // 使用统一的设置配置（由 useSettingsManagement Hook 提供）
 

--- a/src/components/TopicManagement/SidebarResizeHandle.tsx
+++ b/src/components/TopicManagement/SidebarResizeHandle.tsx
@@ -4,10 +4,7 @@
  */
 import React, { useState, useCallback, useEffect, useRef } from 'react';
 import { Box } from '@mui/material';
-
-// 侧边栏宽度限制
-const SIDEBAR_WIDTH_MIN = 340;
-const SIDEBAR_WIDTH_MAX = 800;
+import { SIDEBAR_WIDTH_MIN, getSafeMaxSidebarWidth } from './sidebarOptimization';
 
 interface SidebarResizeHandleProps {
   currentWidth: number;
@@ -45,7 +42,7 @@ const SidebarResizeHandle: React.FC<SidebarResizeHandleProps> = ({
     const handleMouseMove = (e: MouseEvent) => {
       const deltaX = e.clientX - startXRef.current;
       const newWidth = Math.min(
-        SIDEBAR_WIDTH_MAX,
+        getSafeMaxSidebarWidth(),
         Math.max(SIDEBAR_WIDTH_MIN, startWidthRef.current + deltaX)
       );
       onWidthChange(newWidth);
@@ -59,7 +56,7 @@ const SidebarResizeHandle: React.FC<SidebarResizeHandleProps> = ({
       // 通知拖动结束，保存宽度
       if (onWidthChangeEnd) {
         const finalWidth = Math.min(
-          SIDEBAR_WIDTH_MAX,
+          getSafeMaxSidebarWidth(),
           Math.max(SIDEBAR_WIDTH_MIN, startWidthRef.current + (window.event as MouseEvent)?.clientX - startXRef.current || 0)
         );
         onWidthChangeEnd(finalWidth);

--- a/src/components/TopicManagement/SolidMotionSidebar.tsx
+++ b/src/components/TopicManagement/SolidMotionSidebar.tsx
@@ -11,6 +11,7 @@ import { SolidBridge } from '../../shared/bridges/SolidBridge';
 import { AppSidebar } from '../../solid/components/Sidebar/AppSidebar.solid';
 import SidebarTabs from './SidebarTabs';
 import SidebarResizeHandle from './SidebarResizeHandle';
+import { clampSidebarWidth } from './sidebarOptimization';
 import { useDialogBackHandler } from '../../hooks/useDialogBackHandler';
 import { useAppSelector } from '../../shared/store';
 import { Haptics } from '../../shared/utils/hapticFeedback';
@@ -76,7 +77,7 @@ const SolidMotionSidebar = React.memo(function SolidMotionSidebar({
       const appSettings = localStorage.getItem('appSettings');
       if (appSettings) {
         const settings = JSON.parse(appSettings);
-        return settings.sidebarWidth || 350;
+        return clampSidebarWidth(settings.sidebarWidth || 350);
       }
     } catch (e) {
       console.error('读取侧边栏宽度失败:', e);
@@ -90,7 +91,7 @@ const SolidMotionSidebar = React.memo(function SolidMotionSidebar({
   useEffect(() => {
     const handleSettingsChange = (e: CustomEvent) => {
       if (e.detail?.settingId === 'sidebarWidth') {
-        setDrawerWidth(e.detail.value);
+        setDrawerWidth(clampSidebarWidth(e.detail.value));
       }
     };
     window.addEventListener('appSettingsChanged', handleSettingsChange as EventListener);

--- a/src/components/TopicManagement/sidebarOptimization.ts
+++ b/src/components/TopicManagement/sidebarOptimization.ts
@@ -4,6 +4,27 @@
  * 这个文件包含了侧边栏动画和性能优化的所有配置
  */
 
+// 侧边栏宽度限制
+export const SIDEBAR_WIDTH_MIN = 340;
+export const SIDEBAR_WIDTH_MAX = 800;
+// 保证侧边栏不会铺满整个屏幕，否则恢复入口（宽度按钮）会被挤出可视区域
+export const SIDEBAR_VIEWPORT_SAFE_MARGIN = 120;
+
+// 计算当前屏幕下允许的最大宽度，避免设置过大导致无法恢复
+export const getSafeMaxSidebarWidth = (): number => {
+  const viewportLimit =
+    typeof window !== 'undefined'
+      ? window.innerWidth - SIDEBAR_VIEWPORT_SAFE_MARGIN
+      : SIDEBAR_WIDTH_MAX;
+  return Math.max(SIDEBAR_WIDTH_MIN, Math.min(SIDEBAR_WIDTH_MAX, viewportLimit));
+};
+
+// 将宽度收敛到 [最小值, 当前屏幕安全最大值] 区间
+export const clampSidebarWidth = (width: number): number => {
+  const safeMax = getSafeMaxSidebarWidth();
+  return Math.max(SIDEBAR_WIDTH_MIN, Math.min(safeMax, width));
+};
+
 // 动画时长配置
 export const ANIMATION_DURATION = {
   FAST: 150,      // 快速动画 - 用于按钮点击等

--- a/src/pages/ChatPage/components/ChatPageUI.tsx
+++ b/src/pages/ChatPage/components/ChatPageUI.tsx
@@ -7,6 +7,7 @@ import { CustomIcon } from '../../../components/icons';
 import SolidMessageList from '../../../components/message/SolidMessageList';
 import { IntegratedChatInput } from '../../../components/input';
 import { Sidebar } from '../../../components/TopicManagement';
+import { clampSidebarWidth } from '../../../components/TopicManagement/sidebarOptimization';
 import { ModelSelector } from './ModelSelector';
 import { UnifiedModelDisplay } from './UnifiedModelDisplay';
 import { useSelector } from 'react-redux';
@@ -58,7 +59,7 @@ const getStoredSidebarWidth = (): number => {
     const appSettings = localStorage.getItem('appSettings');
     if (appSettings) {
       const settings = JSON.parse(appSettings);
-      return settings.sidebarWidth || DEFAULT_DRAWER_WIDTH;
+      return clampSidebarWidth(settings.sidebarWidth || DEFAULT_DRAWER_WIDTH);
     }
   } catch (e) {
     console.error('读取侧边栏宽度失败:', e);
@@ -244,7 +245,7 @@ const ChatPageUIComponent: React.FC<ChatPageUIProps> = ({
   useEffect(() => {
     const handleSettingsChange = (e: CustomEvent) => {
       if (e.detail?.settingId === 'sidebarWidth') {
-        setSidebarWidth(e.detail.value);
+        setSidebarWidth(clampSidebarWidth(e.detail.value));
       }
     };
     window.addEventListener('appSettingsChanged', handleSettingsChange as EventListener);


### PR DESCRIPTION
## Summary
修复侧边栏宽度设置的两个缺陷：

1. **改动立即生效、无确认环节**：原 `SidebarWidthDialog` 的滑块/输入框/预设会直接调用 `onWidthChange` → `updateSetting('sidebarWidth', ...)` 立刻保存。
2. **宽度无上限**：`handleWidthChange` 只做 `Math.max(MIN, ...)`，输入框无 `max`。用户输入超大值（如 2000px）后侧边栏比视口还宽，把右上角的"宽度按钮"挤出可视区域，导致无法再次打开对话框恢复。

改动：

- **确认保存机制**：对话框改为本地草稿态 `draftWidth`，滑块/输入框/预设仅修改草稿，新增「取消 / 保存」按钮，仅点击「保存」才提交：
  ```
  const [draftWidth, setDraftWidth] = useState(() => clamp(currentWidth));
  // 打开时同步当前值
  useEffect(() => { if (open) setDraftWidth(clamp(currentWidth)); }, [open, currentWidth]);
  const handleSave = () => { onWidthChange(clamp(draftWidth)); onClose(); };
  ```
  点击遮罩 / 返回键 = 取消，不保存。

- **视口安全上限**：在 `sidebarOptimization.ts` 新增共享工具，保证宽度不会铺满屏幕，恢复入口始终可见：
  ```
  getSafeMaxSidebarWidth() = clamp(window.innerWidth - 120, MIN=340, MAX=800)
  clampSidebarWidth(w)     = clamp(w, MIN, getSafeMaxSidebarWidth())
  ```

- **已损坏状态自愈**：在所有读取宽度的入口套用 `clampSidebarWidth`，让已经保存了超大值、当前被卡住的用户重新打开应用即可恢复：
  - `ChatPageUI` 的 `getStoredSidebarWidth` 与 `appSettingsChanged` 监听
  - `SolidMotionSidebar` 的 `getStoredWidth` 与监听
  - `SettingsTab` 显示用的 `currentWidth`
  - `SidebarResizeHandle` 拖动时改用 `getSafeMaxSidebarWidth()` 作为上限

## 测试
- `npx tsc --noEmit --skipLibCheck` 通过
- `npx eslint` 改动文件无新增告警（`SolidMotionSidebar` 的 `set-state-in-effect` 报错为 main 既有问题）


Link to Devin session: https://app.devin.ai/sessions/f6d1e83983bc4a78ad8d0924dca4d3fd
Requested by: @1600822305