### PR TITLE
重构(store): 将 src/shared/store 的 console.* 迁移到统一日志器（Phase 4 样板）

### DIFF
--- a/src/shared/store/index.ts
+++ b/src/shared/store/index.ts
@@ -2,6 +2,10 @@ import { configureStore, combineReducers } from '@reduxjs/toolkit';
 import { persistStore, persistReducer } from 'redux-persist';
 import type { WebStorage } from 'redux-persist';
 import { dexieStorage } from '../services/storage/DexieStorageService';
+import { createLogger } from '../services/infra/logger';
+
+const logger = createLogger('Store');
+const storageLogger = logger.withContext('Redux Storage');
 
 // 🚀 使用 Dexie (IndexedDB) 作为 Redux Persist 的存储后端
 // 相比 localStorage: 容量更大、不阻塞主线程、支持大型状态
@@ -11,7 +15,7 @@ const storage: WebStorage = {
       const value = await dexieStorage.getSetting(`redux_${key}`);
       return value !== null && value !== undefined ? JSON.stringify(value) : null;
     } catch (error) {
-      console.error('[Redux Storage] getItem error:', error);
+      storageLogger.error('getItem error:', error);
       return null;
     }
   },
@@ -20,14 +24,14 @@ const storage: WebStorage = {
       const parsed = JSON.parse(value);
       await dexieStorage.saveSetting(`redux_${key}`, parsed);
     } catch (error) {
-      console.error('[Redux Storage] setItem error:', error);
+      storageLogger.error('setItem error:', error);
     }
   },
   removeItem: async (key) => {
     try {
       await dexieStorage.deleteSetting(`redux_${key}`);
     } catch (error) {
-      console.error('[Redux Storage] removeItem error:', error);
+      storageLogger.error('removeItem error:', error);
     }
   },
 };
@@ -135,7 +139,7 @@ initializeWebSearchSettings().then(settings => {
     store.dispatch({ type: 'webSearch/setWebSearchSettings', payload: settings });
   }
 }).catch(error => {
-  console.error('初始化网络搜索设置失败:', error);
+  logger.error('初始化网络搜索设置失败:', error);
 });
 
 // 初始化 PDF 预处理设置
@@ -144,7 +148,7 @@ initializePdfPreprocessSettings().then(settings => {
     store.dispatch(setPdfPreprocessSettings(settings));
   }
 }).catch(error => {
-  console.error('初始化 PDF 预处理设置失败:', error);
+  logger.error('初始化 PDF 预处理设置失败:', error);
 });
 
 // 初始化视觉识别设置
@@ -153,13 +157,13 @@ initializeVisionRecognitionSettings().then(settings => {
     store.dispatch(setVisionRecognitionSettings(settings));
   }
 }).catch(error => {
-  console.error('初始化视觉识别设置失败:', error);
+  logger.error('初始化视觉识别设置失败:', error);
 });
 
 // 初始化网络代理设置，Capacitor 平台加载后自动恢复代理到插件
 store.dispatch(loadNetworkProxySettings() as any).then((result: any) => {
   if (result.payload?.globalProxy?.enabled && Capacitor.isNativePlatform()) {
-    console.log('[Store] Capacitor 平台：恢复代理配置到 CorsBypass 插件');
+    logger.debug('Capacitor 平台：恢复代理配置到 CorsBypass 插件');
     store.dispatch(applyGlobalProxy(result.payload.globalProxy) as any);
   }
 });

--- a/src/shared/store/middleware/eventMiddleware.ts
+++ b/src/shared/store/middleware/eventMiddleware.ts
@@ -1,6 +1,9 @@
 import type { Middleware } from '@reduxjs/toolkit';
 import { EventEmitter, EVENT_NAMES } from '../../services/infra/EventEmitter';
 import { dexieStorage } from '../../services/storage/DexieStorageService';
