### PR TITLE
feat(logging): 统一日志系统首批(核心 + 兼容垫片 + ESLint)

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -35,6 +35,20 @@ export default tseslint.config(
       'no-async-promise-executor': 'off',
       'prefer-const': 'off',
       'no-control-regex': 'error',
+      // 引导新代码改用统一 logger；现存裸 console 仅告警、不阻断（迁移完成后再升级为 error）
+      'no-console': ['warn', { allow: ['warn', 'error'] }],
+    },
+  },
+  {
+    // 日志基础设施本身必须直接使用 console
+    files: [
+      'src/shared/services/infra/logger/**/*.{ts,tsx}',
+      'src/shared/services/infra/EnhancedConsoleService.ts',
+      'src/shared/services/infra/LoggerService.ts',
+      'src/shared/utils/debugLogger.ts',
+    ],
+    rules: {
+      'no-console': 'off',
     },
   },
 )

--- a/src/shared/services/infra/LoggerService.ts
+++ b/src/shared/services/infra/LoggerService.ts
@@ -3,6 +3,7 @@
  * 提供统一的日志记录功能
  */
 import { getStorageItem, setStorageItem, removeStorageItem } from '../../utils/storage';
+import { forwardLog } from './logger/compat';
 
 // 日志级别
 export type LogLevel = 'DEBUG' | 'INFO' | 'WARN' | 'ERROR';
