### PR TITLE
refactor(logging): MCP 子系统迁移到统一 logger（阶段4 样板）

### DIFF
--- a/src/shared/services/mcp/McpBridgeTool.ts
+++ b/src/shared/services/mcp/McpBridgeTool.ts
@@ -11,6 +11,10 @@
 
 import type { MCPTool, MCPCallToolResponse } from '../../types';
 import { mcpService } from './index';
+import { createLogger } from '../infra/logger';
+
+const logger = createLogger('McpBridge');
+
 
 // ======================== 工具定义 ========================
 
@@ -76,7 +80,7 @@ export async function executeBridgeToolCall(
     }
   } catch (error) {
     const msg = error instanceof Error ? error.message : String(error);
-    console.error(`[McpBridge] 执行失败:`, error);
+    logger.error(`执行失败:`, error);
     return makeErrorResponse(`Bridge 执行失败: ${msg}`);
   }
 }
@@ -184,7 +188,7 @@ async function handleCallTool(
     );
   }
 
-  console.log(`[McpBridge] 调用 ${server.name}.${toolName}`, toolArgs);
+  logger.debug(`调用 ${server.name}.${toolName}`, toolArgs);
 
   // 执行调用（MCPService.callTool 内部会处理连接和重试）
   const result = await mcpService.callTool(server, toolName, toolArgs);

--- a/src/shared/services/mcp/clients/AiSdkMCPClient.ts
+++ b/src/shared/services/mcp/clients/AiSdkMCPClient.ts
@@ -14,6 +14,10 @@ import type { Transport } from '@modelcontextprotocol/sdk/shared/transport.js';
 import { universalFetch } from '../../../utils/universalFetch';
 import { MCP_PROTOCOL_VERSION } from '../types/constants';
 import type { MCPClientOptions, MCPTool, MCPCallToolResponse } from './MCPClientAdapter';