+import { createLogger } from '../../services/infra/logger';
+
+const logger = createLogger('EventMiddleware');
 
 /**
  * Redux中间件，用于在特定操作发生时触发事件
@@ -32,7 +35,7 @@ export const eventMiddleware: Middleware = _store => next => action => {
     // 移除重复的事件发送，避免与流式处理器的事件冲突
     // 流式事件应该只由实际的流式处理器发送
     const { topicId, streaming } = payload;
-    console.log(`[EventMiddleware] 话题流式状态变化: ${topicId}, streaming: ${streaming}`);
+    logger.debug(`话题流式状态变化: ${topicId}, streaming: ${streaming}`);
   }
 
   // 块相关事件
@@ -66,9 +69,9 @@ export const eventMiddleware: Middleware = _store => next => action => {
       Promise.resolve().then(async () => {
         try {
           await dexieStorage.saveTopic(defaultTopic);
-          console.log(`[EventMiddleware] 自动创建的默认话题已保存到数据库: ${defaultTopic.id}`);
+          logger.debug(`自动创建的默认话题已保存到数据库: ${defaultTopic.id}`);
         } catch (error) {
-          console.error('[EventMiddleware] 保存自动创建的默认话题失败:', error);
+          logger.error('保存自动创建的默认话题失败:', error);
         }
       });
     }

--- a/src/shared/store/settingsSlice.ts
+++ b/src/shared/store/settingsSlice.ts
@@ -10,6 +10,9 @@ export type { SettingsState } from './settings/types';
 import type { SettingsState } from './settings/types';
 import { ensureModelIdentityKey, setDefaultFlags, canonicalModelKey, createSetter } from './settings/helpers';
 import { DEFAULT_HAPTIC_FEEDBACK, DEFAULT_CONTEXT_CONDENSE, DEFAULT_TOOLBAR_BUTTONS, getInitialState } from './settings/defaults';
+import { createLogger } from '../services/infra/logger';
+
+const logger = createLogger('settingsSlice');
 
 const initialState = getInitialState();
 
@@ -234,7 +237,7 @@ const settingsSlice = createSlice({
         const validModelSelectorDisplayStyles = ['icon', 'text'] as const;
         const displayStyle = updates.topToolbar.modelSelectorDisplayStyle;
         if (displayStyle !== undefined && !validModelSelectorDisplayStyles.includes(displayStyle as any)) {
-          console.warn(`[settingsSlice] 修复无效的 modelSelectorDisplayStyle: "${displayStyle}", 重置为 "icon"`);
+          logger.warn(`修复无效的 modelSelectorDisplayStyle: "${displayStyle}", 重置为 "icon"`);
           updates.topToolbar = {
             ...updates.topToolbar,
             modelSelectorDisplayStyle: 'icon'
@@ -244,7 +247,7 @@ const settingsSlice = createSlice({
         const validModelSelectorStyles = ['dialog', 'dropdown'] as const;
         const selectorStyle = updates.topToolbar.modelSelectorStyle;
         if (selectorStyle !== undefined && !validModelSelectorStyles.includes(selectorStyle as any)) {
-          console.warn(`[settingsSlice] 修复无效的 modelSelectorStyle: "${selectorStyle}", 重置为 "dialog"`);
+          logger.warn(`修复无效的 modelSelectorStyle: "${selectorStyle}", 重置为 "dialog"`);
           updates.topToolbar = {
             ...updates.topToolbar,
             modelSelectorStyle: 'dialog'
@@ -256,7 +259,7 @@ const settingsSlice = createSlice({
       if (updates.modelSelectorStyle !== undefined) {
         const validStyles = ['dialog', 'dropdown'] as const;
         if (!validStyles.includes(updates.modelSelectorStyle as any)) {
-          console.warn(`[settingsSlice] 修复无效的全局 modelSelectorStyle: "${updates.modelSelectorStyle}", 重置为 "dialog"`);
+          logger.warn(`修复无效的全局 modelSelectorStyle: "${updates.modelSelectorStyle}", 重置为 "dialog"`);
           updates.modelSelectorStyle = 'dialog';
         }
       }

--- a/src/shared/store/slices/assistantsSlice.ts
+++ b/src/shared/store/slices/assistantsSlice.ts
@@ -1,6 +1,9 @@
 import { createSlice } from '@reduxjs/toolkit';
 import type { PayloadAction } from '@reduxjs/toolkit';
 import type { Assistant, ChatTopic } from '../../types/Assistant';
+import { createLogger } from '../../services/infra/logger';
+
+const logger = createLogger('assistantsSlice');
 
 interface AssistantsState {
   assistants: Assistant[];
@@ -24,12 +27,12 @@ const assistantsSlice = createSlice({
   initialState,
   reducers: {
     setAssistants: (state, action: PayloadAction<Assistant[]>) => {
-      console.log(`[assistantsSlice] 设置助手列表，数量: ${action.payload.length}`);
+      logger.debug(`设置助手列表，数量: ${action.payload.length}`);
 
       // 检查是否有头像（支持emoji、avatar、icon任意一种）
       const assistantsWithoutAvatar = action.payload.filter(a => !a.emoji && !a.avatar && !a.icon);
       if (assistantsWithoutAvatar.length > 0) {
-        console.warn(`[assistantsSlice] 发现 ${assistantsWithoutAvatar.length} 个助手没有设置头像（emoji、avatar或icon）:`,
+        logger.warn(`发现 ${assistantsWithoutAvatar.length} 个助手没有设置头像（emoji、avatar或icon）:`,
           assistantsWithoutAvatar.map(a => ({ id: a.id, name: a.name }))
         );
       }
@@ -64,7 +67,7 @@ const assistantsSlice = createSlice({
         // 使用辅助函数同步更新 currentAssistant
         syncCurrentAssistant(state, assistantId, assistant);
 
-        console.log(`[assistantsSlice] 添加话题 ${topic.id} 到助手 ${assistantId}（插入到开头），当前话题数量: ${assistant.topics.length}`);
+        logger.debug(`添加话题 ${topic.id} 到助手 ${assistantId}（插入到开头），当前话题数量: ${assistant.topics.length}`);
       }
     },
     removeTopic: (state, action: PayloadAction<{ assistantId: string; topicId: string }>) => {
@@ -80,7 +83,7 @@ const assistantsSlice = createSlice({
         // 使用辅助函数同步更新 currentAssistant
         syncCurrentAssistant(state, assistantId, assistant);
 
-        console.log(`[assistantsSlice] 从助手 ${assistantId} 移除话题 ${topicId}，剩余话题数量: ${assistant.topics?.length || 0}`);
+        logger.debug(`从助手 ${assistantId} 移除话题 ${topicId}，剩余话题数量: ${assistant.topics?.length || 0}`);
       }
     },
     updateTopic: (state, action: PayloadAction<{ assistantId: string; topic: ChatTopic }>) => {
@@ -94,11 +97,11 @@ const assistantsSlice = createSlice({
         const index = assistant.topics.findIndex(t => t.id === topic.id);
         if (index !== -1) {
           assistant.topics[index] = topic;
-          console.log(`[assistantsSlice] 更新助手 ${assistantId} 的话题 ${topic.id}`);
+          logger.debug(`更新助手 ${assistantId} 的话题 ${topic.id}`);
         } else {
           if (assistant.topicIds.includes(topic.id)) {
             assistant.topics.push(topic);
-            console.log(`[assistantsSlice] 添加话题 ${topic.id} 到助手 ${assistantId} 的topics数组`);
+            logger.debug(`添加话题 ${topic.id} 到助手 ${assistantId} 的topics数组`);
           }
         }
 
@@ -116,7 +119,7 @@ const assistantsSlice = createSlice({
         // 同步更新 currentAssistant
         syncCurrentAssistant(state, assistantId, assistant);
 
-        console.log(`[assistantsSlice] 更新助手 ${assistantId} 的话题，数量: ${topics.length}，topicIds: ${assistant.topicIds.join(', ')}`);
+        logger.debug(`更新助手 ${assistantId} 的话题，数量: ${topics.length}，topicIds: ${assistant.topicIds.join(', ')}`);
       }
     },
     // 添加新的reducers，类似最佳实例
@@ -133,7 +136,7 @@ const assistantsSlice = createSlice({
         // 如果不存在，添加新助手
         state.assistants.push(action.payload);
       }
-      console.log(`[assistantsSlice] 添加助手: ${action.payload.id} (${action.payload.name})`);
+      logger.debug(`添加助手: ${action.payload.id} (${action.payload.name})`);
     },
     updateAssistant: (state, action: PayloadAction<Assistant>) => {
       const index = state.assistants.findIndex(a => a.id === action.payload.id);
@@ -148,7 +151,7 @@ const assistantsSlice = createSlice({
         if (oldAssistant.emoji !== action.payload.emoji ||
             oldAssistant.avatar !== action.payload.avatar ||
             oldAssistant.icon !== action.payload.icon) {
-          console.log(`[assistantsSlice] 助手头像更新: ${action.payload.id} (${action.payload.name})`, {
+          logger.debug(`助手头像更新: ${action.payload.id} (${action.payload.name})`, {
             old: { emoji: oldAssistant.emoji, avatar: oldAssistant.avatar, icon: !!oldAssistant.icon },
             new: { emoji: action.payload.emoji, avatar: action.payload.avatar, icon: !!action.payload.icon }
           });
@@ -158,15 +161,15 @@ const assistantsSlice = createSlice({
         const oldTopicCount = oldAssistant.topics?.length || oldAssistant.topicIds?.length || 0;
         const newTopicCount = action.payload.topics?.length || action.payload.topicIds?.length || 0;
         if (oldTopicCount !== newTopicCount) {
-          console.log(`[assistantsSlice] 助手话题数变化: ${action.payload.id} (${action.payload.name})`, {
+          logger.debug(`助手话题数变化: ${action.payload.id} (${action.payload.name})`, {
             oldCount: oldTopicCount,
             newCount: newTopicCount
           });
         }
 
-        console.log(`[assistantsSlice] 更新助手: ${action.payload.id} (${action.payload.name}), 话题数: ${newTopicCount}`);
+        logger.debug(`更新助手: ${action.payload.id} (${action.payload.name}), 话题数: ${newTopicCount}`);
       } else {
-        console.warn(`[assistantsSlice] 未找到要更新的助手: ${action.payload.id}`);
+        logger.warn(`未找到要更新的助手: ${action.payload.id}`);
       }
     },
     removeAssistant: (state, action: PayloadAction<string>) => {
@@ -178,7 +181,7 @@ const assistantsSlice = createSlice({
         state.currentAssistant = null;
       }
 
-      console.log(`[assistantsSlice] 删除助手: ${assistantId}`);
+      logger.debug(`删除助手: ${assistantId}`);
     }
   }
 });

--- a/src/shared/store/slices/groupsSlice.ts
+++ b/src/shared/store/slices/groupsSlice.ts
@@ -4,6 +4,9 @@ import { nanoid } from '../../utils';
 import { getStorageItem, setStorageItem } from '../../utils/storage';
 import { makeSerializable, diagnoseSerializationIssues } from '../../utils/serialization';
 import { dexieStorage } from '../../services/storage/DexieStorageService';
+import { createLogger } from '../../services/infra/logger';
+
+const logger = createLogger('groupsSlice');
 
 // 类型定义
 type AppDispatch = any;
@@ -37,7 +40,7 @@ const saveGroupsToStorage = async (groups: Group[]): Promise<void> => {
     const { hasCircularRefs, nonSerializableProps } = diagnoseSerializationIssues(groups);
 
     if (hasCircularRefs || nonSerializableProps.length > 0) {
-      console.warn('分组数据存在序列化问题，将尝试修复：', {
+      logger.warn('分组数据存在序列化问题，将尝试修复：', {
         hasCircularRefs,
         nonSerializableProps
       });
@@ -54,12 +57,12 @@ const saveGroupsToStorage = async (groups: Group[]): Promise<void> => {
 
 
   } catch (error) {
-    console.error('保存分组失败:', error);
+    logger.error('保存分组失败:', error);
     // 记录更详细的错误信息，帮助诊断问题
     if (error instanceof Error) {
-      console.error('错误类型:', error.name);
-      console.error('错误消息:', error.message);
-      console.error('错误堆栈:', error.stack);
+      logger.error('错误类型:', error.name);
+      logger.error('错误消息:', error.message);
+      logger.error('错误堆栈:', error.stack);
     }
   }
 };
@@ -70,14 +73,14 @@ const saveGroupsToStorage = async (groups: Group[]): Promise<void> => {
 const saveMapToStorage = async (key: string, map: Record<string, any>): Promise<void> => {
   try {
     if (process.env.NODE_ENV === 'development') {
-      console.log(`开始保存${key}数据...`);
+      logger.debug(`开始保存${key}数据...`);
     }
 
     // 先诊断数据是否存在序列化问题
     const { hasCircularRefs, nonSerializableProps } = diagnoseSerializationIssues(map);
 
     if (hasCircularRefs || nonSerializableProps.length > 0) {
-      console.warn(`${key}数据存在序列化问题，将尝试修复：`, {
+      logger.warn(`${key}数据存在序列化问题，将尝试修复：`, {
         hasCircularRefs,
         nonSerializableProps
       });
@@ -93,15 +96,15 @@ const saveMapToStorage = async (key: string, map: Record<string, any>): Promise<
     await setStorageItem(key, serializableMap);
 
     if (process.env.NODE_ENV === 'development') {
-      console.log(`${key}数据保存成功`);
+      logger.debug(`${key}数据保存成功`);
     }
   } catch (error) {
-    console.error(`保存${key}失败:`, error);
+    logger.error(`保存${key}失败:`, error);
     // 记录更详细的错误信息
     if (error instanceof Error) {
-      console.error('错误类型:', error.name);
-      console.error('错误消息:', error.message);
-      console.error('错误堆栈:', error.stack);
+      logger.error('错误类型:', error.name);
+      logger.error('错误消息:', error.message);
+      logger.error('错误堆栈:', error.stack);
     }
   }
 };
@@ -127,7 +130,7 @@ const initializeGroups = async (dispatch: any) => {
         const firstValue = Object.values(savedTopicGroupMap)[0];
         if (typeof firstValue === 'string') {
           // 这是旧格式，需要迁移
-          console.log('检测到旧格式的topicGroupMap，开始迁移...');
+          logger.debug('检测到旧格式的topicGroupMap，开始迁移...');
           const oldMap = savedTopicGroupMap as unknown as Record<string, string>;
           const newMap: Record<string, Record<string, string>> = {};
 
@@ -147,12 +150,12 @@ const initializeGroups = async (dispatch: any) => {
 
           // 保存迁移后的数据
           await dexieStorage.saveSetting('topicGroupMap', newMap);
-          console.log('topicGroupMap迁移完成');
+          logger.debug('topicGroupMap迁移完成');
         }
       }
 
     } catch (dexieError) {
-      console.warn('从dexieStorage直接加载分组数据失败，尝试使用getStorageItem:', dexieError);
+      logger.warn('从dexieStorage直接加载分组数据失败，尝试使用getStorageItem:', dexieError);
 
       // 如果直接加载失败，尝试使用getStorageItem
       savedGroups = await getStorageItem<Group[]>('groups');
@@ -185,11 +188,11 @@ const initializeGroups = async (dispatch: any) => {
 
     dispatch(loadGroupsSuccess(payload));
   } catch (error) {
-    console.error('加载分组数据失败:', error);
+    logger.error('加载分组数据失败:', error);
     if (error instanceof Error) {
-      console.error('错误类型:', error.name);
-      console.error('错误消息:', error.message);
-      console.error('错误堆栈:', error.stack);
+      logger.error('错误类型:', error.name);
+      logger.error('错误消息:', error.message);
+      logger.error('错误堆栈:', error.stack);
     }
   }
 };
@@ -446,7 +449,7 @@ export const saveGroups = () => async (_dispatch: AppDispatch, getState: () => R
     await saveMapToStorage('topicGroupMap', topicGroupMap);
   } catch (error) {
     if (process.env.NODE_ENV === 'development') {
-      console.error('保存分组数据失败:', error);
+      logger.error('保存分组数据失败:', error);
     }
   }
 };

--- a/src/shared/store/slices/networkProxySlice.ts
+++ b/src/shared/store/slices/networkProxySlice.ts
@@ -4,6 +4,9 @@ import { getStorageItem, setStorageItem } from '../../utils/storage';
 import { CorsBypass } from 'capacitor-cors-bypass-enhanced';
 import { isTauri } from '../../utils/platformDetection';
 import { testTauriProxyConnection } from '../../utils/universalFetch';
+import { createLogger } from '../../services/infra/logger';
+
+const logger = createLogger('networkProxySlice');
 
 /**
  * 代理类型枚举
@@ -126,7 +129,7 @@ export const loadNetworkProxySettings = createAsyncThunk(
       }
       return null;
     } catch (e) {
-      console.error('Failed to load network proxy settings:', e);
+      logger.error('Failed to load network proxy settings:', e);
       return null;
     }
   }
@@ -145,7 +148,7 @@ export const saveNetworkProxySettings = createAsyncThunk(
       });
       return true;
     } catch (e) {
-      console.error('Failed to save network proxy settings:', e);
+      logger.error('Failed to save network proxy settings:', e);
       return false;
     }
   }
@@ -166,7 +169,7 @@ export const testProxyConnection = createAsyncThunk(
       
       // Tauri 桌面端使用专用测试函数
       if (isTauri()) {
-        console.log('[networkProxySlice] Tauri 桌面端代理测试');
+        logger.debug('Tauri 桌面端代理测试');
         const result = await testTauriProxyConnection(
           {
             enabled: true,
@@ -182,7 +185,7 @@ export const testProxyConnection = createAsyncThunk(
       }
       
       // 移动端使用 CorsBypass 插件
-      console.log('[networkProxySlice] 移动端代理测试 (CorsBypass)');
+      logger.debug('移动端代理测试 (CorsBypass)');
       const result = await CorsBypass.testProxy(
         {
           enabled: true,
@@ -198,7 +201,7 @@ export const testProxyConnection = createAsyncThunk(
 
       return result as ProxyTestResult;
     } catch (error: any) {
-      console.error('[networkProxySlice] 代理测试失败:', error);
+      logger.error('代理测试失败:', error);
       return rejectWithValue({
         success: false,
         error: error.message || '代理测试失败',
@@ -219,7 +222,7 @@ export const applyGlobalProxy = createAsyncThunk(
       // Tauri 桌面端：代理配置已保存到 storage，universalFetch 会自动读取
       // 不需要额外操作，但我们记录日志以便调试
       if (isTauri()) {
-        console.log('[networkProxySlice] Tauri 桌面端代理配置已更新:', {
+        logger.debug('Tauri 桌面端代理配置已更新:', {
           enabled: config.enabled,
           type: config.type,
           host: config.host,
@@ -246,7 +249,7 @@ export const applyGlobalProxy = createAsyncThunk(
 
       return true;
     } catch (error: any) {
-      console.error('Failed to apply global proxy:', error);
+      logger.error('Failed to apply global proxy:', error);
       return rejectWithValue(error.message || '应用代理失败');
     }
   }

--- a/src/shared/store/slices/newMessagesSlice.ts
+++ b/src/shared/store/slices/newMessagesSlice.ts
@@ -5,6 +5,9 @@ import type { RootState } from '../index';
 import { dexieStorage } from '../../services/storage/DexieStorageService';
 import { topicCacheManager } from '../../services/topics/TopicCacheManager';
 import { upsertManyBlocks } from './messageBlocksSlice';
+import { createLogger } from '../../services/infra/logger';
+
+const logger = createLogger('loadTopicMessagesThunk');
 
 // 1. 创建实体适配器
 const messagesAdapter = createEntityAdapter<Message>();
@@ -555,7 +558,7 @@ export const loadTopicMessagesThunk = createAsyncThunk(
 
       // 优化：检查是否已完成加载（fulfilledByTopic）
       if (state.messages.fulfilledByTopic[topicId]) {
-        console.log(`[loadTopicMessagesThunk] 话题 ${topicId} 已加载，跳过`);
+        logger.debug(`话题 ${topicId} 已加载，跳过`);
         dispatch(newMessagesActions.setCurrentTopicId(topicId));
         return [];
       }
@@ -568,7 +571,7 @@ export const loadTopicMessagesThunk = createAsyncThunk(
       dispatch(newMessagesActions.setCurrentTopicId(topicId));
 
       if (hasActualMessages) {
-        console.log(`[loadTopicMessagesThunk] 话题 ${topicId} 消息已缓存，跳过加载`);
+        logger.debug(`话题 ${topicId} 消息已缓存，跳过加载`);
         // 标记为已完成加载
         dispatch(newMessagesActions.setTopicFulfilled({ topicId, fulfilled: true }));
         return []; // 直接返回，不重新加载
@@ -629,7 +632,7 @@ export const loadTopicMessagesThunk = createAsyncThunk(
 
       return messagesFromTopic;
     } catch (error) {
-      console.error(`[loadTopicMessagesThunk] 加载话题 ${topicId} 消息失败:`, error);
+      logger.error(`加载话题 ${topicId} 消息失败:`, error);
 
       // 创建错误信息对象
       const errorInfo: ErrorInfo = {

--- a/src/shared/store/slices/pdfPreprocessSlice.ts
+++ b/src/shared/store/slices/pdfPreprocessSlice.ts
@@ -12,6 +12,9 @@ import { createSlice } from '@reduxjs/toolkit';
 import type { PayloadAction } from '@reduxjs/toolkit';
 import { getStorageItem, setStorageItem } from '../../utils/storage';
 import type { PreprocessProviderId } from '../../services/knowledge/preprocess/types';
+import { createLogger } from '../../services/infra/logger';
+
+const logger = createLogger('PdfPreprocess');
 
 // ==================== 存储键 ====================
 
@@ -70,7 +73,7 @@ const saveToStorage = (state: PdfPreprocessState) => {
   };
 
   setStorageItem(STORAGE_KEY, serializable).catch((error) => {
-    console.error('[PdfPreprocess] 保存设置失败:', error);
+    logger.error('保存设置失败:', error);
   });
 };
 
@@ -85,7 +88,7 @@ const loadFromStorage = async (): Promise<PdfPreprocessState> => {
       };
     }
   } catch (error) {
-    console.error('[PdfPreprocess] 加载设置失败:', error);
+    logger.error('加载设置失败:', error);
   }
   return getDefaultState();
 };
@@ -100,7 +103,7 @@ export const initializePdfPreprocessSettings = async (): Promise<PdfPreprocessSt
     const settings = await loadFromStorage();
     return settings;
   } catch (err) {
-    console.error('[PdfPreprocess] 初始化失败:', err);
+    logger.error('初始化失败:', err);
     return null;
   } finally {
     isInitialized = true;

--- a/src/shared/store/slices/visionRecognitionSlice.ts
+++ b/src/shared/store/slices/visionRecognitionSlice.ts
@@ -11,6 +11,9 @@
 import { createSlice } from '@reduxjs/toolkit';
 import type { PayloadAction } from '@reduxjs/toolkit';
 import { getStorageItem, setStorageItem } from '../../utils/storage';
+import { createLogger } from '../../services/infra/logger';
+
+const logger = createLogger('VisionRecognition');
 
 // ==================== 存储键 ====================
 
@@ -96,7 +99,7 @@ const toPlainState = (state: VisionRecognitionState): VisionRecognitionState => 
 const saveToStorage = (state: VisionRecognitionState) => {
   // 必须深拷贝为纯对象，Immer Proxy 无法被 IndexedDB structured clone
   setStorageItem(STORAGE_KEY, toPlainState(state)).catch((error) => {
-    console.error('[VisionRecognition] 保存设置失败:', error);
+    logger.error('保存设置失败:', error);
   });
 };
 
@@ -120,7 +123,7 @@ const loadFromStorage = async (): Promise<VisionRecognitionState> => {
       };
     }
   } catch (error) {
-    console.error('[VisionRecognition] 加载设置失败:', error);
+    logger.error('加载设置失败:', error);
   }
   return defaults;
 };
@@ -134,7 +137,7 @@ export const initializeVisionRecognitionSettings = async (): Promise<VisionRecog
   try {
     return await loadFromStorage();
   } catch (err) {
-    console.error('[VisionRecognition] 初始化失败:', err);
+    logger.error('初始化失败:', err);
     return null;
   } finally {
     isInitialized = true;

--- a/src/shared/store/slices/webSearchSlice.ts
+++ b/src/shared/store/slices/webSearchSlice.ts
@@ -2,6 +2,9 @@ import { createSlice } from '@reduxjs/toolkit';
 import type { PayloadAction } from '@reduxjs/toolkit';
 import type { WebSearchSettings, WebSearchCustomProvider, WebSearchProvider, WebSearchProviderConfig, SearchEngine } from '../../types';
 import { getStorageItem, setStorageItem } from '../../utils/storage';
+import { createLogger } from '../../services/infra/logger';
+
+const logger = createLogger('webSearchSlice');
 
 // 存储键名
 const STORAGE_KEY = 'webSearchSettings';
@@ -99,7 +102,7 @@ const loadFromStorage = async (): Promise<WebSearchSettings> => {
       };
     }
   } catch (error) {
-    console.error('Failed to load webSearchSettings from IndexedDB', error);
+    logger.error('Failed to load webSearchSettings from IndexedDB', error);
   }
 
   // 默认初始状态
@@ -187,7 +190,7 @@ export const initializeWebSearchSettings = async () => {
     // 这个函数会在store初始化后被调用
     return settings;
   } catch (err) {
-    console.error('加载网络搜索设置失败:', err);
+    logger.error('加载网络搜索设置失败:', err);
     return null;
   } finally {
     isInitialized = true;
@@ -235,7 +238,7 @@ const saveToStorage = (state: WebSearchSettings) => {
   };
 
   setStorageItem(STORAGE_KEY, serializableState).catch(error => {
-    console.error('Failed to save webSearchSettings to IndexedDB', error);
+    logger.error('Failed to save webSearchSettings to IndexedDB', error);
   });
 };
 

--- a/src/shared/store/thunks/message/apiPreparation.ts
+++ b/src/shared/store/thunks/message/apiPreparation.ts
@@ -19,6 +19,10 @@ import type { AssistantRegex } from '../../../types/Assistant';
 import { searchRelevantMemories, buildMemoryPrompt, isMemoryEnabled, isMemoryAllowedForAssistant, setActiveMemoryAssistant } from './memoryIntegration';
 import { SkillPromptBuilder } from '../../../services/skills/SkillPromptBuilder';
 import { SkillManager } from '../../../services/skills/SkillManager';
+import { createLogger } from '../../../services/infra/logger';
+
+const logger = createLogger('prepareMessagesForApi');
+const knowledgeLogger = logger.withContext('performKnowledgeSearchIfNeeded');
 
 /** 知识库搜索引用，用于注入到当前用户提问 */
 export interface KnowledgeSearchReference {
@@ -48,7 +52,7 @@ export const performKnowledgeSearchIfNeeded = async (
   assistantMessageId: string
 ): Promise<KnowledgeSearchReference[] | null> => {
   try {
-    console.log('[performKnowledgeSearchIfNeeded] 开始检查知识库选择状态...');
+    knowledgeLogger.debug('开始检查知识库选择状态...');
 
     const storeState = store.getState();
     // 优先使用多选列表，兼容旧的单选
@@ -56,7 +60,7 @@ export const performKnowledgeSearchIfNeeded = async (
     const contextData = getKnowledgeSelectionFromStore(storeState);
 
     if (selectedKBs.length === 0 && !contextData) {
-      console.log('[performKnowledgeSearchIfNeeded] 没有选中知识库，直接返回');
+      knowledgeLogger.debug('没有选中知识库，直接返回');
       return null;
     }
 
@@ -67,7 +71,7 @@ export const performKnowledgeSearchIfNeeded = async (
 
     if (knowledgeBasesToSearch.length === 0) return null;
 
-    console.log(`[performKnowledgeSearchIfNeeded] 检测到 ${knowledgeBasesToSearch.length} 个知识库，开始并行搜索...`);
+    knowledgeLogger.debug(`检测到 ${knowledgeBasesToSearch.length} 个知识库，开始并行搜索...`);
 
     // 设置助手消息状态为搜索中
     store.dispatch(newMessagesActions.updateMessage({
@@ -80,7 +84,7 @@ export const performKnowledgeSearchIfNeeded = async (
     // 获取话题消息
     const messages = await dexieStorage.getTopicMessages(topicId);
     if (!messages || messages.length === 0) {
-      console.warn('[performKnowledgeSearchIfNeeded] 无法获取话题消息');
+      knowledgeLogger.warn('无法获取话题消息');
       return null;
     }
 
@@ -90,18 +94,18 @@ export const performKnowledgeSearchIfNeeded = async (
       .pop();
 
     if (!userMessage) {
-      console.warn('[performKnowledgeSearchIfNeeded] 未找到用户消息');
+      knowledgeLogger.warn('未找到用户消息');
       return null;
     }
 
     // 获取用户消息的文本内容
     const userContent = getMainTextContent(userMessage);
     if (!userContent) {
-      console.warn('[performKnowledgeSearchIfNeeded] 用户消息内容为空');
+      knowledgeLogger.warn('用户消息内容为空');
       return null;
     }
 
-    console.log('[performKnowledgeSearchIfNeeded] 用户消息内容:', userContent);
+    knowledgeLogger.debug('用户消息内容:', userContent);
 
     // 并行搜索所有选中的知识库
     const knowledgeService = MobileKnowledgeService.getInstance();
@@ -116,7 +120,7 @@ export const performKnowledgeSearchIfNeeded = async (
         });
         return { kb, results };
       } catch (err) {
-        console.warn(`[performKnowledgeSearchIfNeeded] 知识库 "${kb.name}" 搜索失败:`, err);
+        knowledgeLogger.warn(`知识库 "${kb.name}" 搜索失败:`, err);
         return { kb, results: [] };
       }
     });
@@ -146,7 +150,7 @@ export const performKnowledgeSearchIfNeeded = async (
     allReferences.forEach((ref, i) => { ref.id = i + 1; });
 
     const totalResults = allReferences.length;
-    console.log(`[performKnowledgeSearchIfNeeded] 并行搜索完成: ${knowledgeBasesToSearch.length} 个知识库, ${totalResults} 个结果`);
+    knowledgeLogger.debug(`并行搜索完成: ${knowledgeBasesToSearch.length} 个知识库, ${totalResults} 个结果`);
 
     if (totalResults > 0) {
       // 发送知识库搜索完成事件
@@ -165,7 +169,7 @@ export const performKnowledgeSearchIfNeeded = async (
 
     return totalResults > 0 ? allReferences : null;
   } catch (error) {
-    console.error('[performKnowledgeSearchIfNeeded] 知识库搜索失败:', error);
+    knowledgeLogger.error('知识库搜索失败:', error);
     store.dispatch(clearSelectedKnowledgeBase());
     return null;
   }
@@ -181,17 +185,17 @@ export const prepareMessagesForApi = async (
     knowledgeReferences?: KnowledgeSearchReference[]; // 提前搜索好的知识库引用，注入到当前用户提问
   }
 ) => {
-  console.log('[prepareMessagesForApi] 开始准备API消息', { topicId, assistantMessageId });
+  logger.debug('开始准备API消息', { topicId, assistantMessageId });
 
   // 获取上下文设置（类似 Roo Code 的 manageContext）
   const { contextCount, contextWindowSize, maxOutputTokens } = await getContextSettings();
-  console.log(`[prepareMessagesForApi] 上下文设置: contextCount=${contextCount}, contextWindowSize=${contextWindowSize}, maxOutputTokens=${maxOutputTokens}`);
+  logger.debug(`上下文设置: contextCount=${contextCount}, contextWindowSize=${contextWindowSize}, maxOutputTokens=${maxOutputTokens}`);
 
   // 3. 获取包含content字段的消息
   // 优先使用传入的 messages，避免重复查询数据库
   const messages = options?.messages || await dexieStorage.getTopicMessages(topicId);
   if (options?.messages) {
-    console.log(`[prepareMessagesForApi] 使用缓存的消息列表，消息数: ${messages.length}`);
+    logger.debug(`使用缓存的消息列表，消息数: ${messages.length}`);
   }
 
   // messages 已按 topic.messageIds 插入顺序排列（getTopicMessages），无需再按时间戳排序
@@ -221,7 +225,7 @@ export const prepareMessagesForApi = async (
   // 如果找到了 clear 消息，只保留 clear 消息之后的消息
   if (clearIndex !== -1) {
     contextFilteredMessages = contextFilteredMessages.slice(clearIndex + 1);
-    console.log(`[prepareMessagesForApi] 发现 clear 消息，过滤后消息数: ${contextFilteredMessages.length}`);
+    logger.debug(`发现 clear 消息，过滤后消息数: ${contextFilteredMessages.length}`);
   }
 
   // 然后应用 contextCount 限制（使用 takeRight 逻辑）
@@ -232,7 +236,7 @@ export const prepareMessagesForApi = async (
     ? contextFilteredMessages  // 无限制
     : contextFilteredMessages.slice(-actualMessageCount);
   
-  console.log(`[prepareMessagesForApi] 消息轮数限制: 原始消息数=${messages.length}, 过滤后消息数=${contextFilteredMessages.length}, 限制后消息数=${limitedMessages.length}, 设置轮数=${contextCount}`);
+  logger.debug(`消息轮数限制: 原始消息数=${messages.length}, 过滤后消息数=${contextFilteredMessages.length}, 限制后消息数=${limitedMessages.length}, 设置轮数=${contextCount}`);
 
   // 类似 Roo Code：如果设置了上下文窗口大小，应用 Token 限制
   if (contextWindowSize > 0) {
@@ -244,7 +248,7 @@ export const prepareMessagesForApi = async (
     // 只有当 allowedTokens 为正数时才进行限制
     if (allowedTokens > 0) {
       let currentTokens = estimateMessagesTokenCount(limitedMessages);
-      console.log(`[prepareMessagesForApi] Token 检查: ${currentTokens}/${allowedTokens} (窗口: ${contextWindowSize})`);
+      logger.debug(`Token 检查: ${currentTokens}/${allowedTokens} (窗口: ${contextWindowSize})`);
       
       // 如果超出限制，进行滑动窗口截断（最多尝试 10 次，避免无限循环）
       let attempts = 0;
@@ -255,16 +259,16 @@ export const prepareMessagesForApi = async (
         
         // 如果消息数没有减少，退出循环
         if (limitedMessages.length >= prevLength) {
-          console.log(`[prepareMessagesForApi] 无法继续截断，退出`);
+          logger.debug(`无法继续截断，退出`);
           break;
         }
         
         currentTokens = estimateMessagesTokenCount(limitedMessages);
-        console.log(`[prepareMessagesForApi] 滑动窗口截断后: Token=${currentTokens}/${allowedTokens}, 消息数=${limitedMessages.length}`);
+        logger.debug(`滑动窗口截断后: Token=${currentTokens}/${allowedTokens}, 消息数=${limitedMessages.length}`);
         attempts++;
       }
     } else {
-      console.log(`[prepareMessagesForApi] 跳过 Token 限制: allowedTokens=${allowedTokens} (窗口太小或输出 Token 太大)`);
+      logger.debug(`跳过 Token 限制: allowedTokens=${allowedTokens} (窗口太小或输出 Token 太大)`);
     }
   }
 
@@ -294,14 +298,14 @@ export const prepareMessagesForApi = async (
     let enabledSkills: import('../../../types/Skill').Skill[] = [];
     try {
       if (assistant.skillIds?.length) {
-        console.log(`[prepareMessagesForApi] 助手有 ${assistant.skillIds.length} 个绑定技能 ID:`, assistant.skillIds);
+        logger.debug(`助手有 ${assistant.skillIds.length} 个绑定技能 ID:`, assistant.skillIds);
         enabledSkills = await SkillManager.getSkillsForAssistant(assistant.id);
-        console.log(`[prepareMessagesForApi] 获取到 ${enabledSkills.length} 个已启用技能:`, enabledSkills.map(s => s.name));
+        logger.debug(`获取到 ${enabledSkills.length} 个已启用技能:`, enabledSkills.map(s => s.name));
       } else {
-        console.log(`[prepareMessagesForApi] 助手没有绑定技能 (skillIds=${JSON.stringify(assistant.skillIds)})`);
+        logger.debug(`助手没有绑定技能 (skillIds=${JSON.stringify(assistant.skillIds)})`);
       }
     } catch (error) {
-      console.warn('[prepareMessagesForApi] 获取技能信息失败，降级到无技能模式:', error);
+      logger.warn('获取技能信息失败，降级到无技能模式:', error);
     }
 
     // 使用 SkillPromptBuilder 统一组装 system prompt（OpenClaw 风格精简列表）
@@ -335,7 +339,7 @@ export const prepareMessagesForApi = async (
   const regexRules: AssistantRegex[] = assistant?.regexRules || [];
   const hasRegexRules = regexRules.length > 0;
   if (hasRegexRules) {
-    console.log(`[prepareMessagesForApi] 检测到 ${regexRules.length} 条正则规则`);
+    logger.debug(`检测到 ${regexRules.length} 条正则规则`);
   }
 
   // 知识库引用注入到上下文中最后一条用户消息（即当前提问）
@@ -350,7 +354,7 @@ export const prepareMessagesForApi = async (
       const originalContent = content;
       content = applyRegexRulesForSending(content, regexRules, scope);
       if (content !== originalContent) {
-        console.log(`[prepareMessagesForApi] 对 ${scope} 消息应用了正则规则`);
+        logger.debug(`对 ${scope} 消息应用了正则规则`);
       }
     }
 
@@ -362,7 +366,7 @@ export const prepareMessagesForApi = async (
       options?.knowledgeReferences?.length
     ) {
       content = applyKnowledgeReferences(content, options.knowledgeReferences);
-      console.log(`[prepareMessagesForApi] 为消息 ${message.id} 注入知识库引用，数量: ${options.knowledgeReferences.length}`);
+      logger.debug(`为消息 ${message.id} 注入知识库引用，数量: ${options.knowledgeReferences.length}`);
     }
 
     // 检查是否有文件或图片块
@@ -383,7 +387,7 @@ export const prepareMessagesForApi = async (
           })
           .join('\n\n');
         content = (content || '') + '\n\n' + toolUseTags;
-        console.log(`[prepareMessagesForApi] 为 assistant 消息添加工具调用标签，工具数量: ${toolBlocksForContent.length}`);
+        logger.debug(`为 assistant 消息添加工具调用标签，工具数量: ${toolBlocksForContent.length}`);
       }
     }
 
@@ -442,7 +446,7 @@ export const prepareMessagesForApi = async (
                 });
               }
             } catch (error) {
-              console.error(`[prepareMessagesForApi] 读取文件内容失败:`, error);
+              logger.error(`读取文件内容失败:`, error);
             }
           }
         }
@@ -487,7 +491,7 @@ export const prepareMessagesForApi = async (
             role: 'user',
             content: toolResults
           });
-          console.log(`[prepareMessagesForApi] 添加工具结果消息，工具数量: ${toolBlocks.length}`);
+          logger.debug(`添加工具结果消息，工具数量: ${toolBlocks.length}`);
         }
       }
     }
@@ -515,12 +519,12 @@ export const prepareMessagesForApi = async (
           if (memories.length > 0) {
             const memoryPrompt = buildMemoryPrompt(memories);
             processedSystemPrompt = processedSystemPrompt + '\n' + memoryPrompt;
-            console.log(`[prepareMessagesForApi] 已注入 ${memories.length} 条相关记忆到系统提示词`);
+            logger.debug(`已注入 ${memories.length} 条相关记忆到系统提示词`);
           }
         }
       }
     } catch (error) {
-      console.error('[prepareMessagesForApi] 记忆搜索失败:', error);
+      logger.error('记忆搜索失败:', error);
     }
   }
 