@@ -42,61 +43,34 @@ function debouncedSaveLogs(): void {
 
 // 日志记录函数
 export function log(level: LogLevel, message: string, data?: any): void {
+  // 统一经新 logger 输出（含级别阈值短路与脱敏）
+  forwardLog(level, message, data);
+
+  // 保留内存缓存 + 防抖持久化，供应用内日志查看器（getRecentLogs）使用
   const timestamp = new Date().toISOString();
-  const logEntry = {
-    timestamp,
-    level,
-    message,
-    data
-  };
-
-  // 根据不同级别使用不同的控制台方法
-  // 序列化数据对象，避免[object Object]
-  const serializedData = data ? JSON.stringify(data, null, 2) : '';
-
-  switch (level) {
-    case 'DEBUG':
-      console.log(`[${timestamp}] [DEBUG] ${message}`, serializedData);
-      break;
-    case 'INFO':
-      console.info(`[${timestamp}] [INFO] ${message}`, serializedData);
-      break;
-    case 'WARN':
-      console.warn(`[${timestamp}] [WARN] ${message}`, serializedData);
-      break;
-    case 'ERROR':
-      console.error(`[${timestamp}] [ERROR] ${message}`, serializedData);
-      break;
-  }
-
-  // 将日志存储到内存缓存，并异步持久化
   if (!cacheInitialized) {
     initLogsCache();
   }
-  
-  logsCache.push(logEntry);
-  
+
+  logsCache.push({ timestamp, level, message, data });
+
   // 保留最近的日志
   if (logsCache.length > MAX_LOGS) {
     logsCache.splice(0, logsCache.length - MAX_LOGS);
   }
-  
+
   // 防抖保存到Dexie
   debouncedSaveLogs();
 }
 
 // 记录API请求
 export function logApiRequest(endpoint: string, level: LogLevel, data: any): void {
-  // 确保请求数据被完整记录
-  console.log(`API请求详情 [${endpoint}]:`, JSON.stringify(data, null, 2));
   log(level, `API请求 [${endpoint}]`, data);
 }
 
 // 记录API响应
 export function logApiResponse(endpoint: string, statusCode: number, data: any): void {
-  const level = statusCode >= 400 ? 'ERROR' : 'INFO';
-  // 确保响应数据被完整记录
-  console.log(`API响应详情 [${endpoint}] 状态码: ${statusCode}:`, JSON.stringify(data, null, 2));
+  const level: LogLevel = statusCode >= 400 ? 'ERROR' : 'INFO';
   log(level, `API响应 [${endpoint}] 状态码: ${statusCode}`, data);
 }
 

--- a/src/shared/services/infra/logger/Logger.ts
+++ b/src/shared/services/infra/logger/Logger.ts
@@ -1,0 +1,127 @@
+/**
+ * 统一日志系统 — 核心 Logger
+ * 负责：级别阈值短路、命名空间、脱敏、向各 Transport 分发。
+ */
+import {
+  LogLevel,
+  type LazyMessage,
+  type LogEntry,
+  type Platform,
+  type Redactor,
+  type Transport,
+} from './types';
+
+/** 多个 logger 实例（根 + withContext 子实例）共享同一份可变核心状态 */
+export interface LoggerCore {
+  level: LogLevel;
+  transports: Transport[];
+  redact?: Redactor;
+  platform: Platform;
+}
+
+export class Logger {
+  private readonly core: LoggerCore;
+  private readonly context?: string;
+
+  constructor(core: LoggerCore, context?: string) {
+    this.core = core;
+    this.context = context;
+  }
+
+  /** 派生带命名空间的子 logger，与父级共享级别/通道配置 */
+  withContext(context: string): Logger {
+    return new Logger(this.core, context);
+  }
+
+  setLevel(level: LogLevel): void {
+    this.core.level = level;
+  }
+
+  getLevel(): LogLevel {
+    return this.core.level;
+  }
+
+  isLevelEnabled(level: LogLevel): boolean {
+    return level !== LogLevel.SILENT && level <= this.core.level;
+  }
+
+  addTransport(transport: Transport): void {
+    if (!this.core.transports.some((t) => t.name === transport.name)) {
+      this.core.transports.push(transport);
+    }
+  }
+
+  removeTransport(name: string): void {
+    this.core.transports = this.core.transports.filter((t) => t.name !== name);
+  }
+
+  setRedactor(redact: Redactor | undefined): void {
+    this.core.redact = redact;
+  }
+
+  error(message: LazyMessage, ...args: unknown[]): void {
+    this.emit(LogLevel.ERROR, message, args);
+  }
+
+  warn(message: LazyMessage, ...args: unknown[]): void {
+    this.emit(LogLevel.WARN, message, args);
+  }
+
+  info(message: LazyMessage, ...args: unknown[]): void {
+    this.emit(LogLevel.INFO, message, args);
+  }
+
+  debug(message: LazyMessage, ...args: unknown[]): void {
+    this.emit(LogLevel.DEBUG, message, args);
+  }
+
+  trace(message: LazyMessage, ...args: unknown[]): void {
+    this.emit(LogLevel.TRACE, message, args);
+  }
+
+  /** 以指定级别记录（兼容垫片转发旧 API 时使用） */
+  logAt(level: LogLevel, message: LazyMessage, ...args: unknown[]): void {
+    this.emit(level, message, args);
+  }
+
+  logApiRequest(endpoint: string, level: LogLevel, data: unknown): void {
+    this.emit(level, `API请求 [${endpoint}]`, [data]);
+  }
+
+  logApiResponse(endpoint: string, statusCode: number, data: unknown): void {
+    const level = statusCode >= 400 ? LogLevel.ERROR : LogLevel.INFO;
+    this.emit(level, `API响应 [${endpoint}] 状态码: ${statusCode}`, [data]);
+  }
+
+  private emit(level: LogLevel, message: LazyMessage, args: unknown[]): void {
+    // 阈值短路：未达阈值直接返回，惰性消息不会被求值
+    if (!this.isLevelEnabled(level)) return;
+
+    const text = typeof message === 'function' ? message() : message;
+    let entry: LogEntry = {
+      timestamp: Date.now(),
+      level,
+      context: this.context,
+      message: text,
+      args,
+      platform: this.core.platform,
+    };
+
+    if (this.core.redact) {
+      try {
+        entry = this.core.redact(entry);
+      } catch {
+        /* 脱敏失败不应阻断日志 */
+      }
+    }
+
+    for (const transport of this.core.transports) {
+      if (transport.level !== undefined && level > transport.level) continue;
+      try {
+        transport.write(entry);
+      } catch {
+        /* 单个 Transport 失败不应拖垮应用或其他通道 */
+      }
+    }
+  }
+}

--- a/src/shared/services/infra/logger/__tests__/logger.test.ts
+++ b/src/shared/services/infra/logger/__tests__/logger.test.ts
@@ -1,0 +1,169 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { Logger, type LoggerCore } from '../Logger';
+import { LogLevel, type LogEntry, type Transport } from '../types';
+import { MemoryTransport } from '../transports/MemoryTransport';
+import { defaultRedact } from '../redact';
+
+class CaptureTransport implements Transport {
+  readonly name = 'capture';
+  level?: LogLevel;
+  entries: LogEntry[] = [];
+  write(entry: LogEntry): void {
+    this.entries.push(entry);
+  }
+}
+
+function makeLogger(level: LogLevel, transports: Transport[], redact = defaultRedact) {
+  const core: LoggerCore = { level, transports, redact, platform: 'web' };
+  return new Logger(core);
+}
+
+describe('Logger 级别阈值短路', () => {
+  it('低于阈值的日志不写入任何 Transport', () => {
+    const cap = new CaptureTransport();
+    const logger = makeLogger(LogLevel.WARN, [cap]);
+
+    logger.debug('debug');
+    logger.info('info');
+    logger.warn('warn');
+    logger.error('error');
+
+    expect(cap.entries.map((e) => e.level)).toEqual([LogLevel.WARN, LogLevel.ERROR]);
+  });
+
+  it('SILENT 关闭所有输出（含 error）', () => {
+    const cap = new CaptureTransport();
+    const logger = makeLogger(LogLevel.SILENT, [cap]);
+    logger.error('boom');
+    expect(cap.entries).toHaveLength(0);
+  });
+
+  it('setLevel 运行时调整阈值', () => {
+    const cap = new CaptureTransport();
+    const logger = makeLogger(LogLevel.WARN, [cap]);
+    logger.debug('x');
+    expect(cap.entries).toHaveLength(0);
+    logger.setLevel(LogLevel.DEBUG);
+    logger.debug('y');
+    expect(cap.entries).toHaveLength(1);
+  });
+});
+
+describe('惰性求值', () => {
+  it('未达阈值时不调用惰性消息函数', () => {
+    const cap = new CaptureTransport();
+    const logger = makeLogger(LogLevel.WARN, [cap]);
+    const fn = vi.fn(() => 'expensive');
+    logger.debug(fn);
+    expect(fn).not.toHaveBeenCalled();
+  });
+
+  it('达到阈值时求值并写入消息', () => {
+    const cap = new CaptureTransport();
+    const logger = makeLogger(LogLevel.DEBUG, [cap]);
+    const fn = vi.fn(() => 'computed');
+    logger.debug(fn);
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(cap.entries[0].message).toBe('computed');
+  });
+});
+
+describe('命名空间', () => {
+  it('withContext 携带 context 且共享父级配置', () => {
+    const cap = new CaptureTransport();
+    const logger = makeLogger(LogLevel.DEBUG, [cap]);
+    const scoped = logger.withContext('MCP');
+    scoped.info('hi');
+    expect(cap.entries[0].context).toBe('MCP');
+
+    // 父级 setLevel 影响子实例（共享 core）
+    logger.setLevel(LogLevel.ERROR);
+    scoped.info('suppressed');
+    expect(cap.entries).toHaveLength(1);
+  });
+});
+
+describe('脱敏 Processor', () => {
+  it('打码 args 中的敏感字段，且不修改调用方原对象', () => {
+    const cap = new CaptureTransport();
+    const logger = makeLogger(LogLevel.DEBUG, [cap]);
+    const payload = { apiKey: 'sk-secret', nested: { token: 'abc', keep: 1 } };
+
+    logger.info('req', payload);
+
+    const logged = cap.entries[0].args[0] as Record<string, unknown>;
+    expect(logged.apiKey).toBe('***');
+    expect((logged.nested as Record<string, unknown>).token).toBe('***');
+    expect((logged.nested as Record<string, unknown>).keep).toBe(1);
+    // 原对象不被改动
+    expect(payload.apiKey).toBe('sk-secret');
+  });
+
+  it('处理循环引用不抛异常', () => {
+    const cap = new CaptureTransport();
+    const logger = makeLogger(LogLevel.DEBUG, [cap]);
+    const cyclic: Record<string, unknown> = { a: 1 };
+    cyclic.self = cyclic;
+    expect(() => logger.info('cyclic', cyclic)).not.toThrow();
+  });
+});
+
+describe('Transport 隔离', () => {
+  let errSpy: ReturnType<typeof vi.spyOn>;
+  beforeEach(() => {
+    errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+  afterEach(() => {
+    errSpy.mockRestore();
+  });
+
+  it('单个 Transport 抛错不影响其他 Transport', () => {
+    const bad: Transport = {
+      name: 'bad',
+      write() {
+        throw new Error('fail');
+      },
+    };
+    const cap = new CaptureTransport();
+    const logger = makeLogger(LogLevel.DEBUG, [bad, cap]);
+    expect(() => logger.info('ok')).not.toThrow();
+    expect(cap.entries).toHaveLength(1);
+  });
+
+  it('Transport 自身 level 高于消息级别时跳过', () => {
+    const cap = new CaptureTransport();
+    cap.level = LogLevel.ERROR;
+    const logger = makeLogger(LogLevel.DEBUG, [cap]);
+    logger.info('skip');
+    logger.error('keep');
+    expect(cap.entries.map((e) => e.level)).toEqual([LogLevel.ERROR]);
+  });
+});
+
+describe('MemoryTransport 环形缓冲', () => {
+  it('超出容量丢弃最旧条目', () => {
+    const mem = new MemoryTransport(3);
+    const logger = makeLogger(LogLevel.DEBUG, [mem]);
+    for (let i = 0; i < 5; i++) logger.info(`m${i}`);
+    const msgs = mem.getEntries().map((e) => e.message);
+    expect(msgs).toEqual(['m2', 'm3', 'm4']);
+  });
+
+  it('clear 清空缓冲', () => {
+    const mem = new MemoryTransport(10);
+    const logger = makeLogger(LogLevel.DEBUG, [mem]);
+    logger.info('a');
+    mem.clear();
+    expect(mem.getEntries()).toHaveLength(0);
+  });
+});
+
+describe('logApiResponse 级别映射', () => {
+  it('状态码 >= 400 记为 ERROR，否则 INFO', () => {
+    const cap = new CaptureTransport();
+    const logger = makeLogger(LogLevel.DEBUG, [cap]);
+    logger.logApiResponse('/a', 200, {});
+    logger.logApiResponse('/b', 500, {});
+    expect(cap.entries.map((e) => e.level)).toEqual([LogLevel.INFO, LogLevel.ERROR]);
+  });
+});

--- a/src/shared/services/infra/logger/compat.ts
+++ b/src/shared/services/infra/logger/compat.ts
@@ -1,0 +1,62 @@
+/**
+ * 兼容垫片：把旧 LoggerService / debugLogger 的调用转发到统一 logger，
+ * 让现有 19+ 个文件无需立即改动即可受益于级别短路与脱敏。
+ */
+import { logger } from './index';
+import { LogLevel } from './types';
+import { getDefaultLevel, readDebugFlag, writeDebugFlag } from './config';
+
+type LegacyLoggerLevel = 'DEBUG' | 'INFO' | 'WARN' | 'ERROR';
+
+const LEGACY_LEVEL: Record<LegacyLoggerLevel, LogLevel> = {
+  DEBUG: LogLevel.DEBUG,
+  INFO: LogLevel.INFO,
+  WARN: LogLevel.WARN,
+  ERROR: LogLevel.ERROR,
+};
+
+/** 转发旧 LoggerService.log(level, message, data) */
+export function forwardLog(
+  level: LegacyLoggerLevel,
+  message: string,
+  data?: unknown,
+): void {
+  const lvl = LEGACY_LEVEL[level] ?? LogLevel.INFO;
+  if (data === undefined) logger.logAt(lvl, message);
+  else logger.logAt(lvl, message, data);
+}
+
+/** 转发旧 debugLog.* */
+export const debugLogCompat = {
+  log: (message: string, ...args: unknown[]): void =>
+    logger.debug(message, ...args),
+  info: (message: string, ...args: unknown[]): void =>
+    logger.info(message, ...args),
+  warn: (message: string, ...args: unknown[]): void =>
+    logger.warn(message, ...args),
+  error: (message: string, ...args: unknown[]): void =>
+    logger.error(message, ...args),
+  component: (componentName: string, action: string, data?: unknown): void => {
+    const scoped = logger.withContext(componentName);
+    if (data === undefined) scoped.debug(action);
+    else scoped.debug(action, data);
+  },
+};
+
+/** 旧 setDebugMode：持久化开关并即时调整 logger 阈值 */
+export function setLoggerDebugMode(enabled: boolean): void {
+  writeDebugFlag(enabled);
+  logger.setLevel(enabled ? LogLevel.DEBUG : getDefaultLevel());
+}
+
+/** 旧 getDebugMode */
+export function getLoggerDebugMode(): boolean {
+  if (readDebugFlag()) return true;
+  if (
+    typeof window !== 'undefined' &&
+    (window as unknown as { __DEBUG__?: boolean }).__DEBUG__ === true
+  ) {
+    return true;
+  }
+  return import.meta.env.DEV;
+}

--- a/src/shared/services/infra/logger/config.ts
+++ b/src/shared/services/infra/logger/config.ts
@@ -1,0 +1,56 @@
+/**
+ * 统一日志系统 — 默认配置与环境判定
+ * 环境判定统一走 import.meta.env.DEV，不使用 process.env.NODE_ENV（浏览器不可靠）
+ */
+import { LogLevel, type LogLevelName, type Platform } from './types';
+import { isTauri, isCapacitor } from '../../../utils/platformDetection';
+
+const DEBUG_FLAG_KEY = 'debug_mode';
+
+/** 运行时调试开关（持久化在 localStorage，刷新后仍生效） */
+export function readDebugFlag(): boolean {
+  try {
+    return (
+      typeof localStorage !== 'undefined' &&
+      localStorage.getItem(DEBUG_FLAG_KEY) === 'true'
+    );
+  } catch {
+    return false;
+  }
+}
+
+export function writeDebugFlag(enabled: boolean): void {
+  try {
+    if (typeof localStorage === 'undefined') return;
+    if (enabled) localStorage.setItem(DEBUG_FLAG_KEY, 'true');
+    else localStorage.removeItem(DEBUG_FLAG_KEY);
+  } catch {
+    /* 忽略存储不可用 */
+  }
+}
+
+/** 默认级别阈值：开发 DEBUG，生产 WARN；手动开调试则强制 DEBUG */
+export function getDefaultLevel(): LogLevel {
+  if (readDebugFlag()) return LogLevel.DEBUG;
+  return import.meta.env.DEV ? LogLevel.DEBUG : LogLevel.WARN;
+}
+
+/** 当前运行平台（在 logger 初始化时计算一次即可） */
+export function resolvePlatform(): Platform {
+  try {
+    if (isTauri()) return 'tauri';
+    if (isCapacitor()) return 'capacitor';
+  } catch {
+    /* 探测失败时退回 web */
+  }
+  return 'web';
+}
+
+export const LEVEL_LABEL: Record<LogLevel, LogLevelName> = {
+  [LogLevel.SILENT]: 'SILENT',
+  [LogLevel.ERROR]: 'ERROR',
+  [LogLevel.WARN]: 'WARN',
+  [LogLevel.INFO]: 'INFO',
+  [LogLevel.DEBUG]: 'DEBUG',
+  [LogLevel.TRACE]: 'TRACE',
+};

--- a/src/shared/services/infra/logger/index.ts
+++ b/src/shared/services/infra/logger/index.ts
@@ -1,0 +1,37 @@
+/**
+ * 统一日志系统入口。
+ *
+ * 用法：
+ *   import { logger, createLogger } from '@/shared/services/infra/logger';
+ *   const log = createLogger('MCP');
+ *   log.info('连接成功', { server });
+ *   log.debug(() => `耗时 ${expensiveCompute()}ms`); // 惰性，未达阈值不求值
+ *
+ * 首批（阶段1）按设计方案 §3.3 的 B 方案，仅注册 ConsoleTransport，
+ * 避免与现有 EnhancedConsoleService 形成双缓冲；阶段6 再启用 MemoryTransport
+ * 并让 DevTools/ConsolePanel 改读它。
+ */
+import { Logger, type LoggerCore } from './Logger';
+import { ConsoleTransport } from './transports/ConsoleTransport';
+import { getDefaultLevel, resolvePlatform } from './config';
+import { defaultRedact } from './redact';
+
+const core: LoggerCore = {
+  level: getDefaultLevel(),
+  transports: [new ConsoleTransport()],
+  redact: defaultRedact,
+  platform: resolvePlatform(),
+};
+
+export const logger = new Logger(core);
+
+/** 创建带命名空间的 logger（推荐业务代码使用） */
+export function createLogger(context: string): Logger {
+  return logger.withContext(context);
+}
+
+export { Logger } from './Logger';
+export { ConsoleTransport } from './transports/ConsoleTransport';
+export { MemoryTransport } from './transports/MemoryTransport';
+export { defaultRedact } from './redact';
+export * from './types';

--- a/src/shared/services/infra/logger/redact.ts
+++ b/src/shared/services/infra/logger/redact.ts
@@ -1,0 +1,52 @@
+/**
+ * 统一日志系统 — 脱敏处理器（核心步骤，非可选）
+ * logApiRequest/Response 等会携带 API Key/token，写出前统一打码。
+ */
+import type { Redactor } from './types';
+
+const SENSITIVE_KEYS = new Set(
+  [
+    'apikey',
+    'api_key',
+    'authorization',
+    'token',
+    'accesstoken',
+    'access_token',
+    'refreshtoken',
+    'refresh_token',
+    'password',
+    'secret',
+    'cookie',
+    'sessiontoken',
+    'session_token',
+  ].map((k) => k.toLowerCase()),
+);
+
+const MASK = '***';
+
+function redactValue(value: unknown, seen: WeakSet<object>): unknown {
+  if (value === null || typeof value !== 'object') return value;
+  if (seen.has(value)) return value;
+  seen.add(value);
+
+  if (Array.isArray(value)) {
+    return value.map((item) => redactValue(item, seen));
+  }
+
+  const out: Record<string, unknown> = {};
+  for (const [key, val] of Object.entries(value as Record<string, unknown>)) {
+    out[key] = SENSITIVE_KEYS.has(key.toLowerCase())
+      ? MASK
+      : redactValue(val, seen);
+  }
+  return out;
+}
+
+/** 默认脱敏：只处理 args 中的对象字段，返回新对象，不修改调用方数据 */
+export const defaultRedact: Redactor = (entry) => {
+  if (entry.args.length === 0) return entry;
+  return {
+    ...entry,
+    args: entry.args.map((arg) => redactValue(arg, new WeakSet<object>())),
+  };
+};

--- a/src/shared/services/infra/logger/transports/ConsoleTransport.ts
+++ b/src/shared/services/infra/logger/transports/ConsoleTransport.ts
@@ -1,0 +1,30 @@
+/**
+ * 控制台输出通道：带级别/命名空间前缀。
+ */
+import { LogLevel, type LogEntry, type Transport } from '../types';
+import { LEVEL_LABEL } from '../config';
+
+export class ConsoleTransport implements Transport {
+  readonly name = 'console';
+
+  write(entry: LogEntry): void {
+    const label = LEVEL_LABEL[entry.level] ?? 'LOG';
+    const prefix = entry.context
+      ? `[${label}] [${entry.context}]`
+      : `[${label}]`;
+    this.method(entry.level)(prefix, entry.message, ...entry.args);
+  }
+
+  private method(level: LogLevel): (...args: unknown[]) => void {
+    switch (level) {
+      case LogLevel.ERROR:
+        return console.error.bind(console);
+      case LogLevel.WARN:
+        return console.warn.bind(console);
+      case LogLevel.INFO:
+        return console.info.bind(console);
+      default:
+        return (console.debug ?? console.log).bind(console);
+    }
+  }
+}

--- a/src/shared/services/infra/logger/transports/MemoryTransport.ts
+++ b/src/shared/services/infra/logger/transports/MemoryTransport.ts
@@ -1,0 +1,29 @@
+/**
+ * 内存环形缓冲通道：供应用内日志查看器（DevTools/ConsolePanel）读取。
+ * 默认不注册（见 index.ts / 设计方案 §3.3 的 B 方案），阶段6 整合时启用。
+ */
+import type { LogEntry, Transport } from '../types';
+
+export class MemoryTransport implements Transport {
+  readonly name = 'memory';
+  private buffer: LogEntry[] = [];
+  private readonly capacity: number;
+
+  constructor(capacity = 500) {
+    this.capacity = Math.max(1, capacity);
+  }
+
+  write(entry: LogEntry): void {
+    this.buffer.push(entry);
+    const overflow = this.buffer.length - this.capacity;
+    if (overflow > 0) this.buffer.splice(0, overflow);
+  }
+
+  getEntries(): readonly LogEntry[] {
+    return this.buffer;
+  }
+
+  clear(): void {
+    this.buffer = [];
+  }
+}

--- a/src/shared/services/infra/logger/types.ts
+++ b/src/shared/services/infra/logger/types.ts
@@ -1,0 +1,42 @@
+/**
+ * 统一日志系统 — 类型定义
+ * 见设计方案 plans/logging-system-design.md
+ */
+
+// 数值级别：越小越重要，便于阈值短路比较
+export const LogLevel = {
+  SILENT: 0,
+  ERROR: 1,
+  WARN: 2,
+  INFO: 3,
+  DEBUG: 4,
+  TRACE: 5,
+} as const;
+
+export type LogLevel = (typeof LogLevel)[keyof typeof LogLevel];
+export type LogLevelName = keyof typeof LogLevel;
+
+export type Platform = 'web' | 'tauri' | 'capacitor';
+
+export interface LogEntry {
+  timestamp: number;
+  level: LogLevel;
+  context?: string;
+  message: string;
+  args: unknown[];
+  platform: Platform;
+}
+
+/** 输出通道：控制台 / 内存 / 持久化 / 远程，互相解耦 */
+export interface Transport {
+  readonly name: string;
+  /** 通道自身的级别阈值（可选，未设则跟随 logger 全局阈值） */
+  level?: LogLevel;
+  write(entry: LogEntry): void;
+}
+
+/** 惰性消息：未达阈值时不会被调用，避免无谓的字符串拼接 */
+export type LazyMessage = string | (() => string);
+
+/** 脱敏处理器：在写入任何 Transport 之前统一过滤敏感字段 */
+export type Redactor = (entry: LogEntry) => LogEntry;

--- a/src/shared/utils/debugLogger.ts
+++ b/src/shared/utils/debugLogger.ts
@@ -1,72 +1,31 @@
 /**
- * 调试日志工具
- * 提供条件日志记录，只在开发环境或启用调试时输出日志
+ * 调试日志工具（兼容垫片）
+ * 现已转发到统一 logger（src/shared/services/infra/logger）。
+ * 级别阈值、命名空间、脱敏由统一 logger 负责，此处仅保留旧 API 形态。
  */
-
-// 检查是否启用调试模式
-const isDebugEnabled = (): boolean => {
-  return (
-    process.env.NODE_ENV === 'development' ||
-    localStorage.getItem('debug_mode') === 'true' ||
-    (window as any).__DEBUG__ === true
-  );
-};
+import {
+  debugLogCompat,
+  getLoggerDebugMode,
+  setLoggerDebugMode,
+} from '../services/infra/logger/compat';
 
 // 日志级别
 export type LogLevel = 'log' | 'info' | 'warn' | 'error';
 
 /**
  * 条件日志记录函数
- * 只在调试模式下输出日志
+ * 是否输出由统一 logger 的级别阈值决定（开发 DEBUG / 生产 WARN）
  */
-export const debugLog = {
-  log: (message: string, ...args: any[]) => {
-    if (isDebugEnabled()) {
-      console.log(`[DEBUG] ${message}`, ...args);
-    }
-  },
-  
-  info: (message: string, ...args: any[]) => {
-    if (isDebugEnabled()) {
-      console.info(`[INFO] ${message}`, ...args);
-    }
-  },
-  
-  warn: (message: string, ...args: any[]) => {
-    if (isDebugEnabled()) {
-      console.warn(`[WARN] ${message}`, ...args);
-    }
-  },
-  
-  error: (message: string, ...args: any[]) => {
-    // 错误日志始终输出
-    console.error(`[ERROR] ${message}`, ...args);
-  },
-  
-  // 组件特定的日志记录
-  component: (componentName: string, action: string, data?: any) => {
-    if (isDebugEnabled()) {
-      console.log(`[${componentName}] ${action}`, data || '');
-    }
-  }
-};
+export const debugLog = debugLogCompat;
 
 /**
  * 启用/禁用调试模式
  */
 export const setDebugMode = (enabled: boolean): void => {
-  if (enabled) {
-    localStorage.setItem('debug_mode', 'true');
-    console.log('🛠️ 调试模式已启用');
-  } else {
-    localStorage.removeItem('debug_mode');
-    console.log('🛠️ 调试模式已禁用');
-  }
+  setLoggerDebugMode(enabled);
 };
 
 /**
  * 检查调试模式状态
  */
-export const getDebugMode = (): boolean => {
-  return isDebugEnabled();
-};
+export const getDebugMode = (): boolean => getLoggerDebugMode();


### PR DESCRIPTION
## Summary

落地 `plans/logging-system-design.md` 的**阶段 1+2+3**(核心 + 兼容垫片 + ESLint),零破坏:不改动任何现有业务调用点,旧 `LoggerService` / `debugLog` 的调用全部转发到新统一 logger。本批不含阶段 4/5/6(codemod 迁移、删除旧服务、DevTools 整合)。

新 logger 的核心价值:**级别阈值短路 + 命名空间 + 惰性求值 + 脱敏**。

```ts
import { createLogger } from '@/shared/services/infra/logger';
const log = createLogger('MCP');
log.info('连接成功', { server, apiKey });          // apiKey 自动打码为 ***
log.debug(() => `耗时 ${expensiveCompute()}ms`);    // 未达阈值时回调不执行
```

### 阶段 1 — 核心 `src/shared/services/infra/logger/`
- `types.ts`:数值 `LogLevel`(`SILENT=0 … TRACE=5`,便于阈值比较)、`LogEntry`、`Transport`、`Redactor`。为兼容 `verbatimModuleSyntax` 用 `const` 对象 + 同名类型,而非 enum。
- `Logger.ts`:
  - `isLevelEnabled(level) = level !== SILENT && level <= currentLevel`,在求值惰性消息**之前**短路;
  - `withContext(ctx)` 派生子 logger,与父级**共享同一份可变 core**(根 `setLevel` 影响所有子实例);
  - 每个 Transport 的 `write` 包 try/catch,单通道抛错不影响其他通道与业务。
- `config.ts`:环境判定统一走 `import.meta.env.DEV`(开发默认 `DEBUG` / 生产 `WARN`),`localStorage['debug_mode']` 持久化开关可强制 `DEBUG`;平台用 `isTauri/isCapacitor` 探测(node 环境安全)。
- `redact.ts`:默认脱敏 Processor,递归打码 `apiKey/token/authorization/password/...` 等键(`WeakSet` 防循环引用,返回新对象不修改调用方数据)。
- `transports/ConsoleTransport.ts`(按级别映射 `console.error/warn/info/debug`,带 `[LEVEL] [ctx]` 前缀)、`transports/MemoryTransport.ts`(环形缓冲)。
- 按设计 §3.3 的 **B 方案**:首批 `index.ts` 仅注册 `ConsoleTransport`,**不**默认挂 `MemoryTransport`,避免与现有 `EnhancedConsoleService` 双缓冲;阶段 6 再启用并让 DevTools 改读它。
- `__tests__/logger.test.ts`:13 个 vitest 用例(阈值短路 / 惰性求值 / 命名空间 / 脱敏含循环引用 / Transport 隔离 / 环形缓冲 / API 级别映射)。

### 阶段 2 — 兼容垫片 `compat.ts`
- `LoggerService.log()` 现转发到 `logger.logAt(...)`,**保留** Dexie 缓存与 `getRecentLogs/clearLogs`(应用内日志查看器不受影响)。
- `logApiRequest/logApiResponse` 改经统一 logger 输出 —— 因此**自动受级别阈值与脱敏约束**,不再像旧代码那样无条件 `console.log` 全量 payload(此前会明文打出 API Key/token)。
- `debugLog.*` / `setDebugMode` / `getDebugMode` 转发到统一 logger;`setDebugMode` 同时即时调整 logger 阈值。

```diff
// LoggerService.log()
- switch (level) { case 'INFO': console.info(...JSON.stringify(data)); ... }
+ forwardLog(level, message, data);  // → 统一 logger(阈值 + 脱敏)
  logsCache.push({ timestamp, level, message, data });  // 缓存/持久化逻辑保留
```

### 阶段 3 — ESLint
- `'no-console': ['warn', { allow: ['warn', 'error'] }]`:仅**告警不阻断**(`eslint .` 仍退出 0,且 lint 不在 CI 中),作为迁移期过渡。
- 对日志基础设施文件(`logger/**`、`EnhancedConsoleService.ts`、`LoggerService.ts`、`debugLogger.ts`)override 为 `off`。
- **刻意未加** husky/lint-staged:避免对所有贡献者强制 pre-commit 钩子、并在 3000+ 处遗留 `console` 上误阻断提交。升级为 `error` + 仅改动文件强制,留作迁移完成后的后续项。

## 验证
- `npm run type-check`:通过(新增/改动文件 `tsc -p tsconfig.app.json` 无报错)。
- `npm run build`(vite):通过,8060 modules transformed。
- `npx vitest run src/shared/services/infra/logger`:13/13 通过。
- `eslint` 改动文件:0 error。


Link to Devin session: https://app.devin.ai/sessions/b18b37124c694c8ab02698a24264d4aa
Requested by: @1600822305