+import { createLogger } from '../../infra/logger';
+
+const logger = createLogger('Mobile MCP Client');
+
 
 export class AiSdkMCPClient {
   private client: Client | null = null;
@@ -23,17 +27,17 @@ export class AiSdkMCPClient {
   constructor(options: MCPClientOptions) {
     this.options = options;
     
-    console.log(`[Mobile MCP Client] 创建客户端适配器（移动端 - CorsBypass 插件）`);
-    console.log(`[Mobile MCP Client] 基础URL: ${options.baseUrl}`);
-    console.log(`[Mobile MCP Client] 类型: ${options.type || 'streamableHttp'}`);
-    console.log(`[Mobile MCP Client] 让 SDK 自动管理 session`);
+    logger.debug(`创建客户端适配器（移动端 - CorsBypass 插件）`);
+    logger.debug(`基础URL: ${options.baseUrl}`);
+    logger.debug(`类型: ${options.type || 'streamableHttp'}`);
+    logger.debug(`让 SDK 自动管理 session`);
   }
 
   /**
    * 初始化连接
    */
   async initialize(): Promise<void> {
-    console.log(`[Mobile MCP Client] 开始初始化连接`);
+    logger.debug(`开始初始化连接`);
 
     try {
       // 创建客户端
@@ -52,7 +56,7 @@ export class AiSdkMCPClient {
         }
       );
       
-      console.log('[Mobile MCP Client] 客户端创建完成');
+      logger.debug('客户端创建完成');
 
       // 创建传输层（移动端直接使用原生 fetch，无需 CORS 处理）
       this.transport = await this.createTransport();
@@ -60,9 +64,9 @@ export class AiSdkMCPClient {
       // 连接（会自动发送初始化请求，不带 sessionId）
       await this.client.connect(this.transport);
 
-      console.log(`[Mobile MCP Client] 连接成功（已发送初始化请求）`);
+      logger.debug(`连接成功（已发送初始化请求）`);
     } catch (error) {
-      console.error('[Mobile MCP Client] 初始化失败:', error);
+      logger.error('初始化失败:', error);
       throw error;
     }
   }
@@ -74,13 +78,13 @@ export class AiSdkMCPClient {
     const { baseUrl, headers, type } = this.options;
 
     // 移动端使用 universalFetch（自动使用 CorsBypass 插件绕过 CORS）
-    console.log('[Mobile MCP Client] 使用 universalFetch + CorsBypass 插件');
+    logger.debug('使用 universalFetch + CorsBypass 插件');
 
     // 创建自定义 fetch 函数（完全模仿 Web 端的 MCPClientAdapter）
     const customFetch = async (url: string | URL, init?: RequestInit) => {
       const urlString = typeof url === 'string' ? url : url.toString();
-      console.log(`[Mobile MCP Client] Fetch: ${urlString}`);
-      console.log(`[Mobile MCP Client] Fetch init:`, init);
+      logger.debug(`Fetch: ${urlString}`);
+      logger.debug(`Fetch init:`, init);
       
       // 直接传递所有参数给 universalFetch，不修改（与 Web 端完全一致）
       return universalFetch(urlString, init);
@@ -94,9 +98,9 @@ export class AiSdkMCPClient {
 
     // StreamableHTTP 传输
     if (type === 'streamableHttp') {
-      console.log('[Mobile MCP Client] 使用 StreamableHTTP 传输（CorsBypass）');
-      console.log(`[Mobile MCP Client] SDK 将自动管理 session（初始化请求不带 sessionId）`);
-      console.log('[Mobile MCP Client] Headers:', JSON.stringify(headers || {}));
+      logger.debug('使用 StreamableHTTP 传输（CorsBypass）');
+      logger.debug(`SDK 将自动管理 session（初始化请求不带 sessionId）`);
+      logger.debug('Headers:', JSON.stringify(headers || {}));
       
       return new StreamableHTTPClientTransport(new URL(baseUrl), {
         fetch: customFetch,  // 使用自定义 fetch
@@ -108,7 +112,7 @@ export class AiSdkMCPClient {
     }
 
     // SSE 传输（默认）
-    console.log('[Mobile MCP Client] 使用 SSE 传输（CorsBypass）');
+    logger.debug('使用 SSE 传输（CorsBypass）');
     
     return new SSEClientTransport(new URL(baseUrl), {
       fetch: customFetch,  // 使用自定义 fetch（用于消息发送）
@@ -129,9 +133,9 @@ export class AiSdkMCPClient {
       throw new Error('客户端未初始化');
     }
 
-    console.log('[Mobile MCP Client] 列出工具');
+    logger.debug('列出工具');
     const result = await this.client.listTools();
-    console.log(`[Mobile MCP Client] 找到 ${result.tools.length} 个工具`);
+    logger.debug(`找到 ${result.tools.length} 个工具`);
     
     return result.tools as MCPTool[];
   }
@@ -144,14 +148,14 @@ export class AiSdkMCPClient {
       throw new Error('客户端未初始化');
     }
 
-    console.log(`[Mobile MCP Client] 调用工具: ${name}`, arguments_);
+    logger.debug(`调用工具: ${name}`, arguments_);
     
     const result = await this.client.callTool({
       name,
       arguments: arguments_
     });
 
-    console.log(`[Mobile MCP Client] 工具调用完成: ${name}`);
+    logger.debug(`工具调用完成: ${name}`);
     
     return {
       content: (result.content || []) as Array<{
@@ -172,9 +176,9 @@ export class AiSdkMCPClient {
       throw new Error('客户端未初始化');
     }
 
-    console.log('[Mobile MCP Client] 列出提示词');
+    logger.debug('列出提示词');
     const result = await this.client.listPrompts();
-    console.log(`[Mobile MCP Client] 找到 ${result.prompts?.length || 0} 个提示词`);
+    logger.debug(`找到 ${result.prompts?.length || 0} 个提示词`);
     
     return result.prompts || [];
   }
@@ -187,7 +191,7 @@ export class AiSdkMCPClient {
       throw new Error('客户端未初始化');
     }
 
-    console.log(`[Mobile MCP Client] 获取提示词: ${name}`);
+    logger.debug(`获取提示词: ${name}`);
     const result = await this.client.getPrompt({
       name,
       arguments: arguments_
@@ -204,9 +208,9 @@ export class AiSdkMCPClient {
       throw new Error('客户端未初始化');
     }
 
-    console.log('[Mobile MCP Client] 列出资源');
+    logger.debug('列出资源');
     const result = await this.client.listResources();
-    console.log(`[Mobile MCP Client] 找到 ${result.resources?.length || 0} 个资源`);
+    logger.debug(`找到 ${result.resources?.length || 0} 个资源`);
     
     return result.resources || [];
   }
@@ -219,7 +223,7 @@ export class AiSdkMCPClient {
       throw new Error('客户端未初始化');
     }
 
-    console.log(`[Mobile MCP Client] 读取资源: ${uri}`);
+    logger.debug(`读取资源: ${uri}`);
     const result = await this.client.readResource({ uri });
     
     return result;
@@ -230,7 +234,7 @@ export class AiSdkMCPClient {
    */
   async close(): Promise<void> {
     if (this.client) {
-      console.log('[Mobile MCP Client] 关闭连接');
+      logger.debug('关闭连接');
       await this.client.close();
       this.client = null;
       this.transport = null;

--- a/src/shared/services/mcp/clients/MCPClientAdapter.ts
+++ b/src/shared/services/mcp/clients/MCPClientAdapter.ts
@@ -11,6 +11,10 @@ import type { Transport } from '@modelcontextprotocol/sdk/shared/transport.js';
 import { universalFetch } from '../../../utils/universalFetch';
 import { Capacitor } from '@capacitor/core';
 import { MobileSSETransport } from './MobileSSETransport';
+import { createLogger } from '../../infra/logger';
+
+const logger = createLogger('MCP Client');
+
 
 export interface MCPClientOptions {
   baseUrl: string;
@@ -42,17 +46,17 @@ export class MCPClientAdapter {
 
   constructor(options: MCPClientOptions) {
     this.options = options;
-    console.log(`[MCP Client] 创建客户端适配器`);
-    console.log(`[MCP Client] 基础URL: ${options.baseUrl}`);
-    console.log(`[MCP Client] 类型: ${options.type || 'sse'}`);
-    console.log(`[MCP Client] 平台: ${Capacitor.isNativePlatform() ? '移动端' : 'Web端'}`);
+    logger.debug(`创建客户端适配器`);
+    logger.debug(`基础URL: ${options.baseUrl}`);
+    logger.debug(`类型: ${options.type || 'sse'}`);
+    logger.debug(`平台: ${Capacitor.isNativePlatform() ? '移动端' : 'Web端'}`);
   }
 
   /**
    * 初始化连接
    */
   async initialize(): Promise<void> {
-    console.log(`[MCP Client] 开始初始化连接`);
+    logger.debug(`开始初始化连接`);
 
     try {
       // 创建客户端
@@ -71,7 +75,7 @@ export class MCPClientAdapter {
         }
       );
       
-      console.log('[MCP Client] 客户端创建完成');
+      logger.debug('客户端创建完成');
 
       // 创建传输层
       this.transport = await this.createTransport();
@@ -79,9 +83,9 @@ export class MCPClientAdapter {
       // 连接
       await this.client.connect(this.transport);
 
-      console.log(`[MCP Client] 连接成功`);
+      logger.debug(`连接成功`);
     } catch (error) {
-      console.error('[MCP Client] 初始化失败:', error);
+      logger.error('初始化失败:', error);
       throw error;
     }
   }
@@ -95,8 +99,8 @@ export class MCPClientAdapter {
     // 创建自定义 fetch 函数，完全模仿 Cherry Studio 的方式
     const customFetch = async (url: string | URL, init?: RequestInit) => {
       const urlString = typeof url === 'string' ? url : url.toString();
-      console.log(`[MCP Client] Fetch: ${urlString}`);
-      console.log(`[MCP Client] Fetch init:`, init);
+      logger.debug(`Fetch: ${urlString}`);
+      logger.debug(`Fetch init:`, init);
       
       // 直接传递所有参数给 universalFetch，不修改
       return universalFetch(urlString, init);
@@ -110,8 +114,8 @@ export class MCPClientAdapter {
 
     // StreamableHTTP 传输
     if (type === 'streamableHttp') {
-      console.log('[MCP Client] 使用 StreamableHTTP 传输');
-      console.log('[MCP Client] Headers:', JSON.stringify(prepareHeaders()));
+      logger.debug('使用 StreamableHTTP 传输');
+      logger.debug('Headers:', JSON.stringify(prepareHeaders()));
       
       const transport = new StreamableHTTPClientTransport(new URL(baseUrl), {
         fetch: customFetch,
@@ -120,28 +124,28 @@ export class MCPClientAdapter {
         }
       });
       
-      console.log('[MCP Client] StreamableHTTP 传输创建完成');
+      logger.debug('StreamableHTTP 传输创建完成');
       return transport;
     }
 
     // SSE 传输（默认）
-    console.log('[MCP Client] 使用 SSE 传输');
-    console.log('[MCP Client] Headers:', JSON.stringify(prepareHeaders()));
-    console.log('[MCP Client] 平台检测:', Capacitor.isNativePlatform() ? '移动端（MobileSSETransport）' : 'Web 端（SSEClientTransport）');
+    logger.debug('使用 SSE 传输');
+    logger.debug('Headers:', JSON.stringify(prepareHeaders()));
+    logger.debug('平台检测:', Capacitor.isNativePlatform() ? '移动端（MobileSSETransport）' : 'Web 端（SSEClientTransport）');
     
     // 移动端：使用自定义的 MobileSSETransport（基于 CorsBypass.startSSE）
     // Web 端：使用标准的 SSEClientTransport
     if (Capacitor.isNativePlatform()) {
-      console.log('[MCP Client] 移动端：使用 MobileSSETransport（CorsBypass.startSSE）');
+      logger.debug('移动端：使用 MobileSSETransport（CorsBypass.startSSE）');
       const headers = prepareHeaders();
-      console.log('[MCP Client] 准备传递给 MobileSSETransport 的 headers:', JSON.stringify(headers));
+      logger.debug('准备传递给 MobileSSETransport 的 headers:', JSON.stringify(headers));
       
       return new MobileSSETransport(new URL(baseUrl), {
         headers,
         fetch: customFetch  // 用于发送消息（HTTP POST）
       });
     } else {
-      console.log('[MCP Client] Web 端：使用标准 SSE 配置');
+      logger.debug('Web 端：使用标准 SSE 配置');
       return new SSEClientTransport(new URL(baseUrl), {
         fetch: customFetch,
         eventSourceInit: {
@@ -162,9 +166,9 @@ export class MCPClientAdapter {
       throw new Error('客户端未初始化');
     }
 
-    console.log('[MCP Client] 列出工具');
+    logger.debug('列出工具');
     const result = await this.client.listTools();
-    console.log(`[MCP Client] 找到 ${result.tools.length} 个工具`);
+    logger.debug(`找到 ${result.tools.length} 个工具`);
     
     return result.tools as MCPTool[];
   }
@@ -177,14 +181,14 @@ export class MCPClientAdapter {
       throw new Error('客户端未初始化');
     }
 
-    console.log(`[MCP Client] 调用工具: ${name}`, arguments_);
+    logger.debug(`调用工具: ${name}`, arguments_);
     
     const result = await this.client.callTool({
       name,
       arguments: arguments_
     });
 
-    console.log(`[MCP Client] 工具调用完成: ${name}`);
+    logger.debug(`工具调用完成: ${name}`);
     
     return {
       content: (result.content || []) as Array<{
@@ -205,9 +209,9 @@ export class MCPClientAdapter {
       throw new Error('客户端未初始化');
     }
 
-    console.log('[MCP Client] 列出提示词');
+    logger.debug('列出提示词');
     const result = await this.client.listPrompts();
-    console.log(`[MCP Client] 找到 ${result.prompts?.length || 0} 个提示词`);
+    logger.debug(`找到 ${result.prompts?.length || 0} 个提示词`);
     
     return result.prompts || [];
   }
@@ -220,7 +224,7 @@ export class MCPClientAdapter {
       throw new Error('客户端未初始化');
     }
 
-    console.log(`[MCP Client] 获取提示词: ${name}`);
+    logger.debug(`获取提示词: ${name}`);
     const result = await this.client.getPrompt({
       name,
       arguments: arguments_
@@ -237,9 +241,9 @@ export class MCPClientAdapter {
       throw new Error('客户端未初始化');
     }
 
-    console.log('[MCP Client] 列出资源');
+    logger.debug('列出资源');
     const result = await this.client.listResources();
-    console.log(`[MCP Client] 找到 ${result.resources?.length || 0} 个资源`);
+    logger.debug(`找到 ${result.resources?.length || 0} 个资源`);
     
     return result.resources || [];
   }
@@ -252,7 +256,7 @@ export class MCPClientAdapter {
       throw new Error('客户端未初始化');
     }
 
-    console.log(`[MCP Client] 读取资源: ${uri}`);
+    logger.debug(`读取资源: ${uri}`);
     const result = await this.client.readResource({ uri });
     
     return result;
@@ -263,7 +267,7 @@ export class MCPClientAdapter {
    */
   async close(): Promise<void> {
     if (this.client) {
-      console.log('[MCP Client] 关闭连接');
+      logger.debug('关闭连接');
       await this.client.close();
       this.client = null;
       this.transport = null;

--- a/src/shared/services/mcp/clients/MobileSSETransport.ts
+++ b/src/shared/services/mcp/clients/MobileSSETransport.ts
@@ -7,6 +7,10 @@ import type { Transport } from '@modelcontextprotocol/sdk/shared/transport.js';
 import type { JSONRPCMessage } from '@modelcontextprotocol/sdk/types.js';
 import { CorsBypass } from 'capacitor-cors-bypass-enhanced';
 import type { PluginListenerHandle } from '@capacitor/core';
+import { createLogger } from '../../infra/logger';
+
+const logger = createLogger('Mobile SSE Transport');
+
 
 export class MobileSSETransport implements Transport {
   private url: URL;
@@ -27,12 +31,12 @@ export class MobileSSETransport implements Transport {
     this.url = url;
     this.headers = options.headers || {};
     this.fetch = options.fetch || globalThis.fetch;
-    console.log('[Mobile SSE Transport] 创建传输，URL:', url.toString());
-    console.log('[Mobile SSE Transport] Headers:', JSON.stringify(this.headers));
+    logger.debug('创建传输，URL:', url.toString());
+    logger.debug('Headers:', JSON.stringify(this.headers));
   }
 
   async start(): Promise<void> {
-    console.log('[Mobile SSE Transport] 开始连接 SSE');
+    logger.debug('开始连接 SSE');
     
     try {
       const result = await CorsBypass.startSSE({
@@ -43,38 +47,38 @@ export class MobileSSETransport implements Transport {
       });
 
       this.connectionId = result.connectionId;
-      console.log('[Mobile SSE Transport] SSE 连接建立，ID:', this.connectionId);
+      logger.debug('SSE 连接建立，ID:', this.connectionId);
 
       // 监听 SSE 事件（保存句柄用于清理）
       const openHandle = await CorsBypass.addListener('sseOpen', (data: any) => {
         if (data.connectionId === this.connectionId) {
-          console.log('[Mobile SSE Transport] SSE 连接打开');
+          logger.debug('SSE 连接打开');
         }
       });
       this.listenerHandles.push(openHandle);
 
       const messageHandle = await CorsBypass.addListener('sseMessage', (data: any) => {
         if (data.connectionId === this.connectionId) {
-          console.log('[Mobile SSE Transport] 收到 SSE 消息:', data.data);
+          logger.debug('收到 SSE 消息:', data.data);
           
           // 第一条消息通常是消息端点路径，不是 JSON-RPC 消息
           if (!this.messageEndpoint && data.data.startsWith('/')) {
             // 构建完整的消息端点 URL
             const baseOrigin = this.url.origin;
             this.messageEndpoint = `${baseOrigin}${data.data}`;
-            console.log('[Mobile SSE Transport] 设置消息端点:', this.messageEndpoint);
+            logger.debug('设置消息端点:', this.messageEndpoint);
             return;
           }
           
           try {
             const message = JSON.parse(data.data) as JSONRPCMessage;
-            console.log('[Mobile SSE Transport] 解析到 JSON-RPC 消息:', message);
+            logger.debug('解析到 JSON-RPC 消息:', message);
             if (this.onmessage) {
               this.onmessage(message);
             }
           } catch (error) {
-            console.error('[Mobile SSE Transport] 解析消息失败:', error);
-            console.error('[Mobile SSE Transport] 原始数据:', data.data);
+            logger.error('解析消息失败:', error);
+            logger.error('原始数据:', data.data);
             if (this.onerror) {
               this.onerror(error as Error);
             }
@@ -85,7 +89,7 @@ export class MobileSSETransport implements Transport {
 
       const errorHandle = await CorsBypass.addListener('sseError', (data: any) => {
         if (data.connectionId === this.connectionId) {
-          console.error('[Mobile SSE Transport] SSE 错误:', data.error);
+          logger.error('SSE 错误:', data.error);
           if (this.onerror) {
             this.onerror(new Error(data.error));
           }
@@ -95,7 +99,7 @@ export class MobileSSETransport implements Transport {
 
       const closeHandle = await CorsBypass.addListener('sseClose', (data: any) => {
         if (data.connectionId === this.connectionId) {
-          console.log('[Mobile SSE Transport] SSE 连接关闭');
+          logger.debug('SSE 连接关闭');
           if (this.onclose) {
             this.onclose();
           }
@@ -104,26 +108,26 @@ export class MobileSSETransport implements Transport {
       this.listenerHandles.push(closeHandle);
 
     } catch (error) {
-      console.error('[Mobile SSE Transport] 连接失败:', error);
+      logger.error('连接失败:', error);
       throw error;
     }
   }
 
   async close(): Promise<void> {
     // 清理所有事件监听器（防止内存泄漏）
-    console.log(`[Mobile SSE Transport] 清理 ${this.listenerHandles.length} 个事件监听器`);
+    logger.debug(`清理 ${this.listenerHandles.length} 个事件监听器`);
     for (const handle of this.listenerHandles) {
       try {
         await handle.remove();
       } catch (e) {
-        console.warn('[Mobile SSE Transport] 移除监听器失败:', e);
+        logger.warn('移除监听器失败:', e);
       }
     }
     this.listenerHandles = [];
     
     // 关闭 SSE 连接
     if (this.connectionId) {
-      console.log('[Mobile SSE Transport] 关闭 SSE 连接:', this.connectionId);
+      logger.debug('关闭 SSE 连接:', this.connectionId);
       await CorsBypass.stopSSE({ connectionId: this.connectionId });
       this.connectionId = null;
     }
@@ -134,11 +138,11 @@ export class MobileSSETransport implements Transport {
 
   async send(message: JSONRPCMessage): Promise<void> {
     // SSE 是单向的（服务器到客户端），消息发送需要通过 HTTP POST
-    console.log('[Mobile SSE Transport] 通过 HTTP POST 发送消息:', JSON.stringify(message));
+    logger.debug('通过 HTTP POST 发送消息:', JSON.stringify(message));
     
     // 等待消息端点设置（通常在第一条 SSE 消息中返回）
     if (!this.messageEndpoint) {
-      console.warn('[Mobile SSE Transport] 消息端点尚未设置，等待...');
+      logger.warn('消息端点尚未设置，等待...');
       // 等待最多 5 秒
       for (let i = 0; i < 50; i++) {
         if (this.messageEndpoint) break;
@@ -149,7 +153,7 @@ export class MobileSSETransport implements Transport {
       }
     }
     
-    console.log('[Mobile SSE Transport] 发送到端点:', this.messageEndpoint);
+    logger.debug('发送到端点:', this.messageEndpoint);
     
     try {
       const response = await this.fetch(this.messageEndpoint, {
@@ -165,9 +169,9 @@ export class MobileSSETransport implements Transport {
         throw new Error(`HTTP ${response.status}: ${response.statusText}`);
       }
 
-      console.log('[Mobile SSE Transport] 消息发送成功');
+      logger.debug('消息发送成功');
     } catch (error) {
-      console.error('[Mobile SSE Transport] 发送消息失败:', error);
+      logger.error('发送消息失败:', error);
       throw error;
     }
   }

--- a/src/shared/services/mcp/clients/StdioMCPClient.ts
+++ b/src/shared/services/mcp/clients/StdioMCPClient.ts
@@ -15,6 +15,11 @@ import type { Transport } from '@modelcontextprotocol/sdk/shared/transport.js';
 import type { JSONRPCMessage } from '@modelcontextprotocol/sdk/types.js';
 import type { MCPClientOptions, MCPTool, MCPCallToolResponse } from './MCPClientAdapter';
 import { isTauri, isDesktop, isWindows } from '../../../utils/platformDetection';
+import { createLogger } from '../../infra/logger';
+
+const logger = createLogger('Stdio MCP Client');
+const transportLogger = createLogger('Stdio Transport');
+
 
 // Tauri Shell 类型定义
 interface TauriChild {
@@ -81,11 +86,11 @@ class StdioTransport implements Transport {
     this.args = args;
     this.env = env;
     this.cwd = cwd;
-    console.log(`[Stdio Transport] 创建传输，命令: ${command} ${args.join(' ')}${cwd ? `, 工作目录: ${cwd}` : ''}`);
+    transportLogger.debug(`创建传输，命令: ${command} ${args.join(' ')}${cwd ? `, 工作目录: ${cwd}` : ''}`);
   }
 
   async start(): Promise<void> {
-    console.log('[Stdio Transport] 启动子进程...');
+    transportLogger.debug('启动子进程...');
 
     try {
       // 动态导入 Tauri Shell API
@@ -93,7 +98,7 @@ class StdioTransport implements Transport {
 
       // 将命令映射到 Tauri scope 中定义的名称
       const { scopeName, finalArgs } = mapCommandToScopeName(this.command, this.args);
-      console.log(`[Stdio Transport] 使用 scope 命令: ${scopeName}, 参数: ${finalArgs.join(' ')}`);
+      transportLogger.debug(`使用 scope 命令: ${scopeName}, 参数: ${finalArgs.join(' ')}`);
 
       // 创建命令 - 使用 scope 名称
       const spawnOptions: Record<string, any> = {
@@ -106,7 +111,7 @@ class StdioTransport implements Transport {
 
       // 监听 close 事件
       cmd.on('close', (data) => {
-        console.log(`[Stdio Transport] 子进程退出，代码: ${data.code}`);
+        transportLogger.debug(`子进程退出，代码: ${data.code}`);
         this.isRunning = false;
         this.child = null;
         if (this.onProcessExit) {
@@ -119,7 +124,7 @@ class StdioTransport implements Transport {
 
       // 监听 error 事件
       cmd.on('error', (error) => {
-        console.error('[Stdio Transport] 子进程错误:', error);
+        transportLogger.error('子进程错误:', error);
         if (this.onerror) {
           this.onerror(new Error(error));
         }
@@ -132,7 +137,7 @@ class StdioTransport implements Transport {
 
       // 监听 stderr - 显示 npx 下载进度等信息
       cmd.stderr.on('data', (line: string) => {
-        console.log('[Stdio Transport] stderr:', line);
+        transportLogger.debug('stderr:', line);
         // npx 下载进度通常输出到 stderr，这是正常的
       });
 
@@ -140,10 +145,10 @@ class StdioTransport implements Transport {
       this.child = await cmd.spawn();
       this.isRunning = true;
 
-      console.log(`[Stdio Transport] 子进程已启动, PID: ${this.child.pid}`);
+      transportLogger.debug(`子进程已启动, PID: ${this.child.pid}`);
 
     } catch (error) {
-      console.error('[Stdio Transport] 启动失败:', error);
+      transportLogger.error('启动失败:', error);
       throw error;
     }
   }
@@ -162,12 +167,12 @@ class StdioTransport implements Transport {
 
       try {
         const message = JSON.parse(trimmed) as JSONRPCMessage;
-        console.log('[Stdio Transport] 收到消息:', message);
+        transportLogger.debug('收到消息:', message);
         if (this.onmessage) {
           this.onmessage(message);
         }
       } catch (parseError) {
-        console.warn('[Stdio Transport] 无法解析行:', trimmed);
+        transportLogger.warn('无法解析行:', trimmed);
       }
     }
   }
@@ -183,21 +188,21 @@ class StdioTransport implements Transport {
     }
 
     const json = JSON.stringify(message) + '\n';
-    console.log('[Stdio Transport] 发送消息:', message);
+    transportLogger.debug('发送消息:', message);
     
     // Tauri 2.0 的 write 方法接受 string 或 number[]
     await this.child.write(json);
   }
 
   async close(): Promise<void> {
-    console.log('[Stdio Transport] 关闭连接');
+    transportLogger.debug('关闭连接');
     this.isRunning = false;
 
     if (this.child) {
       try {
         await this.child.kill();
       } catch (e) {
-        console.warn('[Stdio Transport] 终止子进程失败:', e);
+        transportLogger.warn('终止子进程失败:', e);
       }
       this.child = null;
     }
@@ -232,9 +237,9 @@ export class StdioMCPClient {
       throw new Error('Stdio 传输仅在 Tauri 桌面端可用');
     }
 
-    console.log(`[Stdio MCP Client] 创建客户端`);
-    console.log(`[Stdio MCP Client] 命令: ${options.command}`);
-    console.log(`[Stdio MCP Client] 参数: ${options.args?.join(' ') || ''}`);
+    logger.debug(`创建客户端`);
+    logger.debug(`命令: ${options.command}`);
+    logger.debug(`参数: ${options.args?.join(' ') || ''}`);
   }
 
   /**
@@ -255,7 +260,7 @@ export class StdioMCPClient {
    * 初始化连接
    */
   async initialize(): Promise<void> {
-    console.log('[Stdio MCP Client] 开始初始化连接');
+    logger.debug('开始初始化连接');
 
     try {
       // 创建客户端
@@ -274,7 +279,7 @@ export class StdioMCPClient {
         }
       );
 
-      console.log('[Stdio MCP Client] 客户端创建完成');
+      logger.debug('客户端创建完成');
 
       // 创建 stdio 传输
       this.transport = new StdioTransport(
@@ -286,7 +291,7 @@ export class StdioMCPClient {
 
       // 监听子进程退出事件，通知上层清理
       this.transport.onProcessExit = (code) => {
-        console.log(`[Stdio MCP Client] 子进程退出，code: ${code}`);
+        logger.debug(`子进程退出，code: ${code}`);
         if (this.onProcessExit) {
           this.onProcessExit(code);
         }
@@ -295,9 +300,9 @@ export class StdioMCPClient {
       // 连接
       await this.client.connect(this.transport);
 
-      console.log('[Stdio MCP Client] 连接成功');
+      logger.debug('连接成功');
     } catch (error) {
-      console.error('[Stdio MCP Client] 初始化失败:', error);
+      logger.error('初始化失败:', error);
       throw error;
     }
   }
@@ -310,9 +315,9 @@ export class StdioMCPClient {
       throw new Error('客户端未初始化');
     }
 
-    console.log('[Stdio MCP Client] 列出工具');
+    logger.debug('列出工具');
     const result = await this.client.listTools();
-    console.log(`[Stdio MCP Client] 找到 ${result.tools.length} 个工具`);
+    logger.debug(`找到 ${result.tools.length} 个工具`);
 
     return result.tools as MCPTool[];
   }
@@ -325,14 +330,14 @@ export class StdioMCPClient {
       throw new Error('客户端未初始化');
     }
 
-    console.log(`[Stdio MCP Client] 调用工具: ${name}`, arguments_);
+    logger.debug(`调用工具: ${name}`, arguments_);
 
     const result = await this.client.callTool({
       name,
       arguments: arguments_
     });
 
-    console.log(`[Stdio MCP Client] 工具调用完成: ${name}`);
+    logger.debug(`工具调用完成: ${name}`);
 
     return {
       content: (result.content || []) as Array<{
@@ -353,9 +358,9 @@ export class StdioMCPClient {
       throw new Error('客户端未初始化');
     }
 
-    console.log('[Stdio MCP Client] 列出提示词');
+    logger.debug('列出提示词');
     const result = await this.client.listPrompts();
-    console.log(`[Stdio MCP Client] 找到 ${result.prompts?.length || 0} 个提示词`);
+    logger.debug(`找到 ${result.prompts?.length || 0} 个提示词`);
 
     return result.prompts || [];
   }
@@ -368,7 +373,7 @@ export class StdioMCPClient {
       throw new Error('客户端未初始化');
     }
 
-    console.log(`[Stdio MCP Client] 获取提示词: ${name}`);
+    logger.debug(`获取提示词: ${name}`);
     const result = await this.client.getPrompt({
       name,
       arguments: arguments_
@@ -385,9 +390,9 @@ export class StdioMCPClient {
       throw new Error('客户端未初始化');
     }
 
-    console.log('[Stdio MCP Client] 列出资源');
+    logger.debug('列出资源');
     const result = await this.client.listResources();
-    console.log(`[Stdio MCP Client] 找到 ${result.resources?.length || 0} 个资源`);
+    logger.debug(`找到 ${result.resources?.length || 0} 个资源`);
 
     return result.resources || [];
   }
@@ -400,7 +405,7 @@ export class StdioMCPClient {
       throw new Error('客户端未初始化');
     }
 
-    console.log(`[Stdio MCP Client] 读取资源: ${uri}`);
+    logger.debug(`读取资源: ${uri}`);
     const result = await this.client.readResource({ uri });
 
     return result;
@@ -411,7 +416,7 @@ export class StdioMCPClient {
    */
   async close(): Promise<void> {
     if (this.client) {
-      console.log('[Stdio MCP Client] 关闭连接');
+      logger.debug('关闭连接');
       await this.client.close();
       this.client = null;
       this.transport = null;

--- a/src/shared/services/mcp/confirmation/ToolConfirmationService.ts
+++ b/src/shared/services/mcp/confirmation/ToolConfirmationService.ts
@@ -19,6 +19,10 @@ import type {
   ToolConfirmationRequest,
   ConfirmableToolEntry
 } from './types';
+import { createLogger } from '../../infra/logger';
+
+const logger = createLogger('ToolConfirmation');
+
 
 /** 确认系统事件名 */
 export const CONFIRMATION_EVENTS = {
@@ -70,7 +74,7 @@ export class ToolConfirmationService {
     summaryBuilder?: (args: Record<string, unknown>) => string
   ): void {
     this.registry.set(toolName, { toolName, risk, summaryBuilder });
-    console.log(`[ToolConfirmation] 已注册需确认工具: ${toolName} (${risk})`);
+    logger.debug(`已注册需确认工具: ${toolName} (${risk})`);
   }
 
   /**
@@ -133,7 +137,7 @@ export class ToolConfirmationService {
       // 超时自动拒绝
       const timer = setTimeout(() => {
         if (this.pending.has(request.id)) {
-          console.warn(`[ToolConfirmation] 确认请求超时，自动拒绝: ${toolName}`);
+          logger.warn(`确认请求超时，自动拒绝: ${toolName}`);
           this.pending.delete(request.id);
           EventEmitter.emit(CONFIRMATION_EVENTS.EXPIRED, { requestId: request.id });
           resolve(false);
@@ -143,7 +147,7 @@ export class ToolConfirmationService {
       this.pending.set(request.id, { request, resolve, timer });
 
       // 通知 UI 层
-      console.log(`[ToolConfirmation] 等待用户确认: ${toolName}`, request);
+      logger.debug(`等待用户确认: ${toolName}`, request);
       EventEmitter.emit(CONFIRMATION_EVENTS.REQUIRED, request);
     });
   }
@@ -154,14 +158,14 @@ export class ToolConfirmationService {
   respond(requestId: string, approved: boolean): void {
     const pending = this.pending.get(requestId);
     if (!pending) {
-      console.warn(`[ToolConfirmation] 未找到待处理的确认请求: ${requestId}`);
+      logger.warn(`未找到待处理的确认请求: ${requestId}`);
       return;
     }
 
     clearTimeout(pending.timer);
     this.pending.delete(requestId);
 
-    console.log(`[ToolConfirmation] 用户${approved ? '批准' : '拒绝'}了操作: ${pending.request.toolName}`);
+    logger.debug(`用户${approved ? '批准' : '拒绝'}了操作: ${pending.request.toolName}`);
     pending.resolve(approved);
   }
 

--- a/src/shared/services/mcp/core/MCPConnectionManager.ts
+++ b/src/shared/services/mcp/core/MCPConnectionManager.ts
@@ -17,6 +17,9 @@ import {
   isCorsError
 } from '../types/MCPError';
 import { MCP_CLIENT_INFO } from '../types/constants';
+import { createLogger } from '../../infra/logger';
+
+const logger = createLogger('MCP');
 
 /**
  * 根据 URL 推断 MCP 服务器类型
@@ -30,12 +33,12 @@ function getMcpServerType(url: string): 'streamableHttp' | 'sse' {
  */
 function normalizeServerType(server: MCPServer): MCPServer['type'] {
   if (server.type === 'httpStream') {
-    console.log(`[MCP] 检测到废弃的 httpStream 类型，自动转换为 sse: ${server.name}`);
+    logger.debug(`检测到废弃的 httpStream 类型，自动转换为 sse: ${server.name}`);
     return 'sse';
   }
   if (!server.type && server.baseUrl) {
     const inferredType = getMcpServerType(server.baseUrl);
-    console.log(`[MCP] 根据 URL 推断类型: ${server.name} -> ${inferredType}`);
+    logger.debug(`根据 URL 推断类型: ${server.name} -> ${inferredType}`);
     return inferredType;
   }
   return server.type;
@@ -71,19 +74,19 @@ export class MCPConnectionManager {
 
     const pendingClient = this.pendingClients.get(serverKey);
     if (pendingClient) {
-      console.log(`[MCP] 等待正在初始化的连接: ${server.name}`);
+      logger.debug(`等待正在初始化的连接: ${server.name}`);
       return pendingClient;
     }
 
     const existingClient = this.clients.get(serverKey);
     if (existingClient) {
       try {
-        console.log(`[MCP] 检查现有连接健康状态: ${server.name}`);
+        logger.debug(`检查现有连接健康状态: ${server.name}`);
         await existingClient.ping();
-        console.log(`[MCP] 复用现有连接: ${server.name}`);
+        logger.debug(`复用现有连接: ${server.name}`);
         return existingClient;
       } catch (error) {
-        console.warn(`[MCP] 现有连接已失效，重新创建: ${server.name}`, error);
+        logger.warn(`现有连接已失效，重新创建: ${server.name}`, error);
         this.clients.delete(serverKey);
       }
     }
@@ -97,7 +100,7 @@ export class MCPConnectionManager {
         let transport;
 
         if (server.type === 'inMemory') {
-          console.log(`[MCP] 创建内存传输: ${server.name}`);
+          logger.debug(`创建内存传输: ${server.name}`);
           const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
           const inMemoryServer = createInMemoryMCPServer(server.name, server.args || [], server.env || {});
           await inMemoryServer.connect(serverTransport);
@@ -111,11 +114,11 @@ export class MCPConnectionManager {
             throw new Error('stdio 服务器需要提供 command（要执行的命令）');
           }
 
-          console.log(`[MCP] 创建 stdio 传输: ${server.command} ${(server.args || []).join(' ')}`);
+          logger.debug(`创建 stdio 传输: ${server.command} ${(server.args || []).join(' ')}`);
           const stdioClient = await this.initStdioClient(server);
 
           stdioClient.onProcessExit = (code) => {
-            console.log(`[MCP] stdio 子进程退出 (${server.name})，code: ${code}，清理缓存`);
+            logger.debug(`stdio 子进程退出 (${server.name})，code: ${code}，清理缓存`);
             this.clients.delete(serverKey);
             this.stdioClients.delete(serverKey);
           };
@@ -146,7 +149,7 @@ export class MCPConnectionManager {
           } satisfies IMCPClient;
 
           this.clients.set(serverKey, compatClient);
-          console.log(`[MCP] 成功连接到 stdio 服务器: ${server.name}`);
+          logger.debug(`成功连接到 stdio 服务器: ${server.name}`);
           return compatClient;
 
         } else if (server.type === 'sse' || server.type === 'streamableHttp' || server.type === 'httpStream') {
@@ -155,7 +158,7 @@ export class MCPConnectionManager {
             throw new Error(`${normalizedType} 服务器需要提供 baseUrl`);
           }
 
-          console.log(`[MCP] 创建 ${normalizedType} 传输: ${server.baseUrl}`);
+          logger.debug(`创建 ${normalizedType} 传输: ${server.baseUrl}`);
           const httpStreamClient = await this.initMcpClientAdapter({ ...server, type: normalizedType });
 
           const compatClient = {
@@ -190,7 +193,7 @@ export class MCPConnectionManager {
           } satisfies IMCPClient;
 
           this.clients.set(serverKey, compatClient);
-          console.log(`[MCP] 成功连接到 HTTP Stream 服务器: ${server.name}`);
+          logger.debug(`成功连接到 HTTP Stream 服务器: ${server.name}`);
           return compatClient;
         } else {
           throw new Error(`不支持的服务器类型: ${server.type}`);
@@ -199,17 +202,17 @@ export class MCPConnectionManager {
         if (server.type === 'inMemory') {
           await client.connect(transport);
           this.clients.set(serverKey, client);
-          console.log(`[MCP] 成功连接到服务器: ${server.name}`);
+          logger.debug(`成功连接到服务器: ${server.name}`);
           return client;
         }
 
         throw new Error(`未处理的服务器类型: ${server.type}`);
       } catch (error) {
-        console.error(`[MCP] 连接服务器失败: ${server.name}`, error);
+        logger.error(`连接服务器失败: ${server.name}`, error);
 
         if (error instanceof Error) {
           if (Capacitor.isNativePlatform() && isCorsError(error)) {
-            console.log(`[MCP] 移动端CORS错误，这通常表示服务器配置问题或网络问题`);
+            logger.debug(`移动端CORS错误，这通常表示服务器配置问题或网络问题`);
             throw new MCPCorsError(
               `连接MCP服务器失败: ${server.name} - 网络连接问题或服务器不可用`,
               { serverName: server.name, cause: error }
@@ -234,13 +237,13 @@ export class MCPConnectionManager {
 
     const existingClient = this.mcpClientAdapters.get(serverKey);
     if (existingClient) {
-      console.log(`[MCP] 复用现有 MCP 客户端: ${server.name}`);
+      logger.debug(`复用现有 MCP 客户端: ${server.name}`);
       return existingClient;
     }
 
     const pendingClient = this.pendingMcpClientAdapters.get(serverKey);
     if (pendingClient) {
-      console.log(`[MCP] 等待正在初始化的 MCP 客户端: ${server.name}`);
+      logger.debug(`等待正在初始化的 MCP 客户端: ${server.name}`);
       return pendingClient;
     }
 
@@ -250,9 +253,9 @@ export class MCPConnectionManager {
         const transportType = normalizedType === 'streamableHttp' ? 'streamableHttp' : 'sse';
 
         const isMobile = Capacitor.isNativePlatform();
-        console.log(`[MCP] 创建 MCP 客户端，传输类型: ${transportType}，平台: ${isMobile ? '移动端' : 'Web端'}`);
+        logger.debug(`创建 MCP 客户端，传输类型: ${transportType}，平台: ${isMobile ? '移动端' : 'Web端'}`);
 
-        console.log(`[MCP] ${isMobile ? '移动端' : 'Web端'} 使用 MCPClientAdapter`);
+        logger.debug(`${isMobile ? '移动端' : 'Web端'} 使用 MCPClientAdapter`);
 
         let finalHeaders = server.headers || {};
         if (isMobile && finalHeaders) {
@@ -264,7 +267,7 @@ export class MCPConnectionManager {
             }
           }
           finalHeaders = filteredHeaders;
-          console.log(`[MCP] 移动端过滤 headers，移除 origin/referer`);
+          logger.debug(`移动端过滤 headers，移除 origin/referer`);
         }
 
         const client = new MCPClientAdapter({
@@ -277,11 +280,11 @@ export class MCPConnectionManager {
         await client.initialize();
 
         this.mcpClientAdapters.set(serverKey, client);
-        console.log(`[MCP] MCP 客户端初始化成功: ${server.name}`);
+        logger.debug(`MCP 客户端初始化成功: ${server.name}`);
 
         return client;
       } catch (error) {
-        console.error(`[MCP] MCP 客户端初始化失败: ${server.name}`, error);
+        logger.error(`MCP 客户端初始化失败: ${server.name}`, error);
         throw error;
       } finally {
         this.pendingMcpClientAdapters.delete(serverKey);
@@ -300,22 +303,22 @@ export class MCPConnectionManager {
     const existingClient = this.stdioClients.get(serverKey);
     if (existingClient) {
       if (existingClient.isAlive()) {
-        console.log(`[MCP] 复用现有 Stdio 客户端: ${server.name}`);
+        logger.debug(`复用现有 Stdio 客户端: ${server.name}`);
         return existingClient;
       }
-      console.warn(`[MCP] Stdio 客户端已失效，重新创建: ${server.name}`);
+      logger.warn(`Stdio 客户端已失效，重新创建: ${server.name}`);
       this.stdioClients.delete(serverKey);
     }
 
     const pendingClient = this.pendingStdioClients.get(serverKey);
     if (pendingClient) {
-      console.log(`[MCP] 等待正在初始化的 Stdio 客户端: ${server.name}`);
+      logger.debug(`等待正在初始化的 Stdio 客户端: ${server.name}`);
       return pendingClient;
     }
 
     const initPromise = (async (): Promise<StdioMCPClient> => {
       try {
-        console.log(`[MCP] 创建 Stdio 客户端: ${server.command} ${(server.args || []).join(' ')}`);
+        logger.debug(`创建 Stdio 客户端: ${server.command} ${(server.args || []).join(' ')}`);
 
         const client = new StdioMCPClient({
           command: server.command!,
@@ -328,11 +331,11 @@ export class MCPConnectionManager {
         await client.initialize();
 
         this.stdioClients.set(serverKey, client);
-        console.log(`[MCP] Stdio 客户端初始化成功: ${server.name}`);
+        logger.debug(`Stdio 客户端初始化成功: ${server.name}`);
 
         return client;
       } catch (error) {
-        console.error(`[MCP] Stdio 客户端初始化失败: ${server.name}`, error);
+        logger.error(`Stdio 客户端初始化失败: ${server.name}`, error);
         throw error;
       } finally {
         this.pendingStdioClients.delete(serverKey);
@@ -350,9 +353,9 @@ export class MCPConnectionManager {
     if (client) {
       try {
         await client.close();
-        console.log(`[MCP] 已关闭连接: ${serverKey}`);
+        logger.debug(`已关闭连接: ${serverKey}`);
       } catch (error) {
-        console.error(`[MCP] 关闭客户端连接失败:`, error);
+        logger.error(`关闭客户端连接失败:`, error);
       }
       this.clients.delete(serverKey);
     }
@@ -361,9 +364,9 @@ export class MCPConnectionManager {
     if (mcpClientAdapter) {
       try {
         await mcpClientAdapter.close();
-        console.log(`[MCP] 已关闭 MCP 客户端: ${serverKey}`);
+        logger.debug(`已关闭 MCP 客户端: ${serverKey}`);
       } catch (error) {
-        console.error(`[MCP] 关闭 MCP 客户端连接失败:`, error);
+        logger.error(`关闭 MCP 客户端连接失败:`, error);
       }
       this.mcpClientAdapters.delete(serverKey);
     }
@@ -372,9 +375,9 @@ export class MCPConnectionManager {
     if (stdioClient) {
       try {
         await stdioClient.close();
-        console.log(`[MCP] 已关闭 Stdio 客户端: ${serverKey}`);
+        logger.debug(`已关闭 Stdio 客户端: ${serverKey}`);
       } catch (error) {
-        console.error(`[MCP] 关闭 Stdio 客户端连接失败:`, error);
+        logger.error(`关闭 Stdio 客户端连接失败:`, error);
       }
       this.stdioClients.delete(serverKey);
     }
@@ -393,13 +396,13 @@ export class MCPConnectionManager {
 
   async testConnection(server: MCPServer): Promise<boolean> {
     try {
-      console.log(`[MCP] 测试连接到服务器: ${server.name}`);
+      logger.debug(`测试连接到服务器: ${server.name}`);
       const client = await this.initClient(server);
       await client.listTools();
-      console.log(`[MCP] 连接测试成功: ${server.name}`);
+      logger.debug(`连接测试成功: ${server.name}`);
       return true;
     } catch (error) {
-      console.error(`[MCP] 连接测试失败: ${server.name}`, error);
+      logger.error(`连接测试失败: ${server.name}`, error);
       const serverKey = this.getServerKey(server);
       await this.closeClient(serverKey);
       return false;
@@ -416,7 +419,7 @@ export class MCPConnectionManager {
       await client.ping();
       return true;
     } catch (error) {
-      console.warn(`[MCP] 连接健康检查失败: ${server.name}`, error);
+      logger.warn(`连接健康检查失败: ${server.name}`, error);
       this.clients.delete(serverKey);
       return false;
     }
@@ -449,6 +452,6 @@ export class MCPConnectionManager {
     const promises = Array.from(this.clients.keys()).map(key => this.closeClient(key));
     await Promise.all(promises);
     this.pendingClients.clear();
-    console.log('[MCP] 所有连接已清理');
+    logger.debug('所有连接已清理');
   }
 }

--- a/src/shared/services/mcp/core/MCPServerFactory.ts
+++ b/src/shared/services/mcp/core/MCPServerFactory.ts
@@ -11,13 +11,17 @@ import { DexEditorServer } from '../servers/DexEditorServer';
 import { SearXNGServer } from '../servers/SearXNGServer';
 import { AiSearchServer } from '../servers/AiSearchServer';
 import { SettingsServer } from '../servers/settings/SettingsServer';
+import { createLogger } from '../../infra/logger';
+
+const logger = createLogger('MCP');
+
 
 /**
  * 创建内存 MCP 服务器
  * 工厂函数用于创建内置的 MCP 服务器实例
  */
 export function createInMemoryMCPServer(name: string, args: string[] = [], envs: Record<string, string> = {}): Server {
-  console.log(`[MCP] 创建内存 MCP 服务器: ${name}，参数: ${args}，环境变量: ${JSON.stringify(envs)}`);
+  logger.debug(`创建内存 MCP 服务器: ${name}，参数: ${args}，环境变量: ${JSON.stringify(envs)}`);
 
   switch (name) {
     case '@aether/time': {

--- a/src/shared/services/mcp/core/MCPServerStore.ts
+++ b/src/shared/services/mcp/core/MCPServerStore.ts
@@ -5,6 +5,10 @@
 import type { MCPServer } from '../../../types';
 import { getStorageItem, setStorageItem } from '../../../utils/storage';
 import { getBuiltinMCPServers, isBuiltinServer } from '../../../config/builtinMCPServers';
+import { createLogger } from '../../infra/logger';
+
+const logger = createLogger('MCP');
+
 
 export class MCPServerStore {
   private servers: MCPServer[] = [];
@@ -30,10 +34,10 @@ export class MCPServerStore {
       const saved = await getStorageItem<MCPServer[]>('mcp_servers');
       if (saved) {
         this.servers = saved;
-        console.log(`[MCP] 成功加载 ${saved.length} 个服务器配置`);
+        logger.debug(`成功加载 ${saved.length} 个服务器配置`);
       }
     } catch (error) {
-      console.error('[MCP] 加载服务器配置失败:', error);
+      logger.error('加载服务器配置失败:', error);
     } finally {
       this.isLoaded = true;
       this.loadingPromise = null;
@@ -44,7 +48,7 @@ export class MCPServerStore {
     try {
       await setStorageItem('mcp_servers', this.servers);
     } catch (error) {
-      console.error('[MCP] 保存服务器配置失败:', error);
+      logger.error('保存服务器配置失败:', error);
     }
   }
 
@@ -91,7 +95,7 @@ export class MCPServerStore {
   async addServer(server: MCPServer): Promise<void> {
     await this.ensureLoaded();
     this.servers.push(server);
-    console.log(`[MCP] 添加服务器: ${server.name}, type=${server.type}, command=${server.command || 'N/A'}`);
+    logger.debug(`添加服务器: ${server.name}, type=${server.type}, command=${server.command || 'N/A'}`);
     await this.saveServers();
   }
 
@@ -99,11 +103,11 @@ export class MCPServerStore {
     await this.ensureLoaded();
     const idx = this.servers.findIndex(s => s.id === updatedServer.id);
     if (idx !== -1) {
-      console.log(`[MCP] 更新服务器: ${updatedServer.name}, type=${updatedServer.type}, command=${updatedServer.command || 'N/A'}`);
+      logger.debug(`更新服务器: ${updatedServer.name}, type=${updatedServer.type}, command=${updatedServer.command || 'N/A'}`);
       this.servers[idx] = updatedServer;
       await this.saveServers();
     } else {
-      console.warn(`[MCP] 未找到要更新的服务器: ${updatedServer.id}`);
+      logger.warn(`未找到要更新的服务器: ${updatedServer.id}`);
     }
   }
 
@@ -139,7 +143,7 @@ export class MCPServerStore {
     for (const s of this.servers.filter(s => s.isActive)) {
       this.savedActiveServerIds.add(s.id);
     }
-    console.log(`[MCP] 已保存 ${this.savedActiveServerIds.size} 个活跃服务器的状态`);
+    logger.debug(`已保存 ${this.savedActiveServerIds.size} 个活跃服务器的状态`);
   }
 
   getSavedActiveServerIds(): string[] {

--- a/src/shared/services/mcp/core/MCPService.ts
+++ b/src/shared/services/mcp/core/MCPService.ts
@@ -11,6 +11,10 @@ import { MCPServerStore } from './MCPServerStore';
 import { MCPConnectionManager } from './MCPConnectionManager';
 import { MCPToolExecutor } from './MCPToolExecutor';
 import { AGENTIC_MODE_SERVER } from '../types/constants';
+import { createLogger } from '../../infra/logger';
+
+const logger = createLogger('MCP');
+
 
 export class MCPService {
   private static instance: MCPService;
@@ -100,9 +104,9 @@ export class MCPService {
     if (isActive) {
       try {
         await this.connectionManager.initClient(server);
-        console.log(`[MCP] 服务器已启动: ${server.name}`);
+        logger.debug(`服务器已启动: ${server.name}`);
       } catch (error) {
-        console.error(`[MCP] 启动服务器失败: ${server.name}`, error);
+        logger.error(`启动服务器失败: ${server.name}`, error);
         await this.serverStore.setServerActive(serverId, false);
         throw error;
       }
@@ -114,14 +118,14 @@ export class MCPService {
     if (server) {
       const serverKey = this.connectionManager.getServerKey(server);
       await this.connectionManager.closeClient(serverKey);
-      console.log(`[MCP] 服务器已停止: ${server.name}`);
+      logger.debug(`服务器已停止: ${server.name}`);
     }
   }
 
   public async restartServer(serverId: string): Promise<void> {
     const server = this.serverStore.getServerById(serverId);
     if (server) {
-      console.log(`[MCP] 重启服务器: ${server.name}`);
+      logger.debug(`重启服务器: ${server.name}`);
       const serverKey = this.connectionManager.getServerKey(server);
       await this.connectionManager.closeClient(serverKey);
 
@@ -133,46 +137,46 @@ export class MCPService {
 
   public async stopAllActiveServers(): Promise<void> {
     const activeServers = this.serverStore.getActiveServers();
-    console.log(`[MCP] 正在关闭 ${activeServers.length} 个活跃服务器`);
+    logger.debug(`正在关闭 ${activeServers.length} 个活跃服务器`);
 
     this.serverStore.saveActiveServerIds();
 
     const promises = activeServers.map(async (server) => {
       try {
         await this.toggleServer(server.id, false);
-        console.log(`[MCP] 已关闭服务器: ${server.name}`);
+        logger.debug(`已关闭服务器: ${server.name}`);
       } catch (error) {
-        console.error(`[MCP] 关闭服务器失败: ${server.name}`, error);
+        logger.error(`关闭服务器失败: ${server.name}`, error);
       }
     });
 
     await Promise.all(promises);
-    console.log('[MCP] 所有活跃服务器已关闭');
+    logger.debug('所有活跃服务器已关闭');
   }
 
   public async restoreSavedActiveServers(): Promise<void> {
     if (!this.serverStore.hasSavedActiveServers()) {
-      console.log('[MCP] 没有保存的活跃服务器状态需要恢复');
+      logger.debug('没有保存的活跃服务器状态需要恢复');
       return;
     }
 
     const ids = this.serverStore.getSavedActiveServerIds();
-    console.log(`[MCP] 正在恢复 ${ids.length} 个服务器的活跃状态`);
+    logger.debug(`正在恢复 ${ids.length} 个服务器的活跃状态`);
 
     const promises = ids.map(async (serverId) => {
       try {
         const server = this.serverStore.getServerById(serverId);
         if (server) {
           await this.toggleServer(serverId, true);
-          console.log(`[MCP] 已恢复服务器: ${server.name}`);
+          logger.debug(`已恢复服务器: ${server.name}`);
         }
       } catch (error) {
-        console.error(`[MCP] 恢复服务器失败: ${serverId}`, error);
+        logger.error(`恢复服务器失败: ${serverId}`, error);
       }
     });
 
     await Promise.all(promises);
-    console.log('[MCP] 所有保存的活跃服务器状态已恢复');
+    logger.debug('所有保存的活跃服务器状态已恢复');
 
     this.serverStore.clearSavedActiveServerIds();
   }
@@ -207,9 +211,9 @@ export class MCPService {
       };
 
       await this.serverStore.addServer(serverConfig);
-      console.log(`[MCP] 成功添加内置服务器: ${serverName}`);
+      logger.debug(`成功添加内置服务器: ${serverName}`);
     } catch (error) {
-      console.error(`[MCP] 添加内置服务器失败: ${serverName}`, error);
+      logger.error(`添加内置服务器失败: ${serverName}`, error);
       throw error;
     }
   }

--- a/src/shared/services/mcp/core/MCPToolExecutor.ts
+++ b/src/shared/services/mcp/core/MCPToolExecutor.ts
@@ -8,6 +8,11 @@ import { handleMemoryToolCall } from '../../memory/memoryToolHandler';
 import { ToolConfirmationService } from '../confirmation/ToolConfirmationService';
 import type { MCPConnectionManager } from './MCPConnectionManager';
 import type { MCPServerStore } from './MCPServerStore';
+import { createLogger } from '../../infra/logger';
+
+const logger = createLogger('MCP');
+const memoryLogger = createLogger('Memory');
+
 
 /**
  * 构建函数调用工具名称
@@ -50,13 +55,13 @@ export class MCPToolExecutor {
 
   async listTools(server: MCPServer, options?: { includeDisabled?: boolean }): Promise<MCPTool[]> {
     try {
-      console.log(`[MCP] 获取服务器工具: ${server.name}`);
+      logger.debug(`获取服务器工具: ${server.name}`);
 
       const client = await this.connectionManager.initClient(server);
-      console.log(`[MCP] 客户端已连接，正在调用 listTools...`);
+      logger.debug(`客户端已连接，正在调用 listTools...`);
 
       const result = await client.listTools();
-      console.log(`[MCP] listTools 响应:`, result);
+      logger.debug(`listTools 响应:`, result);
 
       const allTools = result.tools.map(tool => ({
         name: tool.name,
@@ -73,12 +78,12 @@ export class MCPToolExecutor {
         : allTools;
 
       if (disabledTools.length > 0) {
-        console.log(`[MCP] 服务器 ${server.name} 过滤了 ${allTools.length - tools.length} 个禁用工具`);
+        logger.debug(`服务器 ${server.name} 过滤了 ${allTools.length - tools.length} 个禁用工具`);
       }
-      console.log(`[MCP] 服务器 ${server.name} 返回 ${tools.length} 个工具:`, tools.map(t => t.name));
+      logger.debug(`服务器 ${server.name} 返回 ${tools.length} 个工具:`, tools.map(t => t.name));
       return tools;
     } catch (error) {
-      console.error(`[MCP] 获取工具列表失败:`, error);
+      logger.error(`获取工具列表失败:`, error);
       return [];
     }
   }
@@ -88,25 +93,25 @@ export class MCPToolExecutor {
     const activeServers = await this.serverStore.getActiveServersAsync();
     const allTools: MCPTool[] = [];
 
-    console.log(`[MCP] 总服务器数量: ${allServers.length}, 活跃服务器数量: ${activeServers.length}`);
+    logger.debug(`总服务器数量: ${allServers.length}, 活跃服务器数量: ${activeServers.length}`);
 
     if (allServers.length > 0) {
-      console.log(`[MCP] 所有服务器:`, allServers.map(s => `${s.name}(${s.isActive ? '活跃' : '非活跃'})`).join(', '));
+      logger.debug(`所有服务器:`, allServers.map(s => `${s.name}(${s.isActive ? '活跃' : '非活跃'})`).join(', '));
     }
 
     if (activeServers.length === 0) {
-      console.log(`[MCP] 没有活跃的 MCP 服务器`);
+      logger.debug(`没有活跃的 MCP 服务器`);
       return allTools;
     }
 
     for (const server of activeServers) {
       try {
-        console.log(`[MCP] 正在获取服务器 ${server.name} 的工具...`);
+        logger.debug(`正在获取服务器 ${server.name} 的工具...`);
         const tools = await this.listTools(server);
-        console.log(`[MCP] 服务器 ${server.name} 提供 ${tools.length} 个工具`);
+        logger.debug(`服务器 ${server.name} 提供 ${tools.length} 个工具`);
         allTools.push(...tools);
       } catch (error) {
-        console.error(`[MCP] 获取服务器 ${server.name} 的工具失败:`, error);
+        logger.error(`获取服务器 ${server.name} 的工具失败:`, error);
       }
     }
 
@@ -122,7 +127,7 @@ export class MCPToolExecutor {
   ): Promise<MCPCallToolResponse> {
     // 记忆工具走内置处理器
     if (isMemoryTool(toolName)) {
-      console.log(`[Memory] 调用记忆工具: ${toolName}`, args);
+      memoryLogger.debug(`调用记忆工具: ${toolName}`, args);
       const result = await handleMemoryToolCall(toolName, args);
       return {
         content: [{ type: 'text', text: result.message }],
@@ -133,7 +138,7 @@ export class MCPToolExecutor {
     // 禁用工具拦截
     const disabledTools = server.disabledTools || [];
     if (disabledTools.includes(toolName)) {
-      console.warn(`[MCP] 工具 ${toolName} 已被用户禁用，拒绝调用`);
+      logger.warn(`工具 ${toolName} 已被用户禁用，拒绝调用`);
       return {
         content: [{ type: 'text', text: `工具 ${toolName} 已被用户禁用。` }],
         isError: true
@@ -169,7 +174,7 @@ export class MCPToolExecutor {
 
     for (let attempt = 0; attempt < maxRetries; attempt++) {
       try {
-        console.log(`[MCP] 调用工具: ${server.name}.${toolName} (尝试 ${attempt + 1}/${maxRetries})`, args);
+        logger.debug(`调用工具: ${server.name}.${toolName} (尝试 ${attempt + 1}/${maxRetries})`, args);
 
         const client = await this.connectionManager.initClient(server);
         const result = await client.callTool(
@@ -189,7 +194,7 @@ export class MCPToolExecutor {
         };
       } catch (error) {
         lastError = error;
-        console.warn(`[MCP] 工具调用失败 (尝试 ${attempt + 1}/${maxRetries}):`, error);
+        logger.warn(`工具调用失败 (尝试 ${attempt + 1}/${maxRetries}):`, error);
 
         if (attempt < maxRetries - 1) {
           const delay = Math.pow(2, attempt) * 1000;
@@ -198,7 +203,7 @@ export class MCPToolExecutor {
       }
     }
 
-    console.error(`[MCP] 工具调用最终失败:`, lastError);
+    logger.error(`工具调用最终失败:`, lastError);
     return {
       content: [
         {
@@ -214,7 +219,7 @@ export class MCPToolExecutor {
 
   async listPrompts(server: MCPServer): Promise<MCPPrompt[]> {
     try {
-      console.log(`[MCP] 获取服务器提示词: ${server.name}`);
+      logger.debug(`获取服务器提示词: ${server.name}`);
 
       const client = await this.connectionManager.initClient(server);
       const result = await client.listPrompts();
@@ -228,17 +233,17 @@ export class MCPToolExecutor {
       }));
     } catch (error) {
       if (error instanceof Error && error.message.includes('-32601')) {
-        console.log(`[MCP] 服务器 ${server.name} 不支持提示词功能`);
+        logger.debug(`服务器 ${server.name} 不支持提示词功能`);
         return [];
       }
-      console.error(`[MCP] 获取提示词列表失败:`, error);
+      logger.error(`获取提示词列表失败:`, error);
       return [];
     }
   }
 
   async listResources(server: MCPServer): Promise<MCPResource[]> {
     try {
-      console.log(`[MCP] 获取服务器资源: ${server.name}`);
+      logger.debug(`获取服务器资源: ${server.name}`);
 
       const client = await this.connectionManager.initClient(server);
       const result = await client.listResources();
@@ -253,10 +258,10 @@ export class MCPToolExecutor {
       }));
     } catch (error) {
       if (error instanceof Error && error.message.includes('-32601')) {
-        console.log(`[MCP] 服务器 ${server.name} 不支持资源功能`);
+        logger.debug(`服务器 ${server.name} 不支持资源功能`);
         return [];
       }
-      console.error(`[MCP] 获取资源列表失败:`, error);
+      logger.error(`获取资源列表失败:`, error);
       return [];
     }
   }

--- a/src/shared/services/mcp/servers/AiSearchServer.ts
+++ b/src/shared/services/mcp/servers/AiSearchServer.ts
@@ -11,6 +11,10 @@ import { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import { CallToolRequestSchema, ListToolsRequestSchema } from '@modelcontextprotocol/sdk/types.js';
 import type { Tool } from '@modelcontextprotocol/sdk/types.js';
 import { universalFetch } from '../../../utils/universalFetch';
+import { createLogger } from '../../infra/logger';
+
+const logger = createLogger('AI Search');
+
 
 // ─── 默认系统提示词（与原项目一致）───
 const DEFAULT_SYSTEM_PROMPT = `你是一个专业的搜索助手,擅长联网搜索并提供准确、详细的答案。
@@ -185,7 +189,7 @@ export class AiSearchServer {
       }
 
       const query = params.query;
-      console.log(`[AI Search] 搜索: ${query}`);
+      logger.debug(`搜索: ${query}`);
 
       let result: string;
 
@@ -201,13 +205,13 @@ export class AiSearchServer {
         result = await this.callApi(query);
       }
 
-      console.log(`[AI Search] 搜索完成，返回 ${result.length} 字符`);
+      logger.debug(`搜索完成，返回 ${result.length} 字符`);
 
       return {
         content: [{ type: 'text', text: result }]
       };
     } catch (error) {
-      console.error('[AI Search] 搜索失败:', error);
+      logger.error('搜索失败:', error);
       return {
         content: [{
           type: 'text',
@@ -229,11 +233,11 @@ export class AiSearchServer {
   // ═══════════════════════════════════════════════════
 
   private async multiDimensionSearch(query: string): Promise<string> {
-    console.log(`[AI Search] 多维度搜索: 拆分为 ${this.config.maxQueryPlan} 个子查询`);
+    logger.debug(`多维度搜索: 拆分为 ${this.config.maxQueryPlan} 个子查询`);
 
     // 1. 用 AI 拆分查询
     const subQueries = await this.splitQuery(query);
-    console.log(`[AI Search] 拆分完成: ${subQueries.length} 个子查询`);
+    logger.debug(`拆分完成: ${subQueries.length} 个子查询`);
 
     // 2. 并发执行所有子查询
     const startTime = Date.now();
@@ -244,7 +248,7 @@ export class AiSearchServer {
 
     const successCount = results.filter(r => r.status === 'fulfilled').length;
     const failCount = results.filter(r => r.status === 'rejected').length;
-    console.log(`[AI Search] 并发完成: 成功 ${successCount}, 失败 ${failCount}, 耗时 ${elapsed}ms`);
+    logger.debug(`并发完成: 成功 ${successCount}, 失败 ${failCount}, 耗时 ${elapsed}ms`);
 
     // 3. 组装结果
     let output = '';
@@ -273,7 +277,7 @@ export class AiSearchServer {
     const systemPrompt = '你是查询拆分助手。只返回 JSON 数组，不要任何解释、标记或其他文本。直接输出 JSON 数组。';
 
     const modelId = this.config.analysisModelId || this.config.modelId;
-    console.log(`[AI Search] 使用模型 ${modelId} 拆分查询`);
+    logger.debug(`使用模型 ${modelId} 拆分查询`);
 
     const response = await this.callApiWithModel(splitPrompt, systemPrompt, modelId);
 
@@ -289,7 +293,7 @@ export class AiSearchServer {
     try {
       subQueries = JSON.parse(cleaned);
     } catch {
-      console.error('[AI Search] JSON 解析失败，原始响应:', response);
+      logger.error('JSON 解析失败，原始响应:', response);
       throw new Error(`解析子查询失败，响应内容: ${cleaned}`);
     }
 
@@ -337,7 +341,7 @@ export class AiSearchServer {
         const statusCode = codeMatch ? parseInt(codeMatch[1], 10) : 0;
 
         if (attempt < this.config.retryCount && (retryableCodes.includes(statusCode) || statusCode === 0)) {
-          console.warn(`[AI Search] 请求失败，重试 ${attempt + 1}/${this.config.retryCount}`);
+          logger.warn(`请求失败，重试 ${attempt + 1}/${this.config.retryCount}`);
           await new Promise(resolve => setTimeout(resolve, 1000));
           continue;
         }

--- a/src/shared/services/mcp/servers/CalendarServer.ts
+++ b/src/shared/services/mcp/servers/CalendarServer.ts
@@ -7,6 +7,10 @@ import { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import { CallToolRequestSchema, ListToolsRequestSchema } from '@modelcontextprotocol/sdk/types.js';
 import type { Tool } from '@modelcontextprotocol/sdk/types.js';
 import { z } from 'zod';
+import { createLogger } from '../../infra/logger';
+
+const logger = createLogger('Calendar MCP');
+
 
 // 工具定义
 const GET_CALENDARS_TOOL: Tool = {
@@ -204,7 +208,7 @@ export class CalendarServer {
     if (typeof window !== 'undefined' && (window as any).plugins?.calendar) {
       this.calendarPlugin = (window as any).plugins.calendar;
     } else {
-      console.warn('[Calendar MCP] Cordova Calendar plugin not found, running in mock mode');
+      logger.warn('Cordova Calendar plugin not found, running in mock mode');
     }
   }
 

--- a/src/shared/services/mcp/servers/MetasoSearchServer.ts
+++ b/src/shared/services/mcp/servers/MetasoSearchServer.ts
@@ -8,6 +8,12 @@ import { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import { CallToolRequestSchema, ListToolsRequestSchema } from '@modelcontextprotocol/sdk/types.js';
 import type { Tool } from '@modelcontextprotocol/sdk/types.js';
 import { universalFetch } from '../../../utils/universalFetch';
+import { createLogger } from '../../infra/logger';
+
+const chatLogger = createLogger('Metaso Chat');
+const readerLogger = createLogger('Metaso Reader');
+const searchLogger = createLogger('Metaso Search');
+
 
 // 工具定义
 const METASO_SEARCH_TOOL: Tool = {
@@ -194,7 +200,7 @@ export class MetasoSearchServer {
       };
 
       // 记录API调用参数（便于调试）
-      console.log('[Metaso Search] API请求参数:', {
+      searchLogger.debug('API请求参数:', {
         query: params.query,
         scope: requestBody.scope,
         size: requestBody.size,
@@ -286,7 +292,7 @@ export class MetasoSearchServer {
         ]
       };
     } catch (error) {
-      console.error('[Metaso Search] 搜索失败:', error);
+      searchLogger.error('搜索失败:', error);
       return {
         content: [
           {
@@ -364,7 +370,7 @@ ${content}
         ]
       };
     } catch (error) {
-      console.error('[Metaso Reader] 阅读失败:', error);
+      readerLogger.error('阅读失败:', error);
       return {
         content: [
           {
@@ -417,7 +423,7 @@ ${content}
       };
 
       // 记录API调用参数
-      console.log('[Metaso Chat] API请求参数:', {
+      chatLogger.debug('API请求参数:', {
         query: params.query,
         model,
         scope,
@@ -579,7 +585,7 @@ ${content}
         };
       }
     } catch (error) {
-      console.error('[Metaso Chat] 对话失败:', error);
+      chatLogger.error('对话失败:', error);
       return {
         content: [
           {

--- a/src/shared/services/mcp/servers/SearXNGServer.ts
+++ b/src/shared/services/mcp/servers/SearXNGServer.ts
@@ -11,6 +11,10 @@ import { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import { CallToolRequestSchema, ListToolsRequestSchema } from '@modelcontextprotocol/sdk/types.js';
 import type { Tool } from '@modelcontextprotocol/sdk/types.js';
 import { universalFetch } from '../../../utils/universalFetch';
+import { createLogger } from '../../infra/logger';
+
+const logger = createLogger('SearXNG');
+
 
 // ==================== 工具定义 ====================
 
@@ -205,7 +209,7 @@ export class SearXNGServer {
 
       const searchUrl = `${this.baseUrl}/search?${searchParams.toString()}`;
 
-      console.log('[SearXNG] 开始搜索:', { query, engines, language, categories, timeRange, pageno, safesearch });
+      logger.debug('开始搜索:', { query, engines, language, categories, timeRange, pageno, safesearch });
 
       // 发送搜索请求
       const response = await universalFetch(searchUrl, {
@@ -230,7 +234,7 @@ export class SearXNGServer {
       const corrections: string[] = data.corrections || [];
       const infoboxes: any[] = data.infoboxes || [];
 
-      console.log(`[SearXNG] 搜索完成，找到 ${results.length} 个结果，${suggestions.length} 条建议，${answers.length} 个直接答案，${infoboxes.length} 个信息卡片`);
+      logger.debug(`搜索完成，找到 ${results.length} 个结果，${suggestions.length} 条建议，${answers.length} 个直接答案，${infoboxes.length} 个信息卡片`);
 
       // 格式化输出
       let resultText = `## SearXNG 搜索结果\n\n`;
@@ -330,7 +334,7 @@ export class SearXNGServer {
         ]
       };
     } catch (error) {
-      console.error('[SearXNG] 搜索失败:', error);
+      logger.error('搜索失败:', error);
       return {
         content: [
           {
@@ -360,7 +364,7 @@ export class SearXNGServer {
     try {
       const { url, maxLength = 5000 } = params;
 
-      console.log('[SearXNG] 开始抓取网页:', url);
+      logger.debug('开始抓取网页:', url);
 
       // 直接抓取网页内容
       const response = await universalFetch(url, {
@@ -413,7 +417,7 @@ export class SearXNGServer {
       resultText += `\n---\n\n`;
       resultText += extractedContent;
 
-      console.log(`[SearXNG] 网页抓取完成，提取 ${extractedContent.length} 字符`);
+      logger.debug(`网页抓取完成，提取 ${extractedContent.length} 字符`);
 
       return {
         content: [
@@ -424,7 +428,7 @@ export class SearXNGServer {
         ]
       };
     } catch (error) {
-      console.error('[SearXNG] 网页抓取失败:', error);
+      logger.error('网页抓取失败:', error);
       return {
         content: [
           {


### PR DESCRIPTION
## Summary
阶段4(分模块迁移)的**首个样板 PR**:把 `src/shared/services/mcp` 下 **15 个文件、222 处裸 `console.*`** 迁移到 PR #240 落地的统一日志器 `createLogger`。纯日志出口替换,**不改变任何业务行为**。

迁移规范(后续子系统沿用):
- 每文件用既有 `[前缀]` 建一个命名空间 logger,并把前缀从消息里剥掉:
  ```diff
  - console.log(`[MCP] 复用现有连接: ${server.name}`);
  + logger.debug(`复用现有连接: ${server.name}`);
  ```
  ```ts
  import { createLogger } from '../../infra/logger';
  const logger = createLogger('MCP');
  ```
- 级别映射:`console.log`→`logger.debug`(诊断噪音,生产默认隐藏)、`info`→`info`、`debug`→`debug`、`warn`→`warn`、`error`→`error`。
- **多前缀文件按前缀拆分多个 logger**(语义不混):
  - `StdioMCPClient`: `logger`=`createLogger('Stdio MCP Client')` / `transportLogger`=`createLogger('Stdio Transport')`
  - `MetasoSearchServer`: `chatLogger` / `readerLogger` / `searchLogger`
  - `MCPToolExecutor`: `logger`(MCP) / `memoryLogger`(Memory)

各文件上下文名:`MCP`、`MCP Client`、`Mobile MCP Client`、`Stdio MCP Client`/`Stdio Transport`、`Mobile SSE Transport`、`AI Search`、`SearXNG`、`Metaso Chat/Reader/Search`、`ToolConfirmation`、`McpBridge`、`Calendar MCP`。

迁移后 `src/shared/services/mcp` 内 `console.*` 归零(0 处)。手动按子系统迁移、无全局 codemod;改动经人工逐文件核对。

## 验证
- `npm run type-check` 通过。
- `npm run build`(vite)通过:`✓ 8060 modules transformed`,`✓ built in 4.64s`。
- `eslint src/shared/services/mcp`:改动文件 `no-console` 告警归零;残留的 18 个 `preserve-caught-error` error 与 37 个告警均在**本 PR 未触碰**的文件(`FetchServer.ts`、`file-editor/handlers/*`),为既有问题。

## 范围
仅 `src/shared/services/mcp/**`,不动 logger 核心 / 旧 `LoggerService` / ESLint 配置。不涉及阶段5(移除旧服务)/阶段6(DevTools 整合)。`shared/store` 样板由并行会话单独提 PR。


Link to Devin session: https://app.devin.ai/sessions/b18b37124c694c8ab02698a24264d4aa
Requested by: @1600822305