@@ -529,7 +533,7 @@ export const prepareMessagesForApi = async (
     content: processedSystemPrompt
   });
 
-  console.log(`[prepareMessagesForApi] 准备完成，系统提示词长度: ${processedSystemPrompt.length}，API消息数量: ${apiMessages.length}，上下文限制: ${contextCount}`);
+  logger.debug(`准备完成，系统提示词长度: ${processedSystemPrompt.length}，API消息数量: ${apiMessages.length}，上下文限制: ${contextCount}`);
 
   return apiMessages;
 };

--- a/src/shared/store/thunks/message/assistantResponse.ts
+++ b/src/shared/store/thunks/message/assistantResponse.ts
@@ -49,6 +49,14 @@ import {
   prepareOriginalMessages,
   extractGeminiSystemPrompt
 } from './helpers';
+import { createLogger } from '../../../services/infra/logger';
+
+const logger = createLogger('processAssistantResponse');
+const mcpLogger = logger.withContext('MCP');
+const webSearchLogger = logger.withContext('WebSearch');
+const agenticLogger = logger.withContext('Agentic');
+const sendMessageLogger = logger.withContext('sendMessage');
+const memoryLogger = logger.withContext('Memory');
 
 /**
  * 处理文本生成响应
@@ -82,19 +90,19 @@ async function handleTextGeneration(context: {
     ? [...filteredOriginalMessages]
     : [...apiMessages];
 
-  console.log(`[processAssistantResponse] Provider类型: ${model.provider}, 使用${isActualGeminiProvider ? '原始' : 'API'}格式消息，消息数量: ${currentMessagesToSend.length}`);
+  logger.debug(`Provider类型: ${model.provider}, 使用${isActualGeminiProvider ? '原始' : 'API'}格式消息，消息数量: ${currentMessagesToSend.length}`);
 
   // 获取 MCP 模式设置（统一使用 Dexie 存储）
   const savedMcpMode = await dexieStorage.getSetting('mcp-mode');
   const mcpMode: 'prompt' | 'function' = (savedMcpMode === 'prompt' || savedMcpMode === 'function') ? savedMcpMode : 'function';
-  console.log(`[MCP] 当前模式: ${mcpMode}`);
+  mcpLogger.debug(`当前模式: ${mcpMode}`);
 
   // 准备工具列表（包含网络搜索工具）
   let allTools = [...mcpTools];
   if (webSearchTool && webSearchProviderId) {
     const webSearchMcpTool = createWebSearchMcpTool(webSearchTool, webSearchProviderId, extractedKeywords);
     allTools.push(webSearchMcpTool);
-    console.log('[WebSearch] 网络搜索工具已添加到工具列表，AI 可自主决定是否调用');
+    webSearchLogger.debug('网络搜索工具已添加到工具列表，AI 可自主决定是否调用');
   }
 
   // 提取系统提示词（所有供应商都需要）
@@ -132,16 +140,16 @@ async function handleTextGeneration(context: {
 
     // 收集工具调用结果
     const toolResults = await collectToolResults(assistantMessage.id, consumedBlockIds);
-    console.log(`[Agentic] 收集到 ${toolResults.length} 个工具结果`);
+    agenticLogger.debug(`收集到 ${toolResults.length} 个工具结果`);
 
     if (toolResults.length === 0) {
       // AI 没有使用任何工具，增加错误计数并注入提醒消息
       const mistakeCount = incrementMistakeCount();
-      console.log(`[Agentic] AI 没有使用工具，连续错误次数: ${mistakeCount}`);
+      agenticLogger.debug(`AI 没有使用工具，连续错误次数: ${mistakeCount}`);
 
       // 检查是否达到错误限制
       if (hasReachedMistakeLimit()) {
-        console.log(`[Agentic] 达到连续错误限制，结束循环`);
+        agenticLogger.debug(`达到连续错误限制，结束循环`);
         break;
       }
 
@@ -150,11 +158,11 @@ async function handleTextGeneration(context: {
       if (assistantContent) {
         const assistantMsg = buildAssistantMessage(assistantContent, isActualGeminiProvider);
         currentMessagesToSend = [...currentMessagesToSend, assistantMsg];
-        console.log(`[Agentic] 添加 AI 回复到消息历史: ${assistantContent.substring(0, 100)}...`);
+        agenticLogger.debug(`添加 AI 回复到消息历史: ${assistantContent.substring(0, 100)}...`);
       }
 
       // 注入提醒消息，让 AI 继续
-      console.log(`[Agentic] 注入提醒消息，要求 AI 使用工具`);
+      agenticLogger.debug(`注入提醒消息，要求 AI 使用工具`);
       const reminderMessage = buildNoToolsUsedMessage(isActualGeminiProvider);
       currentMessagesToSend = [...currentMessagesToSend, reminderMessage];
       
@@ -174,7 +182,7 @@ async function handleTextGeneration(context: {
 
     // 检查是否应该继续
     if (!shouldContinueLoop()) {
-      console.log(`[Agentic] 循环终止条件满足，结束循环`);
+      agenticLogger.debug(`循环终止条件满足，结束循环`);
       break;
     }
 
@@ -185,11 +193,11 @@ async function handleTextGeneration(context: {
     if (assistantContent) {
       const assistantMsg = buildAssistantMessage(assistantContent, isActualGeminiProvider);
       currentMessagesToSend = [...currentMessagesToSend, assistantMsg];
-      console.log(`[Agentic] 添加 AI 的 assistant 消息（含工具调用）到消息历史`);
+      agenticLogger.debug(`添加 AI 的 assistant 消息（含工具调用）到消息历史`);
     }
 
     // 将工具结果添加到消息历史
-    console.log(`[Agentic] 工具执行完成，将结果发回 AI 继续下一轮`);
+    agenticLogger.debug(`工具执行完成，将结果发回 AI 继续下一轮`);
     currentMessagesToSend = buildMessagesWithToolResults(
       currentMessagesToSend,
       toolResults,
@@ -224,7 +232,7 @@ export const processAssistantResponse = async (
 
     // 3. 创建占位符块
     const placeholderBlock = createPlaceholderBlock(assistantMessage.id);
-    console.log(`[sendMessage] 创建占位符块: ${placeholderBlock.id}`);
+    sendMessageLogger.debug(`创建占位符块: ${placeholderBlock.id}`);
 
     await messageBlockRepository.createBlockAndAttach(placeholderBlock);
 
@@ -250,7 +258,7 @@ export const processAssistantResponse = async (
     // 9. 准备消息（参考 Cherry-Studio：一次加载，多格式输出）
     // 只加载一次消息列表
     const messages = await dexieStorage.getTopicMessages(topicId);
-    console.log(`[processAssistantResponse] 加载消息列表，消息数: ${messages.length}`);
+    logger.debug(`加载消息列表，消息数: ${messages.length}`);
 
     // 传递给两个函数，避免重复查询
     const apiMessages = await prepareMessagesForApi(topicId, assistantMessage.id, mcpTools, {
@@ -350,12 +358,12 @@ export const processAssistantResponse = async (
                 .filter(Boolean);
               // 异步提取记忆，不阻塞响应
               extractAndSaveMemories(userContent, finalContent, assistant?.id, priorMessages).catch(err => {
-                console.error('[Memory] 自动记忆提取失败:', err);
+                memoryLogger.error('自动记忆提取失败:', err);
               });
             }
           }
         } catch (memError) {
-          console.error('[Memory] 记忆提取过程出错:', memError);
+          memoryLogger.error('记忆提取过程出错:', memError);
         }
       }
 
@@ -365,7 +373,7 @@ export const processAssistantResponse = async (
       cancelAgenticLoop();
 
       if (error?.name === 'AbortError' || error?.message?.includes('aborted')) {
-        console.log('[processAssistantResponse] 请求被用户中断');
+        logger.debug('请求被用户中断');
         return await responseHandler.completeWithInterruption();
       }
 
@@ -377,7 +385,7 @@ export const processAssistantResponse = async (
     }
 
   } catch (error) {
-    console.error('处理助手响应失败:', error);
+    logger.error('处理助手响应失败:', error);
 
     dispatch(newMessagesActions.setTopicLoading({ topicId, loading: false }));
     dispatch(newMessagesActions.setTopicStreaming({ topicId, streaming: false }));

--- a/src/shared/store/thunks/message/helpers/agenticLoop.ts
+++ b/src/shared/store/thunks/message/helpers/agenticLoop.ts
@@ -12,6 +12,9 @@ import {
   getTooManyMistakesMessage,
   getMaxIterationsReachedMessage 
 } from '../../../../prompts/agentic/sections/responses';
+import { createLogger } from '../../../../services/infra/logger';
+
+const logger = createLogger('Agentic');
 
 /**
  * 工具调用结果类型
@@ -41,7 +44,7 @@ export function checkAgenticMode(mcpTools: { serverName?: string }[]): boolean {
  * 启动 Agentic 循环
  */
 export function startAgenticLoop(topicId: string): void {
-  console.log(`[Agentic] 检测到 @aether/file-editor，启用 Agentic 模式`);
+  logger.debug(`检测到 @aether/file-editor，启用 Agentic 模式`);
   agenticLoopService.startLoop(topicId);
   // 启用文件跟踪器
   agenticFileTracker.enable(topicId);
@@ -205,7 +208,7 @@ export function buildMessagesWithToolResults(
 export function processAgenticIteration(): number {
   if (agenticLoopService.getState().isAgenticMode) {
     const iteration = agenticLoopService.startIteration();
-    console.log(`[Agentic] 开始第 ${iteration} 次迭代`);
+    logger.debug(`开始第 ${iteration} 次迭代`);
     return iteration;
   }
   return 0;
@@ -243,7 +246,7 @@ export function handleCompletionSignal(completionResult: ToolCallResultInfo): vo
     isCompletion: true,
     content: completionResult
   });
-  console.log(`[Agentic] 检测到 attempt_completion，任务完成`);
+  logger.debug(`检测到 attempt_completion，任务完成`);
 }
 
 /**
@@ -259,7 +262,7 @@ export function shouldContinueLoop(): boolean {
 export function endAgenticLoop(): void {
   if (agenticLoopService.getState().isAgenticMode) {
     const finalState = agenticLoopService.endLoop();
-    console.log(`[Agentic] 循环结束:`, {
+    logger.debug(`循环结束:`, {
       totalIterations: finalState.currentIteration,
       completionReason: finalState.completionReason,
       hasCompletionResult: !!finalState.completionResult
@@ -273,7 +276,7 @@ export function endAgenticLoop(): void {
 export function cancelAgenticLoop(): void {
   if (agenticLoopService.getState().isAgenticMode) {
     agenticLoopService.cancel();
-    console.log(`[Agentic] 由于错误取消循环`);
+    logger.debug(`由于错误取消循环`);
   }
 }
 

--- a/src/shared/store/thunks/message/helpers/assistantHelpers.ts
+++ b/src/shared/store/thunks/message/helpers/assistantHelpers.ts
@@ -2,6 +2,9 @@
  * 助手信息获取辅助函数
  */
 import { dexieStorage } from '../../../../services/storage/DexieStorageService';
+import { createLogger } from '../../../../services/infra/logger';
+
+const logger = createLogger('processAssistantResponse');
 
 /**
  * 获取助手信息
@@ -11,7 +14,7 @@ export async function fetchAssistantInfo(topicId: string): Promise<any> {
     const topic = await dexieStorage.getTopic(topicId);
     if (topic?.assistantId) {
       const assistant = await dexieStorage.getAssistant(topic.assistantId);
-      console.log(`[processAssistantResponse] 获取到助手信息:`, {
+      logger.debug(`获取到助手信息:`, {
         id: assistant?.id,
         name: assistant?.name,
         temperature: assistant?.temperature,
@@ -22,7 +25,7 @@ export async function fetchAssistantInfo(topicId: string): Promise<any> {
       return assistant;
     }
   } catch (error) {
-    console.error('[processAssistantResponse] 获取助手信息失败:', error);
+    logger.error('获取助手信息失败:', error);
   }
   return null;
 }

--- a/src/shared/store/thunks/message/helpers/imageGeneration.ts
+++ b/src/shared/store/thunks/message/helpers/imageGeneration.ts
@@ -10,7 +10,10 @@ import { messageBlockRepository } from '../../../../services/messages/MessageBlo
 import { isGeminiModel as isGeminiProvider } from '../../../../../config/models';
 import type { Model } from '../../../../types';
 import type { Message } from '../../../../types/newMessage';
+import { createLogger } from '../../../../services/infra/logger';
 import type { AppDispatch } from '../../../index';
+
+const logger = createLogger('imageGeneration');
 
 interface ImageGenerationContext {
   dispatch: AppDispatch;
@@ -71,7 +74,7 @@ async function saveBase64Image(
     });
     return `[图片:${imageId}]`;
   } catch (error) {
-    console.error('保存生成的图片失败，使用原始base64:', error);
+    logger.error('保存生成的图片失败，使用原始base64:', error);
     return imageUrl;
   }
 }

--- a/src/shared/store/thunks/message/helpers/mcpHelpers.ts
+++ b/src/shared/store/thunks/message/helpers/mcpHelpers.ts
@@ -8,6 +8,11 @@ import { MCP_BRIDGE_TOOL_DEFINITION } from '../../../../services/mcp/McpBridgeTo
 import { READ_SKILL_TOOL_DEFINITION } from '../../../../services/skills/SkillReadTool';
 import { getStorageItem } from '../../../../utils/storage';
 import type { MCPTool } from '../../../../types';
+import { createLogger } from '../../../../services/infra/logger';
+
+const logger = createLogger('MCP');
+const memoryLogger = logger.withContext('Memory');
+const skillLogger = logger.withContext('Skill');
 
 /**
  * 获取 MCP 工具
@@ -18,14 +23,14 @@ export async function fetchMcpTools(toolsEnabled?: boolean, hasSkills?: boolean)
   // 技能独立开关（与 MCP 总开关分离，统一使用 Dexie 存储）
   const skillsEnabled = (await getStorageItem<boolean>('skills-enabled')) ?? false;
   const shouldInjectSkills = skillsEnabled && hasSkills;
-  console.log(`[MCP] fetchMcpTools 参数: toolsEnabled=${toolsEnabled}, hasSkills=${hasSkills}, skillsEnabled=${skillsEnabled}, shouldInjectSkills=${shouldInjectSkills}`);
+  logger.debug(`fetchMcpTools 参数: toolsEnabled=${toolsEnabled}, hasSkills=${hasSkills}, skillsEnabled=${skillsEnabled}, shouldInjectSkills=${shouldInjectSkills}`);
 
   if (!toolsEnabled) {
     if (shouldInjectSkills) {
-      console.log(`[MCP] MCP 工具未启用，但技能已开启 — 仅注入 read_skill`);
+      logger.debug(`MCP 工具未启用，但技能已开启 — 仅注入 read_skill`);
       return [READ_SKILL_TOOL_DEFINITION];
     }
-    console.log(`[MCP] 工具未启用 (toolsEnabled=${toolsEnabled})`);
+    logger.debug(`工具未启用 (toolsEnabled=${toolsEnabled})`);
     return [];
   }
 
@@ -33,49 +38,49 @@ export async function fetchMcpTools(toolsEnabled?: boolean, hasSkills?: boolean)
   const bridgeMode = await getStorageItem<boolean>('mcp-bridge-mode');
   if (bridgeMode) {
     const allServers = await mcpService.getServersAsync();
-    console.log(`[MCP] 桥梁模式激活 — 仅注入 mcp_bridge 工具（替代 ${allServers.length} 个服务器的所有工具）`);
+    logger.debug(`桥梁模式激活 — 仅注入 mcp_bridge 工具（替代 ${allServers.length} 个服务器的所有工具）`);
     const tools: MCPTool[] = [MCP_BRIDGE_TOOL_DEFINITION];
 
     // 记忆工具仍然正常注入（它不是 MCP server 工具）
     if (isMemoryToolEnabled()) {
       const memoryTools = getMemoryToolDefinitions();
       tools.push(...memoryTools);
-      console.log(`[Memory] 添加 ${memoryTools.length} 个记忆工具`);
+      memoryLogger.debug(`添加 ${memoryTools.length} 个记忆工具`);
     }
 
     // read_skill 独立注入（受技能开关控制）
     if (shouldInjectSkills) {
       tools.push(READ_SKILL_TOOL_DEFINITION);
-      console.log(`[Skill] 添加 read_skill 工具`);
+      skillLogger.debug(`添加 read_skill 工具`);
     }
 
     return tools;
   }
 
   try {
-    console.log(`[MCP] 开始获取工具，可能需要连接网络服务器...`);
+    logger.debug(`开始获取工具，可能需要连接网络服务器...`);
     const mcpTools = await mcpService.getAllAvailableTools();
     
     // 如果记忆工具开关开启，添加记忆工具
     if (isMemoryToolEnabled()) {
       const memoryTools = getMemoryToolDefinitions();
       mcpTools.push(...memoryTools);
-      console.log(`[Memory] 添加 ${memoryTools.length} 个记忆工具`);
+      memoryLogger.debug(`添加 ${memoryTools.length} 个记忆工具`);
     }
 
     // read_skill 独立注入（受技能开关控制）
     if (shouldInjectSkills) {
       mcpTools.push(READ_SKILL_TOOL_DEFINITION);
-      console.log(`[Skill] 添加 read_skill 工具`);
+      skillLogger.debug(`添加 read_skill 工具`);
     }
     
-    console.log(`[MCP] 获取到 ${mcpTools.length} 个可用工具`);
+    logger.debug(`获取到 ${mcpTools.length} 个可用工具`);
     if (mcpTools.length > 0) {
-      console.log(`[MCP] 工具列表:`, mcpTools.map(t => t.name || t.id).join(', '));
+      logger.debug(`工具列表:`, mcpTools.map(t => t.name || t.id).join(', '));
     }
     return mcpTools;
   } catch (error) {
-    console.error('[MCP] 获取工具失败:', error);
+    logger.error('获取工具失败:', error);
     return [];
   }
 }

--- a/src/shared/store/thunks/message/helpers/messagePreparation.ts
+++ b/src/shared/store/thunks/message/helpers/messagePreparation.ts
@@ -3,6 +3,9 @@
  */
 import { dexieStorage } from '../../../../services/storage/DexieStorageService';
 import type { Message } from '../../../../types/newMessage';
+import { createLogger } from '../../../../services/infra/logger';
+
+const logger = createLogger('prepareOriginalMessages');
 
 /**
  * 准备原始消息（用于 Gemini provider）
@@ -18,7 +21,7 @@ export async function prepareOriginalMessages(
   // 优先使用缓存的消息，避免重复查询
   const originalMessages = cachedMessages || await dexieStorage.getTopicMessages(topicId);
   if (cachedMessages) {
-    console.log(`[prepareOriginalMessages] 使用缓存的消息列表，消息数: ${originalMessages.length}`);
+    logger.debug(`使用缓存的消息列表，消息数: ${originalMessages.length}`);
   }
   
   const sortedMessages = [...originalMessages].sort((a, b) =>

--- a/src/shared/store/thunks/message/helpers/webSearchTool.ts
+++ b/src/shared/store/thunks/message/helpers/webSearchTool.ts
@@ -17,6 +17,9 @@ import type { MCPTool } from '../../../../types';
 import type { Message } from '../../../../types/newMessage';
 import { MessageBlockType } from '../../../../types/newMessage';
 import type { RootState } from '../../../index';
+import { createLogger } from '../../../../services/infra/logger';
+
+const logger = createLogger('SearchTools');
 
 export interface WebSearchConfig {
   webSearchTool: any | null;
@@ -145,7 +148,7 @@ export async function configureSearchTools(
       result.extractedKeywords = { question: [userContent] };
       result.webSearchTool = createWebSearchToolDefinition(result.extractedKeywords);
     }
-    console.log('[SearchTools] AI 意图分析已关闭，直接注入工具');
+    logger.debug('AI 意图分析已关闭，直接注入工具');
     return result;
   }
 
@@ -155,7 +158,7 @@ export async function configureSearchTools(
     shouldKnowledgeSearch
   };
 
-  console.log('[SearchTools] 开始统一意图分析:', analysisOptions);
+  logger.debug('开始统一意图分析:', analysisOptions);
 
   const intentResult = await analyzeUnifiedSearchIntent(
     userContent,
@@ -171,13 +174,13 @@ export async function configureSearchTools(
   if (intentResult.websearch) {
     result.extractedKeywords = intentResult.websearch;
     result.webSearchTool = createWebSearchToolDefinition(result.extractedKeywords);
-    console.log('[SearchTools] Web 搜索关键词:', result.extractedKeywords.question);
+    logger.debug('Web 搜索关键词:', result.extractedKeywords.question);
   }
 
   // 知识库搜索关键词（传递给知识库搜索流程使用）
   if (intentResult.knowledge) {
     result.knowledgeKeywords = intentResult.knowledge;
-    console.log('[SearchTools] 知识库搜索关键词:', result.knowledgeKeywords.question);
+    logger.debug('知识库搜索关键词:', result.knowledgeKeywords.question);
   }
 
   return result;

--- a/src/shared/store/thunks/message/memoryIntegration.ts
+++ b/src/shared/store/thunks/message/memoryIntegration.ts
@@ -6,6 +6,9 @@ import store from '../../index';
 import { memoryService } from '../../../services/memory/MemoryService';
 import { MemoryProcessor, type MemoryProcessorConfig } from '../../../services/memory/MemoryProcessor';
 import { setCurrentAssistantId } from '../../slices/memorySlice';
+import { createLogger } from '../../../services/infra/logger';
+
+const logger = createLogger('Memory');
 
 /**
  * 创建 MemoryProcessor 实例
@@ -113,13 +116,13 @@ export async function searchRelevantMemories(
     });
     
     if (results.memories.length > 0) {
-      console.log(`[Memory] 找到 ${results.memories.length} 条相关记忆`);
+      logger.debug(`找到 ${results.memories.length} 条相关记忆`);
       return results.memories.map(m => m.memory);
     }
     
     return [];
   } catch (error) {
-    console.error('[Memory] 搜索记忆失败:', error);
+    logger.error('搜索记忆失败:', error);
     return [];
   }
 }
@@ -159,7 +162,7 @@ export async function extractAndSaveMemories(
   const assistantId = assistantIdOverride || getCurrentAssistantId();
   const processor = getMemoryProcessor(assistantId);
   if (!processor) {
-    console.log('[Memory] MemoryProcessor 未初始化，跳过记忆提取');
+    logger.debug('MemoryProcessor 未初始化，跳过记忆提取');
     return;
   }
   
@@ -176,10 +179,10 @@ export async function extractAndSaveMemories(
     const result = await processor.processConversation(messages);
     
     if (result.addedCount > 0) {
-      console.log(`[Memory] 成功提取并保存 ${result.addedCount} 条新记忆`);
+      logger.info(`成功提取并保存 ${result.addedCount} 条新记忆`);
     }
   } catch (error) {
-    console.error('[Memory] 提取记忆失败:', error);
+    logger.error('提取记忆失败:', error);
   }
 }
 

--- a/src/shared/store/thunks/message/messageOperations.ts
+++ b/src/shared/store/thunks/message/messageOperations.ts
@@ -8,10 +8,13 @@ import { refreshTopicPreview } from '../../../services/topics/TopicPreviewServic
 import { processAssistantResponse } from './assistantResponse';
 import { versionService } from '../../../services/messages/VersionService';
 import { getModelIdentityKey } from '../../../utils/modelUtils';
+import { createLogger } from '../../../services/infra/logger';
 import type { Message } from '../../../types/newMessage';
 import type { Model } from '../../../types';
 import type { RootState, AppDispatch } from '../../index';
 import { AssistantMessageStatus } from '../../../types/newMessage';
+
+const logger = createLogger('regenerateResponse');
 
 /**
  * 统一的重新生成选项接口
@@ -92,7 +95,7 @@ export const deleteMessage = (messageId: string, topicId: string) => async (disp
 
     return true;
   } catch (error) {
-    console.error(`删除消息失败:`, error);
+    logger.error(`删除消息失败:`, error);
     throw error;
   }
 };
@@ -108,7 +111,7 @@ export const regenerateResponse = (options: RegenerateOptions) =>
   async (dispatch: AppDispatch, getState: () => RootState) => {
     const { messageId, topicId, model, source, saveVersion = true } = options;
     
-    console.log(`[regenerateResponse] 开始重新生成响应`, {
+    logger.debug(`开始重新生成响应`, {
       messageId,
       topicId,
       source,
@@ -156,7 +159,7 @@ export const regenerateResponse = (options: RegenerateOptions) =>
 
       return true;
     } catch (error) {
-      console.error(`[regenerateResponse] 重新生成失败:`, error);
+      logger.error(`重新生成失败:`, error);
 
       // 清除加载状态
       dispatch(newMessagesActions.setTopicLoading({ topicId, loading: false }));
@@ -252,12 +255,12 @@ async function saveMessageVersionIfNeeded(message: Message): Promise<Message> {
     // 重新获取消息以获取最新的版本信息
     const messageWithVersions = await dexieStorage.getMessage(message.id);
     if (messageWithVersions) {
-      console.log(`[regenerateResponse] 版本数: ${messageWithVersions.versions?.length || 0}`);
+      logger.debug(`版本数: ${messageWithVersions.versions?.length || 0}`);
       return messageWithVersions;
     }
     return message;
   } catch (versionError) {
-    console.error(`[regenerateResponse] 保存版本失败:`, versionError);
+    logger.error(`保存版本失败:`, versionError);
     return message; // 版本保存失败不影响主流程
   }
 }
@@ -290,7 +293,7 @@ async function resetAssistantMessageForRegenerate(
     currentVersionId: undefined
   };
 
-  console.log(`[regenerateResponse] 消息已重置`, {
+  logger.debug(`消息已重置`, {
     messageId: resetMessage.id,
     newModelId: resetMessage.modelId,
     newModelName: resetMessage.model?.name

--- a/src/shared/store/thunks/message/sendMessage.ts
+++ b/src/shared/store/thunks/message/sendMessage.ts
@@ -8,6 +8,9 @@ import { saveMessageAndBlocksToDB } from './utils';
 import { processAssistantResponse } from './assistantResponse';
 import { AssistantMessageStatus } from '../../../types/newMessage';
 import { getModelIdentityKey } from '../../../utils/modelUtils';
+import { createLogger } from '../../../services/infra/logger';
+
+const logger = createLogger('sendMessage');
 
 export const sendMessage = (
   content: string,
@@ -78,7 +81,7 @@ export const sendMessage = (
 
     return userMessage.id;
   } catch (error) {
-    console.error('发送消息失败:', error);
+    logger.error('发送消息失败:', error);
 
     // 清除加载状态
     dispatch(newMessagesActions.setTopicLoading({ topicId, loading: false }));

--- a/src/shared/store/thunks/message/utils.ts
+++ b/src/shared/store/thunks/message/utils.ts
@@ -2,6 +2,9 @@ import { dexieStorage } from '../../../services/storage/DexieStorageService';
 import { throttle } from 'lodash';
 import type { Message, MessageBlock } from '../../../types/newMessage';
 import { refreshTopicPreview } from '../../../services/topics/TopicPreviewService';
+import { createLogger } from '../../../services/infra/logger';
+
+const logger = createLogger('saveMessageAndBlocksToDB');
 
 export const saveMessageAndBlocksToDB = async (message: Message, blocks: MessageBlock[]) => {
   try {
@@ -30,9 +33,9 @@ export const saveMessageAndBlocksToDB = async (message: Message, blocks: Message
         // 如果消息不存在，添加到messageIds数组
         if (!topic.messageIds.includes(message.id)) {
           topic.messageIds.push(message.id);
-          console.log(`[saveMessageAndBlocksToDB] 添加新消息 ${message.id} 到话题 ${topic.id}`);
+          logger.debug(`添加新消息 ${message.id} 到话题 ${topic.id}`);
         } else {
-          console.log(`[saveMessageAndBlocksToDB] 消息 ${message.id} 已存在于话题 ${topic.id}`);
+          logger.debug(`消息 ${message.id} 已存在于话题 ${topic.id}`);
         }
 
         // 更新话题的lastMessageTime
@@ -40,7 +43,7 @@ export const saveMessageAndBlocksToDB = async (message: Message, blocks: Message
 
         // 保存更新后的话题
         await dexieStorage.topics.put(topic);
-        console.log(`[saveMessageAndBlocksToDB] 话题 ${topic.id} 现有 ${topic.messageIds.length} 条消息`);
+        logger.debug(`话题 ${topic.id} 现有 ${topic.messageIds.length} 条消息`);
       }
     });
 
@@ -48,7 +51,7 @@ export const saveMessageAndBlocksToDB = async (message: Message, blocks: Message
     // 与消息主流程解耦，失败不影响保存。
     void refreshTopicPreview(message.topicId);
   } catch (error) {
-    console.error('保存消息和块到数据库失败:', error);
+    logger.error('保存消息和块到数据库失败:', error);
     throw error;
   }
 };


### PR DESCRIPTION
## Summary

这是日志系统迁移 **Phase 4** 的 store 层样板 PR（与并行进行的 `src/shared/services/mcp` 迁移配套）。将 `src/shared/store/**` 下全部 **155** 处原始 `console.*` 调用，替换为 PR #240 落地的统一日志器 `createLogger`（位于 `src/shared/services/infra/logger`）。

迁移严格遵循以下规则，**不改动任何非日志行为**，也不涉及 store 目录以外的文件（logger 核心、`LoggerService.ts`、`debugLogger.ts`、ESLint 配置等均未触碰）。

### 迁移规则

- 每个文件顶部（在所有 `import` 之后）新增一个模块级 logger：
  ```ts
  import { createLogger } from '../../../services/infra/logger'; // 相对深度按文件实际层级
  const logger = createLogger('<Context>');
  ```
  `<Context>` 取自该文件原有 `[前缀]` 标签（去掉方括号）；无前缀的文件取其主模块名（如文件名/函数名）。
- 相对路径按各文件实际深度书写（仓库无 `@/` 的 `tsc` 路径别名，故全部使用相对路径）：
  `store/index.ts → ../services/infra/logger`；`slices/*`、`settingsSlice.ts`、`middleware/* → ../../...`；`thunks/message/* → ../../../...`；`thunks/message/helpers/* → ../../../../...`。
- 去掉消息字符串里的 `[前缀]`（命名空间已携带），其余参数、顺序、emoji、错误对象尾参全部保留。例如：
  ```diff
  - console.log('[MCP] 获取到 N 个可用工具')
  + logger.debug('获取到 N 个可用工具')           // createLogger('MCP')
  - console.error('保存失败:', err)
  + logger.error('保存失败:', err)
  ```

### 级别映射

- `console.log` → `logger.debug`（绝大多数诊断/冗余日志，生产环境默认隐藏）。
- `console.warn` → `logger.warn`；`console.error` → `logger.error`；`console.info` → `logger.info`；`console.debug` → `logger.debug`。
- 仅有 **1 处** `console.log` 升级为 `logger.info`，因为它是真正有意义的运营里程碑：
  `src/shared/store/thunks/message/memoryIntegration.ts` 中 `成功提取并保存 N 条新记忆` → `logger.info(...)`。
- 本目录无 `console.group/groupEnd`，无需折叠处理。

### 混合前缀文件

对一个文件混用多个前缀的情况，取**主模块**作为模块级 logger，其余少数前缀用 `logger.withContext('Other')` 派生子 logger：

- `apiPreparation.ts`：主 `prepareMessagesForApi` + `withContext('performKnowledgeSearchIfNeeded')`。
- `assistantResponse.ts`：主 `processAssistantResponse` + `withContext` 派生 `MCP`/`WebSearch`/`Agentic`/`sendMessage`/`Memory`。
- `helpers/mcpHelpers.ts`：主 `MCP` + `withContext` 派生 `Memory`/`Skill`。

### 涉及文件（共 22 个）

`index.ts`、`settingsSlice.ts`、`middleware/eventMiddleware.ts`；`slices/`（`assistantsSlice`、`groupsSlice`、`networkProxySlice`、`newMessagesSlice`、`pdfPreprocessSlice`、`visionRecognitionSlice`、`webSearchSlice`）；`thunks/message/`（`apiPreparation`、`assistantResponse`、`memoryIntegration`、`messageOperations`、`sendMessage`、`utils`）；`thunks/message/helpers/`（`agenticLoop`、`assistantHelpers`、`imageGeneration`、`mcpHelpers`、`messagePreparation`、`webSearchTool`）。

### 校验

- `grep -rEn "console\.(log|info|warn|error|debug|trace|group)" src/shared/store` → **0 命中**。
- `npm run type-check` ✅ 通过。
- `npm run build`（`vite build`）✅ 成功。
- `npx eslint src/shared/store`：仅剩 1 处 `no-useless-assignment`（`helpers/imageGeneration.ts` 的 `let imageUrls: string[] = []`），与日志迁移无关，迁移前即存在（在 `main` 上同样报此错）。


Link to Devin session: https://app.devin.ai/sessions/f1d6582e965f4b1b9f1a377b7374f342
Requested by: @1600822305