### PR TITLE
refactor(logging): shared/api 子系统迁移到统一 logger（阶段4）

### DIFF
--- a/src/shared/api/anthropic-aisdk/client.ts
+++ b/src/shared/api/anthropic-aisdk/client.ts
@@ -8,6 +8,10 @@ import { createAnthropic } from '@ai-sdk/anthropic';
 import type { AnthropicProvider as AISDKAnthropicProvider } from '@ai-sdk/anthropic';
 import type { Model } from '../../types';
 import { createPlatformFetch, createHeaderFilterFetch } from '../../utils/universalFetch';
+import { createLogger } from '../../services/infra/logger';
+
+const logger = createLogger('Anthropic SDK Client');
+
 
 
 /**
@@ -85,7 +89,7 @@ export function createClient(model: Model): AISDKAnthropicProvider {
   try {
     const apiKey = model.apiKey;
     if (!apiKey) {
-      console.error('[Anthropic SDK Client] 错误: 未提供 API 密钥');
+      logger.error('错误: 未提供 API 密钥');
       throw new Error('未提供 Anthropic API 密钥，请在设置中配置');
     }
 
@@ -96,7 +100,7 @@ export function createClient(model: Model): AISDKAnthropicProvider {
     if (import.meta.env.DEV && baseURL.includes('code.newcli.com')) {
       const proxyPath = baseURL.replace('https://code.newcli.com', '/api/newcli');
       baseURL = `${window.location.origin}${proxyPath}`;
-      console.log(`[Anthropic SDK Client] 开发环境代理转换`);
+      logger.debug(`开发环境代理转换`);
     }
 
     // 确保 baseURL 格式正确
@@ -109,7 +113,7 @@ export function createClient(model: Model): AISDKAnthropicProvider {
       baseURL = baseURL.slice(0, -3);
     }
 
-    console.log(`[Anthropic SDK Client] 创建客户端, 模型ID: ${model.id}, baseURL: ${baseURL.substring(0, 30)}...`);
+    logger.debug(`创建客户端, 模型ID: ${model.id}, baseURL: ${baseURL.substring(0, 30)}...`);
 
     // 构建配置
     const config: Parameters<typeof createAnthropic>[0] = {
@@ -127,7 +131,7 @@ export function createClient(model: Model): AISDKAnthropicProvider {
     // 添加模型级别额外头部
     if (model.extraHeaders) {
       Object.assign(customHeaders, model.extraHeaders);
-      console.log(`[Anthropic SDK Client] 设置模型额外头部: ${Object.keys(model.extraHeaders).join(', ')}`);
+      logger.debug(`设置模型额外头部: ${Object.keys(model.extraHeaders).join(', ')}`);
     }
 
     // 添加供应商级别额外头部
@@ -143,7 +147,7 @@ export function createClient(model: Model): AISDKAnthropicProvider {
       });
 
       if (headersToRemove.length > 0) {
-        console.log(`[Anthropic SDK Client] 配置删除请求头: ${headersToRemove.join(', ')}`);
+        logger.debug(`配置删除请求头: ${headersToRemove.join(', ')}`);
       }
     }
 
@@ -172,18 +176,18 @@ export function createClient(model: Model): AISDKAnthropicProvider {
 
     // 创建并返回 AI SDK Anthropic Provider
     const client = createAnthropic(config);
-    console.log(`[Anthropic SDK Client] 客户端创建成功`);
+    logger.debug(`客户端创建成功`);
     return client;
 
   } catch (error) {
-    console.error('[Anthropic SDK Client] 创建客户端失败:', error);
+    logger.error('创建客户端失败:', error);
     
     // 创建后备客户端
     const fallbackClient = createAnthropic({
       apiKey: 'sk-missing-key-please-configure',
       baseURL: 'https://api.anthropic.com',
     });
-    console.warn('[Anthropic SDK Client] 使用后备客户端配置');
+    logger.warn('使用后备客户端配置');
     return fallbackClient;
   }
 }
@@ -195,7 +199,7 @@ export async function testConnection(model: Model): Promise<boolean> {
   try {
     const client = createClient(model);
     
-    console.log(`[Anthropic SDK Client] 测试连接: ${model.id}`);
+    logger.debug(`测试连接: ${model.id}`);
     
     const result = await generateText({
       model: client(model.id),
@@ -205,7 +209,7 @@ export async function testConnection(model: Model): Promise<boolean> {
 
     return Boolean(result.text);
   } catch (error) {
-    console.error('[Anthropic SDK Client] 连接测试失败:', error);
+    logger.error('连接测试失败:', error);
     return false;
   }
 }

--- a/src/shared/api/anthropic-aisdk/index.ts
+++ b/src/shared/api/anthropic-aisdk/index.ts
@@ -62,6 +62,10 @@ export type { Model, Message, MCPTool } from '../../types';
 
 // 导入 universalFetch 用于 fetchModels
 import { universalFetch } from '../../utils/universalFetch';
+import { createLogger } from '../../services/infra/logger';
+
+const logger = createLogger('anthropic-aisdk');
+
 
 /**
  * 获取 Claude 模型列表
@@ -69,14 +73,14 @@ import { universalFetch } from '../../utils/universalFetch';
  * @returns 模型列表
  */
 export async function fetchModels(provider: any): Promise<any[]> {
-  console.log(`[anthropic-aisdk] 获取Claude模型列表`);
+  logger.debug(`获取Claude模型列表`);
   
   try {
     const baseUrl = provider.baseUrl || 'https://api.anthropic.com';
     const apiKey = provider.apiKey;
     
     if (!apiKey) {
-      console.warn('[anthropic-aisdk] 未提供 API Key，返回预设模型列表');
+      logger.warn('未提供 API Key，返回预设模型列表');
       return getDefaultModels();
     }
 
@@ -109,7 +113,7 @@ export async function fetchModels(provider: any): Promise<any[]> {
 
     throw new Error('未找到模型数据');
   } catch (error) {
-    console.error('[anthropic-aisdk] 获取模型列表失败:', error);
+    logger.error('获取模型列表失败:', error);
     return getDefaultModels();
   }
 }

--- a/src/shared/api/anthropic-aisdk/provider.ts
+++ b/src/shared/api/anthropic-aisdk/provider.ts
@@ -25,6 +25,10 @@ import { ChunkType, type Chunk } from '../../types/chunk';
 import { getMainTextContent } from '../../utils/blockUtils';
 import { UnifiedParameterManager } from '../parameters/UnifiedParameterManager';
 import { AnthropicParameterFormatter } from '../parameters/formatters';
+import { createLogger } from '../../services/infra/logger';
+
+const logger = createLogger('Anthropic SDK Provider');
+
 
 /**
  * Anthropic 参数接口
@@ -133,7 +137,7 @@ export abstract class BaseAnthropicAISDKProvider extends AbstractBaseProvider {
       return { type: 'disabled' };
     }
 
-    console.log(`[AnthropicProvider] 模型 ${this.model.id} Extended Thinking: enabled`);
+    logger.debug(`模型 ${this.model.id} Extended Thinking: enabled`);
 
     return {
       type: 'enabled',
@@ -244,7 +248,7 @@ export abstract class BaseAnthropicAISDKProvider extends AbstractBaseProvider {
                   data: typeof data === 'string' ? data : Buffer.from(data).toString('base64')
                 }
               });
-              console.log(`[Anthropic SDK Provider] 添加 PDF 文件: ${file.filename || 'unknown'}`);
+              logger.debug(`添加 PDF 文件: ${file.filename || 'unknown'}`);
             } else if (mediaType?.startsWith('image/') && data) {
               // 图像文件
               contentParts.push({
@@ -283,7 +287,7 @@ export abstract class BaseAnthropicAISDKProvider extends AbstractBaseProvider {
           });
         }
       } catch (error) {
-        console.error(`[Anthropic SDK Provider] 处理消息失败:`, error);
+        logger.error(`处理消息失败:`, error);
       }
     }
 
@@ -360,7 +364,7 @@ export abstract class BaseAnthropicAISDKProvider extends AbstractBaseProvider {
       });
       return Boolean(result.text);
     } catch (error) {
-      console.error('[Anthropic SDK Provider] API 连接测试失败:', error);
+      logger.error('API 连接测试失败:', error);
       return false;
     }
   }
@@ -409,7 +413,7 @@ export abstract class BaseAnthropicAISDKProvider extends AbstractBaseProvider {
     const toolNames = toolCalls.map(tc => tc.function?.name || tc.name || '');
     const hasCompletion = this.hasCompletionTool(toolNames);
 
-    console.log(`[Anthropic SDK Provider] 处理 ${toolCalls.length} 个工具调用${hasCompletion ? '（含 attempt_completion）' : ''}`);
+    logger.debug(`处理 ${toolCalls.length} 个工具调用${hasCompletion ? '（含 attempt_completion）' : ''}`);
 
     const mcpToolResponses = this.convertToolCallsToMcpResponses(toolCalls, mcpTools);
     const results = await parseAndCallTools(mcpToolResponses, mcpTools, onChunk);
@@ -437,7 +441,7 @@ export abstract class BaseAnthropicAISDKProvider extends AbstractBaseProvider {
     const toolNames = toolResponses.map(tr => tr.tool?.name || tr.tool?.id || '');
     const hasCompletion = this.hasCompletionTool(toolNames);
 
-    console.log(`[Anthropic SDK Provider] 处理 ${toolResponses.length} 个 XML 工具调用${hasCompletion ? '（含 attempt_completion）' : ''}`);
+    logger.debug(`处理 ${toolResponses.length} 个 XML 工具调用${hasCompletion ? '（含 attempt_completion）' : ''}`);
 
     const results = await parseAndCallTools(content, mcpTools, onChunk);
     const messages: any[] = [];
@@ -475,7 +479,7 @@ export abstract class BaseAnthropicAISDKProvider extends AbstractBaseProvider {
 export class AnthropicAISDKProvider extends BaseAnthropicAISDKProvider {
   constructor(model: Model) {
     super(model);
-    console.log(`[AnthropicAISDKProvider] 初始化完成，模型: ${model.id}`);
+    logger.debug(`初始化完成，模型: ${model.id}`);
   }
 
   /**
@@ -495,7 +499,7 @@ export class AnthropicAISDKProvider extends BaseAnthropicAISDKProvider {
       assistant?: any;
     }
   ): Promise<string | { content: string; reasoning?: string; reasoningTime?: number }> {
-    console.log(`[AnthropicAISDKProvider] 开始 API 调用, 模型: ${this.model.id}`);
+    logger.debug(`开始 API 调用, 模型: ${this.model.id}`);
 
     const {
       onChunk,
@@ -522,7 +526,7 @@ export class AnthropicAISDKProvider extends BaseAnthropicAISDKProvider {
     const { unified, apiParams } = this.getApiParams(assistant);
     const streamEnabled = unified.stream ?? true;
 
-    console.log(`[AnthropicAISDKProvider] API 请求参数:`, {
+    logger.debug(`API 请求参数:`, {
       model: this.model.id,
       apiParams,
       stream: streamEnabled,
@@ -531,7 +535,7 @@ export class AnthropicAISDKProvider extends BaseAnthropicAISDKProvider {
 
     // 检查 API 密钥
     if (!this.model.apiKey) {
-      console.error('[AnthropicAISDKProvider] 错误: API 密钥未设置');
+      logger.error('错误: API 密钥未设置');
       throw new Error('API 密钥未设置，请在设置中配置 Anthropic API 密钥');
     }
 
@@ -561,11 +565,11 @@ export class AnthropicAISDKProvider extends BaseAnthropicAISDKProvider {
       }
     } catch (error: any) {
       if (error?.name === 'AbortError' || error?.message?.includes('aborted')) {
-        console.log('[AnthropicAISDKProvider] 请求被用户中断');
+        logger.debug('请求被用户中断');
         throw new DOMException('Operation aborted', 'AbortError');
       }
 
-      console.error('[AnthropicAISDKProvider] API 请求失败:', error);
+      logger.error('API 请求失败:', error);
       throw error;
     }
   }
@@ -603,7 +607,7 @@ export class AnthropicAISDKProvider extends BaseAnthropicAISDKProvider {
 
     while (iteration < maxIterations) {
       iteration++;
-      console.log(`[AnthropicAISDKProvider] 流式工具调用迭代 ${iteration}`);
+      logger.debug(`流式工具调用迭代 ${iteration}`);
 
       const usePromptMode = this.getUseSystemPromptForTools();
       const streamTools = usePromptMode ? [] : tools;
@@ -628,7 +632,7 @@ export class AnthropicAISDKProvider extends BaseAnthropicAISDKProvider {
 
       // 检查是否有工具调用
       if (result.hasToolCalls) {
-        console.log(`[AnthropicAISDKProvider] 检测到工具调用`);
+        logger.debug(`检测到工具调用`);
 
         const content = result.content;
         const nativeToolCalls = result.nativeToolCalls;
@@ -647,7 +651,7 @@ export class AnthropicAISDKProvider extends BaseAnthropicAISDKProvider {
             currentMessages.push(...xmlToolResults);
 
             if (hasCompletion) {
-              console.log(`[AnthropicAISDKProvider] attempt_completion 已执行`);
+              logger.debug(`attempt_completion 已执行`);
               return this.formatResult(result);
             }
             continue;
@@ -689,7 +693,7 @@ export class AnthropicAISDKProvider extends BaseAnthropicAISDKProvider {
             currentMessages.push(...toolResults);
 
             if (hasCompletion) {
-              console.log(`[AnthropicAISDKProvider] attempt_completion 已执行`);
+              logger.debug(`attempt_completion 已执行`);
               return this.formatResult(result);
             }
             continue;
@@ -701,7 +705,7 @@ export class AnthropicAISDKProvider extends BaseAnthropicAISDKProvider {
       return this.formatResult(result);
     }
 
-    console.warn(`[AnthropicAISDKProvider] 达到最大迭代次数 ${maxIterations}`);
+    logger.warn(`达到最大迭代次数 ${maxIterations}`);
     return '';
   }
 

--- a/src/shared/api/anthropic-aisdk/stream.ts
+++ b/src/shared/api/anthropic-aisdk/stream.ts
@@ -13,6 +13,11 @@ import type { Model, MCPTool } from '../../types';
 import { convertMcpToolsToAISDK } from './tools';
 import { supportsExtendedThinking, isClaudeReasoningModel } from './client';
 import { getAppropriateTag, type ReasoningTag, DEFAULT_REASONING_TAGS } from '../../config/reasoningTags';
+import { createLogger } from '../../services/infra/logger';
+
+const logger = createLogger('Anthropic SDK Stream');
+const nonStreamLogger = createLogger('Anthropic SDK NonStream');
+
 
 /**
  * 解析推理标签内容（用于兼容非原生推理模式）
@@ -155,7 +160,7 @@ export async function streamCompletion(
   additionalParams?: StreamParams,
   onChunk?: (chunk: Chunk) => void
 ): Promise<StreamResult> {
-  console.log(`[Anthropic SDK Stream] 开始流式响应, 模型: ${modelId}`);
+  logger.debug(`开始流式响应, 模型: ${modelId}`);
 
   const startTime = Date.now();
   const signal = additionalParams?.signal;
@@ -198,7 +203,7 @@ export async function streamCompletion(
     let tools: any = undefined;
     if (enableTools && mcpTools.length > 0 && mcpMode === 'function') {
       tools = convertMcpToolsToAISDK(mcpTools);
-      console.log(`[Anthropic SDK Stream] 启用 ${Object.keys(tools).length} 个工具`);
+      logger.debug(`启用 ${Object.keys(tools).length} 个工具`);
     }
 
     // 🛡️ Prompt 模式防幻觉：添加 stopSequences
@@ -220,7 +225,7 @@ export async function streamCompletion(
         },
         ...(extraBody || {})
       };
-      console.log(`[Anthropic SDK Stream] 启用 Extended Thinking, 预算: ${thinkingBudgetTokens} tokens`);
+      logger.debug(`启用 Extended Thinking, 预算: ${thinkingBudgetTokens} tokens`);
     } else if (extraBody && typeof extraBody === 'object' && Object.keys(extraBody).length > 0) {
       providerOptions.anthropic = extraBody;
     }
@@ -234,7 +239,7 @@ export async function streamCompletion(
       headers = {
         'anthropic-beta': 'interleaved-thinking-2025-05-14'
       };
-      console.log(`[Anthropic SDK Stream] 启用交错思考模式`);
+      logger.debug(`启用交错思考模式`);
     }
 
     const result = await streamText({
@@ -303,11 +308,11 @@ export async function streamCompletion(
 
         case 'reasoning-end':
           // 推理结束
-          console.log(`[Anthropic SDK Stream] 推理完成`);
+          logger.debug(`推理完成`);
           break;
 
         case 'tool-call':
-          console.log(`[Anthropic SDK Stream] 检测到工具调用: ${part.toolName}`);
+          logger.debug(`检测到工具调用: ${part.toolName}`);
           const toolInput = (part as any).input || (part as any).args || {};
           toolCalls.push({
             id: part.toolCallId,
@@ -331,7 +336,7 @@ export async function streamCompletion(
           break;
 
         case 'finish':
-          console.log(`[Anthropic SDK Stream] 流式响应完成`);
+          logger.debug(`流式响应完成`);
           break;
       }
     }
@@ -380,7 +385,7 @@ export async function streamCompletion(
 
     // 检查工具使用标签（XML 模式）
     if (hasToolUseTags(fullContent)) {
-      console.log(`[Anthropic SDK Stream] 检测到 XML 工具使用标签`);
+      logger.debug(`检测到 XML 工具使用标签`);
       EventEmitter.emit(EVENT_NAMES.TOOL_USE_DETECTED, {
         content: fullContent,
         model: modelId
@@ -388,7 +393,7 @@ export async function streamCompletion(
     }
 
     const endTime = Date.now();
-    console.log(`[Anthropic SDK Stream] 完成，耗时: ${endTime - startTime}ms`);
+    logger.debug(`完成，耗时: ${endTime - startTime}ms`);
 
     return {
       content: fullContent,
@@ -399,7 +404,7 @@ export async function streamCompletion(
     };
 
   } catch (error: any) {
-    console.error('[Anthropic SDK Stream] 流式响应失败:', error);
+    logger.error('流式响应失败:', error);
 
     EventEmitter.emit(EVENT_NAMES.STREAM_ERROR, {
       provider: 'anthropic-aisdk',
@@ -423,7 +428,7 @@ export async function nonStreamCompletion(
   maxTokens?: number,
   additionalParams?: StreamParams
 ): Promise<StreamResult> {
-  console.log(`[Anthropic SDK NonStream] 开始非流式响应, 模型: ${modelId}`);
+  nonStreamLogger.debug(`开始非流式响应, 模型: ${modelId}`);
 
   const startTime = Date.now();
   const signal = additionalParams?.signal;
@@ -485,7 +490,7 @@ export async function nonStreamCompletion(
     });
 
     const endTime = Date.now();
-    console.log(`[Anthropic SDK NonStream] 完成，耗时: ${endTime - startTime}ms`);
+    nonStreamLogger.debug(`完成，耗时: ${endTime - startTime}ms`);
 
     // 提取推理内容
     const reasoning = (result as any).reasoning || (result as any).reasoningText;
@@ -500,7 +505,7 @@ export async function nonStreamCompletion(
     };
 
   } catch (error: any) {
-    console.error('[Anthropic SDK NonStream] 非流式响应失败:', error);
+    nonStreamLogger.error('非流式响应失败:', error);
     throw error;
   }
 }

--- a/src/shared/api/anthropic-aisdk/tools.ts
+++ b/src/shared/api/anthropic-aisdk/tools.ts
@@ -4,6 +4,10 @@
  */
 import type { MCPTool, MCPToolResponse, MCPCallToolResponse, Model } from '../../types';
 import { splitMcpToolContent, buildAISDKToolOutput, toImageDataUrl } from '../../utils/mcpToolResultContent';
+import { createLogger } from '../../services/infra/logger';
+
+const logger = createLogger('Anthropic SDK Tools');
+
 
 /**
  * Claude 内置工具类型
@@ -96,7 +100,7 @@ export function convertToolCallsToMcpResponses(
         args = toolCall.input;
       }
     } catch (e) {
-      console.warn(`[Anthropic SDK Tools] 解析工具参数失败: ${e}`);
+      logger.warn(`解析工具参数失败: ${e}`);
       args = toolCall.function?.arguments || toolCall.args || toolCall.input || {};
     }
 

--- a/src/shared/api/baseProvider.ts
+++ b/src/shared/api/baseProvider.ts
@@ -5,6 +5,10 @@
 import type { Message, MCPTool, Model } from '../types';
 import { buildSystemPrompt, type WorkspaceInfo } from '../utils/mcpPrompt';
 import { workspaceService } from '../services/files/WorkspaceService';
+import { createLogger } from '../services/infra/logger';
+
+const logger = createLogger('MCP');
+
 
 /**
  * 基础提供者接口
@@ -97,30 +101,30 @@ export abstract class AbstractBaseProvider implements BaseProvider {
       return { tools };
     }
 
-    console.log(`[MCP] 用户选择的工具模式: ${mcpMode}, 工具数量: ${mcpTools.length}, 启用工具: ${enableToolUse}`);
+    logger.debug(`用户选择的工具模式: ${mcpMode}, 工具数量: ${mcpTools.length}, 启用工具: ${enableToolUse}`);
 
     // 如果用户明确选择提示词模式，强制使用系统提示词模式
     if (mcpMode === 'prompt') {
-      console.log(`[MCP] 用户选择提示词注入模式，使用系统提示词模式`);
+      logger.debug(`用户选择提示词注入模式，使用系统提示词模式`);
       this.useSystemPromptForTools = true;
-      console.log(`[MCP] 设置 useSystemPromptForTools = true`);
+      logger.debug(`设置 useSystemPromptForTools = true`);
       return { tools };
     }
 
     // 如果工具数量超过阈值，强制使用系统提示词模式
     if (mcpTools.length > AbstractBaseProvider.SYSTEM_PROMPT_THRESHOLD) {
-      console.log(`[MCP] 工具数量 ${mcpTools.length} 超过阈值 ${AbstractBaseProvider.SYSTEM_PROMPT_THRESHOLD}，使用系统提示词模式`);
+      logger.debug(`工具数量 ${mcpTools.length} 超过阈值 ${AbstractBaseProvider.SYSTEM_PROMPT_THRESHOLD}，使用系统提示词模式`);
       this.useSystemPromptForTools = true;
       return { tools };
     }
 
     // 用户选择函数调用模式，直接使用函数调用模式（不再检测模型能力）
     if (mcpMode === 'function' && enableToolUse) {
-      console.log(`[MCP] 用户选择函数调用模式，使用函数调用模式`);
+      logger.debug(`用户选择函数调用模式，使用函数调用模式`);
       tools = this.convertMcpTools<T>(mcpTools);
       this.useSystemPromptForTools = false;
     } else {
-      console.log(`[MCP] 使用系统提示词模式`);
+      logger.debug(`使用系统提示词模式`);
       this.useSystemPromptForTools = true;
     }
 
@@ -151,7 +155,7 @@ export abstract class AbstractBaseProvider implements BaseProvider {
       this.workspacesCacheTime = now;
       return this.cachedWorkspaces;
     } catch (error) {
-      console.warn('[MCP] 获取工作区列表失败:', error);
+      logger.warn('获取工作区列表失败:', error);
       return this.cachedWorkspaces; // 返回缓存的数据
     }
   }
@@ -161,19 +165,19 @@ export abstract class AbstractBaseProvider implements BaseProvider {
    * 这是提供商层面的备用注入机制
    */
   protected buildSystemPromptWithTools(basePrompt: string, mcpTools?: MCPTool[], workspaces?: WorkspaceInfo[]): string {
-    console.log(`[MCP] buildSystemPromptWithTools - 工具数量: ${mcpTools?.length || 0}, useSystemPromptForTools: ${this.useSystemPromptForTools}`);
+    logger.debug(`buildSystemPromptWithTools - 工具数量: ${mcpTools?.length || 0}, useSystemPromptForTools: ${this.useSystemPromptForTools}`);
 
     // 如果没有工具或不使用系统提示词模式，直接返回基础提示词
     if (!mcpTools || mcpTools.length === 0 || !this.useSystemPromptForTools) {
-      console.log(`[MCP] 不注入工具提示词 - 原因: ${!mcpTools ? '无工具' : mcpTools.length === 0 ? '工具数量为0' : '不使用系统提示词模式'}`);
+      logger.debug(`不注入工具提示词 - 原因: ${!mcpTools ? '无工具' : mcpTools.length === 0 ? '工具数量为0' : '不使用系统提示词模式'}`);
       return basePrompt || '';
     }
 
-    console.log(`[MCP] 提供商层注入：将 ${mcpTools.length} 个工具注入到系统提示词中, 工作区数量: ${workspaces?.length || 0}`);
+    logger.debug(`提供商层注入：将 ${mcpTools.length} 个工具注入到系统提示词中, 工作区数量: ${workspaces?.length || 0}`);
     const result = buildSystemPrompt(basePrompt || '', mcpTools, {
       workspaces: workspaces || []
     });
-    console.log(`[MCP] 注入后的系统提示词长度: ${result.length}`);
+    logger.debug(`注入后的系统提示词长度: ${result.length}`);
     return result;
   }
 

--- a/src/shared/api/dashscope/index.ts
+++ b/src/shared/api/dashscope/index.ts
@@ -20,6 +20,10 @@ export {
   generateImage,
   isDashScopeImageModel
 } from './image';
+import { createLogger } from '../../services/infra/logger';
+
+const logger = createLogger('DashScope');
+
 
 // 导出 Provider
 export { DashScopeProvider } from './provider';
@@ -37,7 +41,7 @@ export async function sendChatRequest(
     baseUrl: getDashScopeCompatibleUrl(model)
   };
 
-  console.log(`[DashScope] sendChatRequest - 模型: ${model.id}, 使用兼容模式`);
+  logger.debug(`sendChatRequest - 模型: ${model.id}, 使用兼容模式`);
 
   return openaiSendChatMessage(messages as Message[], compatibleModel, {
     systemPrompt: options?.systemPrompt
@@ -49,7 +53,7 @@ export async function sendChatRequest(
  * DashScope 不支持标准的 /v1/models 接口，返回预设列表
  */
 export async function fetchModels(_provider: any): Promise<any[]> {
-  console.log(`[DashScope] 使用预设模型列表`);
+  logger.debug(`使用预设模型列表`);
   return [
     // 聊天模型
     { id: 'qwen-max', name: 'Qwen-Max', description: '通义千问超大规模语言模型，适合复杂任务', owned_by: 'dashscope' },

--- a/src/shared/api/dashscope/provider.ts
+++ b/src/shared/api/dashscope/provider.ts
@@ -7,6 +7,10 @@ import type { Chunk } from '../../types/chunk';
 import { AbstractBaseProvider } from '../baseProvider';
 import { OpenAIProvider } from '../openai/provider';
 import { getDashScopeCompatibleUrl } from './client';
+import { createLogger } from '../../services/infra/logger';
+
+const logger = createLogger('DashScope');
+
 
 /**
  * DashScope Provider
@@ -43,7 +47,7 @@ export class DashScopeProvider extends AbstractBaseProvider {
       abortSignal?: AbortSignal;
     }
   ): Promise<string | { content: string; reasoning?: string; reasoningTime?: number }> {
-    console.log(`[DashScope] 通过 OpenAI 兼容模式发送聊天请求 - 模型: ${this.model.id}`);
+    logger.debug(`通过 OpenAI 兼容模式发送聊天请求 - 模型: ${this.model.id}`);
     return this.openaiProvider.sendChatMessage(messages, options);
   }
 
@@ -51,7 +55,7 @@ export class DashScopeProvider extends AbstractBaseProvider {
    * 测试 API 连接 — 委托给 OpenAI Provider
    */
   async testConnection(): Promise<boolean> {
-    console.log(`[DashScope] 测试连接 - 模型: ${this.model.id}`);
+    logger.debug(`测试连接 - 模型: ${this.model.id}`);
     return this.openaiProvider.testConnection();
   }
 

--- a/src/shared/api/gemini-aisdk/client.ts
+++ b/src/shared/api/gemini-aisdk/client.ts
@@ -8,6 +8,10 @@ import { createGoogleGenerativeAI } from '@ai-sdk/google';
 import type { GoogleGenerativeAIProvider } from '@ai-sdk/google';
 import type { Model } from '../../types';
 import { createPlatformFetch, createHeaderFilterFetch } from '../../utils/universalFetch';
+import { createLogger } from '../../services/infra/logger';
+
+const logger = createLogger('Gemini AI SDK Client');
+
 
 
 /**
@@ -85,7 +89,7 @@ export function createClient(model: Model): GoogleGenerativeAIProvider {
   try {
     const apiKey = model.apiKey;
     if (!apiKey) {
-      console.error('[Gemini AI SDK Client] 错误: 未提供 API 密钥');
+      logger.error('错误: 未提供 API 密钥');
       throw new Error('未提供 Gemini API 密钥，请在设置中配置');
     }
 
@@ -96,7 +100,7 @@ export function createClient(model: Model): GoogleGenerativeAIProvider {
     if (import.meta.env.DEV && baseURL.includes('code.newcli.com')) {
       const proxyPath = baseURL.replace('https://code.newcli.com', '/api/newcli');
       baseURL = `${window.location.origin}${proxyPath}`;
-      console.log(`[Gemini AI SDK Client] 开发环境代理转换`);
+      logger.debug(`开发环境代理转换`);
     }
 
     // 确保 baseURL 格式正确
@@ -104,7 +108,7 @@ export function createClient(model: Model): GoogleGenerativeAIProvider {
       baseURL = baseURL.slice(0, -1);
     }
 
-    console.log(`[Gemini AI SDK Client] 创建客户端, 模型ID: ${model.id}, baseURL: ${baseURL.substring(0, 40)}...`);
+    logger.debug(`创建客户端, 模型ID: ${model.id}, baseURL: ${baseURL.substring(0, 40)}...`);
 
     // 构建配置
     const config: Parameters<typeof createGoogleGenerativeAI>[0] = {
@@ -122,7 +126,7 @@ export function createClient(model: Model): GoogleGenerativeAIProvider {
     // 添加模型级别额外头部
     if (model.extraHeaders) {
       Object.assign(customHeaders, model.extraHeaders);
-      console.log(`[Gemini AI SDK Client] 设置模型额外头部: ${Object.keys(model.extraHeaders).join(', ')}`);
+      logger.debug(`设置模型额外头部: ${Object.keys(model.extraHeaders).join(', ')}`);
     }
 
     // 添加供应商级别额外头部
@@ -138,7 +142,7 @@ export function createClient(model: Model): GoogleGenerativeAIProvider {
       });
 
       if (headersToRemove.length > 0) {
-        console.log(`[Gemini AI SDK Client] 配置删除请求头: ${headersToRemove.join(', ')}`);
+        logger.debug(`配置删除请求头: ${headersToRemove.join(', ')}`);
       }
     }
 
@@ -158,18 +162,18 @@ export function createClient(model: Model): GoogleGenerativeAIProvider {
 
     // 创建并返回 AI SDK Google Generative AI Provider
     const client = createGoogleGenerativeAI(config);
-    console.log(`[Gemini AI SDK Client] 客户端创建成功`);
+    logger.debug(`客户端创建成功`);
     return client;
 
   } catch (error) {
-    console.error('[Gemini AI SDK Client] 创建客户端失败:', error);
+    logger.error('创建客户端失败:', error);
     
     // 创建后备客户端
     const fallbackClient = createGoogleGenerativeAI({
       apiKey: 'missing-key-please-configure',
       baseURL: getDefaultBaseUrl(),
     });
-    console.warn('[Gemini AI SDK Client] 使用后备客户端配置');
+    logger.warn('使用后备客户端配置');
     return fallbackClient;
   }
 }
@@ -181,7 +185,7 @@ export async function testConnection(model: Model): Promise<boolean> {
   try {
     const client = createClient(model);
     
-    console.log(`[Gemini AI SDK Client] 测试连接: ${model.id}`);
+    logger.debug(`测试连接: ${model.id}`);
     
     // 使用简单的生成请求测试连接
     const result = await generateText({
@@ -192,7 +196,7 @@ export async function testConnection(model: Model): Promise<boolean> {
 
     return Boolean(result.text);
   } catch (error) {
-    console.error('[Gemini AI SDK Client] 连接测试失败:', error);
+    logger.error('连接测试失败:', error);
     return false;
   }
 }

--- a/src/shared/api/gemini-aisdk/embeddingService.ts
+++ b/src/shared/api/gemini-aisdk/embeddingService.ts
@@ -4,6 +4,10 @@
  */
 import type { Model } from '../../types';
 import { getEmbeddingDimensions } from '../../config/embeddingModels';
+import { createLogger } from '../../services/infra/logger';
+
+const logger = createLogger('GeminiEmbeddingService');
+
 
 /**
  * Gemini 嵌入服务接口
@@ -59,7 +63,7 @@ export function createGeminiEmbeddingService(model: Model): GeminiEmbeddingServi
         
         throw new Error('Gemini 嵌入响应格式错误');
       } catch (error) {
-        console.error('[GeminiEmbeddingService] 获取嵌入失败:', error);
+        logger.error('获取嵌入失败:', error);
         throw error;
       }
     },
@@ -104,7 +108,7 @@ export function createGeminiEmbeddingService(model: Model): GeminiEmbeddingServi
         
         throw new Error('Gemini 批量嵌入响应格式错误');
       } catch (error) {
-        console.error('[GeminiEmbeddingService] 批量获取嵌入失败:', error);
+        logger.error('批量获取嵌入失败:', error);
         throw error;
       }
     },
@@ -124,7 +128,7 @@ export function createGeminiEmbeddingService(model: Model): GeminiEmbeddingServi
         const testVector = await this.getEmbedding('test', embeddingModel);
         return testVector.length;
       } catch (error) {
-        console.error('[GeminiEmbeddingService] 获取嵌入维度失败:', error);
+        logger.error('获取嵌入维度失败:', error);
         // 默认返回 768（text-embedding-004 的默认维度）
         return 768;
       }

--- a/src/shared/api/gemini-aisdk/image.ts
+++ b/src/shared/api/gemini-aisdk/image.ts
@@ -3,6 +3,10 @@
  * 使用 @ai-sdk/google 实现图像生成
  */
 import type { Model } from '../../types';
+import { createLogger } from '../../services/infra/logger';
+
+const logger = createLogger('GeminiImage');
+
 
 /**
  * 图像生成结果
@@ -45,7 +49,7 @@ export async function generateImage(
   const imageModelId = model.id || 'gemini-2.0-flash-exp-image-generation';
   
   try {
-    console.log(`[GeminiImage] 开始生成图像, 模型: ${imageModelId}`);
+    logger.debug(`开始生成图像, 模型: ${imageModelId}`);
     
     const url = `${baseUrl}/models/${imageModelId}:generateContent?key=${apiKey}`;
     
@@ -88,15 +92,15 @@ export async function generateImage(
     }
 
     if (imageUrls.length === 0) {
-      console.warn('[GeminiImage] 响应中没有图像数据');
+      logger.warn('响应中没有图像数据');
       throw new Error('Gemini 没有返回图像数据');
     }
 
-    console.log(`[GeminiImage] 成功生成 ${imageUrls.length} 张图像`);
+    logger.debug(`成功生成 ${imageUrls.length} 张图像`);
     return imageUrls;
     
   } catch (error) {
-    console.error('[GeminiImage] 图像生成失败:', error);
+    logger.error('图像生成失败:', error);
     throw error;
   }
 }

--- a/src/shared/api/gemini-aisdk/provider.ts
+++ b/src/shared/api/gemini-aisdk/provider.ts
@@ -21,6 +21,10 @@ import { getMainTextContent, findImageBlocks, findFileBlocks } from '../../utils
 import { readFileContent, getFileTypeByExtension, FileTypes } from '../../utils/fileUtils';
 import { UnifiedParameterManager } from '../parameters/UnifiedParameterManager';
 import { GeminiParameterFormatter } from '../parameters/formatters';
+import { createLogger } from '../../services/infra/logger';
+
+const logger = createLogger('Gemini AI SDK Provider');
+
 
 /**
  * AI SDK Gemini Provider 基类
@@ -182,14 +186,14 @@ export abstract class BaseGeminiAISDKProvider extends AbstractBaseProvider {
                 parts.push({ type: 'text', text: `${fileName}\n${fileContent}` });
               }
             } catch (error) {
-              console.error('[Gemini AI SDK Provider] 读取文件内容失败:', error);
+              logger.error('读取文件内容失败:', error);
             }
           }
         }
 
         apiMessages.push({ role: message.role, content: parts });
       } catch (error) {
-        console.error(`[Gemini AI SDK Provider] 处理消息失败:`, error);
+        logger.error(`处理消息失败:`, error);
       }
     }
 
@@ -262,7 +266,7 @@ export abstract class BaseGeminiAISDKProvider extends AbstractBaseProvider {
       });
       return Boolean(result.text);
     } catch (error) {
-      console.error('[Gemini AI SDK Provider] API 连接测试失败:', error);
+      logger.error('API 连接测试失败:', error);
       return false;
     }
   }
@@ -312,7 +316,7 @@ export abstract class BaseGeminiAISDKProvider extends AbstractBaseProvider {
     const toolNames = toolCalls.map(tc => tc.function?.name || tc.name || '');
     const hasCompletion = this.hasCompletionTool(toolNames);
 
-    console.log(`[Gemini AI SDK Provider] 处理 ${toolCalls.length} 个工具调用${hasCompletion ? '（含 attempt_completion）' : ''}`);
+    logger.debug(`处理 ${toolCalls.length} 个工具调用${hasCompletion ? '（含 attempt_completion）' : ''}`);
 
     const mcpToolResponses = this.convertToolCallsToMcpResponses(toolCalls, mcpTools);
     const results = await parseAndCallTools(mcpToolResponses, mcpTools, onChunk);
@@ -340,7 +344,7 @@ export abstract class BaseGeminiAISDKProvider extends AbstractBaseProvider {
     const toolNames = toolResponses.map(tr => tr.tool?.name || tr.tool?.id || '');
     const hasCompletion = this.hasCompletionTool(toolNames);
 
-    console.log(`[Gemini AI SDK Provider] 处理 ${toolResponses.length} 个 XML 工具调用${hasCompletion ? '（含 attempt_completion）' : ''}`);
+    logger.debug(`处理 ${toolResponses.length} 个 XML 工具调用${hasCompletion ? '（含 attempt_completion）' : ''}`);
 
     const results = await parseAndCallTools(content, mcpTools, onChunk);
     const messages: any[] = [];
@@ -378,7 +382,7 @@ export abstract class BaseGeminiAISDKProvider extends AbstractBaseProvider {
 export class GeminiAISDKProvider extends BaseGeminiAISDKProvider {
   constructor(model: Model) {
     super(model);
-    console.log(`[GeminiAISDKProvider] 初始化完成，模型: ${model.id}`);
+    logger.debug(`初始化完成，模型: ${model.id}`);
   }
 
   /**
@@ -397,7 +401,7 @@ export class GeminiAISDKProvider extends BaseGeminiAISDKProvider {
       assistant?: any;
     }
   ): Promise<string | { content: string; reasoning?: string; reasoningTime?: number }> {
-    console.log(`[GeminiAISDKProvider] 开始 API 调用, 模型: ${this.model.id}`);
+    logger.debug(`开始 API 调用, 模型: ${this.model.id}`);
 
     const {
       onChunk,
@@ -429,7 +433,7 @@ export class GeminiAISDKProvider extends BaseGeminiAISDKProvider {
     const maxTokens = apiParams.maxOutputTokens;
     const thinkingBudget = apiParams.thinkingConfig?.thinkingBudget;
 
-    console.log(`[GeminiAISDKProvider] API 请求参数:`, {
+    logger.debug(`API 请求参数:`, {
       model: this.model.id,
       temperature,
       maxTokens,
@@ -441,7 +445,7 @@ export class GeminiAISDKProvider extends BaseGeminiAISDKProvider {
 
     // 检查 API 密钥
     if (!this.model.apiKey) {
-      console.error('[GeminiAISDKProvider] 错误: API 密钥未设置');
+      logger.error('错误: API 密钥未设置');
       throw new Error('API 密钥未设置，请在设置中配置 Gemini API 密钥');
     }
 
@@ -473,7 +477,7 @@ export class GeminiAISDKProvider extends BaseGeminiAISDKProvider {
       }
     } catch (error: any) {
       if (error?.name === 'AbortError' || error?.message?.includes('aborted')) {
-        console.log('[GeminiAISDKProvider] 请求被用户中断');
+        logger.debug('请求被用户中断');
         throw new DOMException('Operation aborted', 'AbortError');
       }
 
@@ -482,7 +486,7 @@ export class GeminiAISDKProvider extends BaseGeminiAISDKProvider {
         throw new Error(`模型 ${modelName} 不支持当前的最大输出 token 设置 (${maxTokens})。`);
       }
 
-      console.error('[GeminiAISDKProvider] API 请求失败:', error);
+      logger.error('API 请求失败:', error);
       throw error;
     }
   }
@@ -522,7 +526,7 @@ export class GeminiAISDKProvider extends BaseGeminiAISDKProvider {
 
     while (iteration < maxIterations) {
       iteration++;
-      console.log(`[GeminiAISDKProvider] 流式工具调用迭代 ${iteration}`);
+      logger.debug(`流式工具调用迭代 ${iteration}`);
 
       // 准备工具配置
       const usePromptMode = this.getUseSystemPromptForTools();
@@ -550,7 +554,7 @@ export class GeminiAISDKProvider extends BaseGeminiAISDKProvider {
 
       // 检查是否有工具调用
       if (result.hasToolCalls) {
-        console.log(`[GeminiAISDKProvider] 检测到工具调用`);
+        logger.debug(`检测到工具调用`);
 
         const content = result.content;
         const nativeToolCalls = result.nativeToolCalls;
@@ -570,7 +574,7 @@ export class GeminiAISDKProvider extends BaseGeminiAISDKProvider {
             currentMessages.push(...xmlToolResults);
 
             if (hasCompletion) {
-              console.log(`[GeminiAISDKProvider] attempt_completion 已执行`);
+              logger.debug(`attempt_completion 已执行`);
               return this.formatResult(result);
             }
             continue;
@@ -616,7 +620,7 @@ export class GeminiAISDKProvider extends BaseGeminiAISDKProvider {
             currentMessages.push(...toolResults);
 
             if (hasCompletion) {
-              console.log(`[GeminiAISDKProvider] attempt_completion 已执行`);
+              logger.debug(`attempt_completion 已执行`);
               return this.formatResult(result);
             }
             continue;
@@ -628,7 +632,7 @@ export class GeminiAISDKProvider extends BaseGeminiAISDKProvider {
       return this.formatResult(result);
     }
 
-    console.warn(`[GeminiAISDKProvider] 达到最大迭代次数 ${maxIterations}`);
+    logger.warn(`达到最大迭代次数 ${maxIterations}`);
     return '';
   }
 

--- a/src/shared/api/gemini-aisdk/stream.ts
+++ b/src/shared/api/gemini-aisdk/stream.ts
@@ -14,6 +14,11 @@ import type { Model, MCPTool } from '../../types';
 import type { ModelProvider } from '../../config/defaultModels';
 import { convertMcpToolsToAISDK, parseGroundingMetadata } from './tools';
 import store from '../../store';
+import { createLogger } from '../../services/infra/logger';
+
+const logger = createLogger('Gemini AI SDK Stream');
+const nonStreamLogger = createLogger('Gemini AI SDK NonStream');
+
 
 /**
  * 获取模型对应的供应商配置
@@ -30,7 +35,7 @@ function getProviderConfig(model: Model): ModelProvider | null {
     const provider = providers.find((p: ModelProvider) => p.id === model.provider);
     return provider || null;
   } catch (error) {
-    console.error('[Gemini AI SDK Stream] 获取供应商配置失败:', error);
+    logger.error('获取供应商配置失败:', error);
     return null;
   }
 }
@@ -89,7 +94,7 @@ export async function streamCompletion(
   additionalParams?: StreamParams,
   onChunk?: (chunk: Chunk) => void
 ): Promise<StreamResult> {
-  console.log(`[Gemini AI SDK Stream] 开始流式响应, 模型: ${modelId}`);
+  logger.debug(`开始流式响应, 模型: ${modelId}`);
 
   const startTime = Date.now();
   const signal = additionalParams?.signal;
@@ -155,7 +160,7 @@ export async function streamCompletion(
         });
       }
       if (tools && Object.keys(tools).length > 0) {
-        console.log(`[Gemini AI SDK Stream] 启用 ${Object.keys(tools).length} 个工具`);
+        logger.debug(`启用 ${Object.keys(tools).length} 个工具`);
       }
     }
 
@@ -166,7 +171,7 @@ export async function streamCompletion(
     // 添加 extraBody
     if (extraBody && typeof extraBody === 'object' && Object.keys(extraBody).length > 0) {
       Object.assign(googleOptions, extraBody);
-      console.log(`[Gemini AI SDK Stream] 合并自定义请求体参数: ${Object.keys(extraBody).join(', ')}`);
+      logger.debug(`合并自定义请求体参数: ${Object.keys(extraBody).join(', ')}`);
     }
 
     // 添加思考配置（如果模型支持）
@@ -175,7 +180,7 @@ export async function streamCompletion(
         thinkingBudget: additionalParams.thinkingBudget || 1024,
         includeThoughts: additionalParams.includeThoughts !== false
       };
-      console.log(`[Gemini AI SDK Stream] 启用思考配置: budget=${googleOptions.thinkingConfig.thinkingBudget}`);
+      logger.debug(`启用思考配置: budget=${googleOptions.thinkingConfig.thinkingBudget}`);
     }
 
     if (Object.keys(googleOptions).length > 0) {
@@ -185,7 +190,7 @@ export async function streamCompletion(
     // 如果启用 Google Search，使用特殊的工具配置
     // 注意：Google Search 需要通过 providerOptions 或特殊工具启用
     if (enableGoogleSearch) {
-      console.log(`[Gemini AI SDK Stream] 启用 Google Search Grounding`);
+      logger.debug(`启用 Google Search Grounding`);
       // Google Search 通过 providerOptions 启用
       if (!providerOptions) providerOptions = { google: {} };
       providerOptions.google = providerOptions.google || {};
@@ -197,7 +202,7 @@ export async function streamCompletion(
     const isPromptMode = !enableTools && mcpTools.length > 0;
     const stopSequences = isPromptMode ? ['<tool_use_result'] : undefined;
 
-    console.log(`[Gemini AI SDK Stream] 创建流式请求`);
+    logger.debug(`创建流式请求`);
 
     const result = await streamText({
       model: client(modelId),
@@ -247,7 +252,7 @@ export async function streamCompletion(
           break;
 
         case 'tool-call':
-          console.log(`[Gemini AI SDK Stream] 检测到工具调用: ${part.toolName}`);
+          logger.debug(`检测到工具调用: ${part.toolName}`);
           const toolInput = (part as any).input || (part as any).args || {};
           toolCalls.push({
             id: part.toolCallId,
@@ -331,7 +336,7 @@ export async function streamCompletion(
 
     // 检查工具使用标签（XML 模式）
     if (hasToolUseTags(fullContent)) {
-      console.log(`[Gemini AI SDK Stream] 检测到 XML 工具使用标签`);
+      logger.debug(`检测到 XML 工具使用标签`);
       EventEmitter.emit(EVENT_NAMES.TOOL_USE_DETECTED, {
         content: fullContent,
         model: modelId
@@ -339,7 +344,7 @@ export async function streamCompletion(
     }
 
     const endTime = Date.now();
-    console.log(`[Gemini AI SDK Stream] 完成，耗时: ${endTime - startTime}ms`);
+    logger.debug(`完成，耗时: ${endTime - startTime}ms`);
 
     return {
       content: fullContent,
@@ -352,7 +357,7 @@ export async function streamCompletion(
     };
 
   } catch (error: any) {
-    console.error('[Gemini AI SDK Stream] 流式响应失败:', error);
+    logger.error('流式响应失败:', error);
 
     EventEmitter.emit(EVENT_NAMES.STREAM_ERROR, {
       provider: 'gemini-aisdk',
@@ -376,7 +381,7 @@ export async function nonStreamCompletion(
   maxTokens?: number,
   additionalParams?: StreamParams
 ): Promise<StreamResult> {
-  console.log(`[Gemini AI SDK NonStream] 开始非流式响应, 模型: ${modelId}`);
+  nonStreamLogger.debug(`开始非流式响应, 模型: ${modelId}`);
 
   const startTime = Date.now();
   const signal = additionalParams?.signal;
@@ -434,7 +439,7 @@ export async function nonStreamCompletion(
 
     if (extraBody && typeof extraBody === 'object' && Object.keys(extraBody).length > 0) {
       Object.assign(googleOptions, extraBody);
-      console.log(`[Gemini AI SDK NonStream] 合并自定义请求体参数: ${Object.keys(extraBody).join(', ')}`);
+      nonStreamLogger.debug(`合并自定义请求体参数: ${Object.keys(extraBody).join(', ')}`);
     }
 
     if (additionalParams?.thinkingBudget || additionalParams?.includeThoughts) {
@@ -469,7 +474,7 @@ export async function nonStreamCompletion(
 
     const endTime = Date.now();
     const totalTime = endTime - startTime;
-    console.log(`[Gemini AI SDK NonStream] 完成，耗时: ${totalTime}ms`);
+    nonStreamLogger.debug(`完成，耗时: ${totalTime}ms`);
 
     // 提取推理内容和 grounding metadata
     // AI SDK v5: result.reasoningText 是字符串，result.reasoning 是数组
@@ -496,7 +501,7 @@ export async function nonStreamCompletion(
         // 按 token 比例估算思考时间
         const thoughtsRatio = usageMetadata.thoughtsTokenCount / usageMetadata.totalTokenCount;
         reasoningTime = Math.round(totalTime * thoughtsRatio);
-        console.log(`[Gemini AI SDK NonStream] 思考时间估算: ${reasoningTime}ms (tokens: ${usageMetadata.thoughtsTokenCount}/${usageMetadata.totalTokenCount})`);
+        nonStreamLogger.debug(`思考时间估算: ${reasoningTime}ms (tokens: ${usageMetadata.thoughtsTokenCount}/${usageMetadata.totalTokenCount})`);
       } else {
         // 回退：使用总时间
         reasoningTime = totalTime;
@@ -514,7 +519,7 @@ export async function nonStreamCompletion(
     };
 
   } catch (error: any) {
-    console.error('[Gemini AI SDK NonStream] 非流式响应失败:', error);
+    nonStreamLogger.error('非流式响应失败:', error);
     throw error;
   }
 }

--- a/src/shared/api/gemini-aisdk/tools.ts
+++ b/src/shared/api/gemini-aisdk/tools.ts
@@ -5,6 +5,10 @@
  */
 import type { MCPTool, MCPToolResponse, MCPCallToolResponse, Model } from '../../types';
 import { splitMcpToolContent, buildAISDKToolOutput, toImageDataUrl } from '../../utils/mcpToolResultContent';
+import { createLogger } from '../../services/infra/logger';
+
+const logger = createLogger('Gemini AI SDK Tools');
+
 
 /**
  * 将 MCP 工具转换为 AI SDK 工具格式
@@ -64,7 +68,7 @@ export function convertToolCallsToMcpResponses(
         args = toolCall.function.arguments;
       }
     } catch (e) {
-      console.warn(`[Gemini AI SDK Tools] 解析工具参数失败: ${e}`);
+      logger.warn(`解析工具参数失败: ${e}`);
       args = toolCall.function?.arguments || toolCall.args || {};
     }
 

--- a/src/shared/api/index.ts
+++ b/src/shared/api/index.ts
@@ -6,6 +6,10 @@ import { OpenAIResponseProvider } from '../providers/OpenAIResponseProvider';
 import type { ModelProvider } from '../config/defaultModels';
 import { ChunkType } from '../types/chunk';
 import { isAbortError } from '../utils/abortController';
+import { createLogger } from '../services/infra/logger';
+
+const logger = createLogger('API');
+
 
 /**
  * API模块索引文件
@@ -57,7 +61,7 @@ export const testApiConnection = async (model: Model): Promise<boolean> => {
   try {
     // 检查是否为 OpenAI Responses API 提供商
     if (model.providerType === 'openai-response') {
-      console.log('[testApiConnection] 使用 OpenAI Responses API 测试连接');
+      logger.debug('使用 OpenAI Responses API 测试连接');
 
       // 使用静态导入的 OpenAIResponseProvider
       const provider = new OpenAIResponseProvider(model);
@@ -85,7 +89,7 @@ export const testApiConnection = async (model: Model): Promise<boolean> => {
     const content = typeof response === 'string' ? response : response.content;
     return Boolean(content && content.length > 0);
   } catch (error) {
-    console.error('API连接测试失败:', error);
+    logger.error('API连接测试失败:', error);
     return false;
   }
 };
@@ -102,11 +106,11 @@ export const sendChatRequest = async (options: ChatRequest): Promise<{ success: 
     return processModelRequest(model, options);
   } catch (error) {
     if (isAbortError(error)) {
-      console.log('[sendChatRequest] 请求已取消:', error instanceof Error ? error.message : String(error));
+      logger.debug('请求已取消:', error instanceof Error ? error.message : String(error));
       throw error;
     }
 
-    console.error('[sendChatRequest] 请求失败:', error instanceof Error ? error.message : String(error));
+    logger.error('请求失败:', error instanceof Error ? error.message : String(error));
     throw error;
   }
 }
@@ -198,20 +202,20 @@ async function processModelRequest(model: Model, options: ChatRequest): Promise<
       };
     } catch (error) {
       if (isAbortError(error)) {
-        console.log('[processModelRequest] API调用已取消:', error instanceof Error ? error.message : String(error));
+        logger.debug('API调用已取消:', error instanceof Error ? error.message : String(error));
         throw error;
       }
 
-      console.error('[processModelRequest] API调用失败:', error instanceof Error ? error.message : String(error));
+      logger.error('API调用失败:', error instanceof Error ? error.message : String(error));
       throw error;
     }
   } catch (error) {
     if (isAbortError(error)) {
-      console.log('[processModelRequest] 请求已取消:', error instanceof Error ? error.message : String(error));
+      logger.debug('请求已取消:', error instanceof Error ? error.message : String(error));
       throw error;
     }
 
-    console.error('[processModelRequest] 请求失败:', error instanceof Error ? error.message : String(error));
+    logger.error('请求失败:', error instanceof Error ? error.message : String(error));
     throw error;
   }
 }
@@ -293,10 +297,10 @@ function findModelById(modelId: string): Model | null {
       }
     }
 
-    console.warn(`[findModelById] 未找到模型: ${modelId}`);
+    logger.warn(`未找到模型: ${modelId}`);
     return null;
   } catch (error) {
-    console.error('[findModelById] 查找失败:', error);
+    logger.error('查找失败:', error);
     return null;
   }
 }

--- a/src/shared/api/openai-aisdk/client.ts
+++ b/src/shared/api/openai-aisdk/client.ts
@@ -9,6 +9,10 @@ import type { OpenAIProvider as AISDKOpenAIProvider } from '@ai-sdk/openai';
 import type { Model } from '../../types';
 import { createPlatformFetch, createHeaderFilterFetch } from '../../utils/universalFetch';
 import { isReasoningModel } from '../../../config/models';
+import { createLogger } from '../../services/infra/logger';
+
+const logger = createLogger('AI SDK Client');
+
 
 
 /**
@@ -93,7 +97,7 @@ export function createClient(model: Model): AISDKOpenAIProvider {
   try {
     const apiKey = model.apiKey;
     if (!apiKey) {
-      console.error('[AI SDK Client] 错误: 未提供 API 密钥');
+      logger.error('错误: 未提供 API 密钥');
       throw new Error('未提供 OpenAI API 密钥，请在设置中配置');
     }
 
@@ -104,7 +108,7 @@ export function createClient(model: Model): AISDKOpenAIProvider {
     if (import.meta.env.DEV && baseURL.includes('code.newcli.com')) {
       const proxyPath = baseURL.replace('https://code.newcli.com', '/api/newcli');
       baseURL = `${window.location.origin}${proxyPath}`;
-      console.log(`[AI SDK Client] 开发环境代理转换`);
+      logger.debug(`开发环境代理转换`);
     }
 
     // 检查是否需要特殊处理
@@ -120,7 +124,7 @@ export function createClient(model: Model): AISDKOpenAIProvider {
       baseURL = `${baseURL}/v1`;
     }
 
-    console.log(`[AI SDK Client] 创建客户端, 模型ID: ${model.id}, baseURL: ${baseURL.substring(0, 30)}...`);
+    logger.debug(`创建客户端, 模型ID: ${model.id}, baseURL: ${baseURL.substring(0, 30)}...`);
 
     // 构建配置
     const config: Parameters<typeof createOpenAI>[0] = {
@@ -138,13 +142,13 @@ export function createClient(model: Model): AISDKOpenAIProvider {
     // Azure OpenAI 特殊配置
     if (isAzureOpenAI(model)) {
       customHeaders['api-version'] = (model as any).apiVersion || '2024-02-15-preview';
-      console.log(`[AI SDK Client] 检测到 Azure OpenAI`);
+      logger.debug(`检测到 Azure OpenAI`);
     }
 
     // 添加模型级别额外头部
     if (model.extraHeaders) {
       Object.assign(customHeaders, model.extraHeaders);
-      console.log(`[AI SDK Client] 设置模型额外头部: ${Object.keys(model.extraHeaders).join(', ')}`);
+      logger.debug(`设置模型额外头部: ${Object.keys(model.extraHeaders).join(', ')}`);
     }
 
     // 添加供应商级别额外头部
@@ -160,7 +164,7 @@ export function createClient(model: Model): AISDKOpenAIProvider {
       });
 
       if (headersToRemove.length > 0) {
-        console.log(`[AI SDK Client] 配置删除请求头: ${headersToRemove.join(', ')}`);
+        logger.debug(`配置删除请求头: ${headersToRemove.join(', ')}`);
       }
     }
 
@@ -190,23 +194,23 @@ export function createClient(model: Model): AISDKOpenAIProvider {
     // 添加组织信息
     if ((model as any).organization) {
       config.organization = (model as any).organization;
-      console.log(`[AI SDK Client] 设置组织ID: ${(model as any).organization}`);
+      logger.debug(`设置组织ID: ${(model as any).organization}`);
     }
 
     // 创建并返回 AI SDK OpenAI Provider
     const client = createOpenAI(config);
-    console.log(`[AI SDK Client] 客户端创建成功`);
+    logger.debug(`客户端创建成功`);
     return client;
 
   } catch (error) {
-    console.error('[AI SDK Client] 创建客户端失败:', error);
+    logger.error('创建客户端失败:', error);
     
     // 创建后备客户端
     const fallbackClient = createOpenAI({
       apiKey: 'sk-missing-key-please-configure',
       baseURL: 'https://api.openai.com/v1',
     });
-    console.warn('[AI SDK Client] 使用后备客户端配置');
+    logger.warn('使用后备客户端配置');
     return fallbackClient;
   }
 }
@@ -218,7 +222,7 @@ export async function testConnection(model: Model): Promise<boolean> {
   try {
     const client = createClient(model);
     
-    console.log(`[AI SDK Client] 测试连接: ${model.id}`);
+    logger.debug(`测试连接: ${model.id}`);
     
     // 使用 .chat() 调用 Chat Completions API（兼容 OpenAI 兼容 API）
     const result = await generateText({
@@ -229,7 +233,7 @@ export async function testConnection(model: Model): Promise<boolean> {
 
     return Boolean(result.text);
   } catch (error) {
-    console.error('[AI SDK Client] 连接测试失败:', error);
+    logger.error('连接测试失败:', error);
     return false;
   }
 }

--- a/src/shared/api/openai-aisdk/provider.ts
+++ b/src/shared/api/openai-aisdk/provider.ts
@@ -19,6 +19,10 @@ import {
   convertToolCallsToMcpResponses
 } from './tools';
 import { ChunkType, type Chunk } from '../../types/chunk';
+import { createLogger } from '../../services/infra/logger';
+
+const logger = createLogger('AI SDK Provider');
+
 
 /**
  * AI SDK OpenAI Provider 基类
@@ -121,7 +125,7 @@ export abstract class BaseOpenAIAISDKProvider extends AbstractBaseProvider {
           });
         }
       } catch (error) {
-        console.error(`[AI SDK Provider] 处理消息失败:`, error);
+        logger.error(`处理消息失败:`, error);
         const content = (message as any).content;
         if (content && typeof content === 'string' && content.trim()) {
           apiMessages.push({
@@ -156,7 +160,7 @@ export abstract class BaseOpenAIAISDKProvider extends AbstractBaseProvider {
       });
       return Boolean(result.text);
     } catch (error) {
-      console.error('[AI SDK Provider] API 连接测试失败:', error);
+      logger.error('API 连接测试失败:', error);
       return false;
     }
   }
@@ -206,7 +210,7 @@ export abstract class BaseOpenAIAISDKProvider extends AbstractBaseProvider {
     const toolNames = toolCalls.map(tc => tc.function?.name || tc.name || '');
     const hasCompletion = this.hasCompletionTool(toolNames);
 
-    console.log(`[AI SDK Provider] 处理 ${toolCalls.length} 个工具调用${hasCompletion ? '（含 attempt_completion）' : ''}`);
+    logger.debug(`处理 ${toolCalls.length} 个工具调用${hasCompletion ? '（含 attempt_completion）' : ''}`);
 
     const mcpToolResponses = this.convertToolCallsToMcpResponses(toolCalls, mcpTools);
     const results = await parseAndCallTools(mcpToolResponses, mcpTools, onChunk);
@@ -243,7 +247,7 @@ export abstract class BaseOpenAIAISDKProvider extends AbstractBaseProvider {
     const toolNames = toolResponses.map(tr => tr.tool?.name || tr.tool?.id || '');
     const hasCompletion = this.hasCompletionTool(toolNames);
 
-    console.log(`[AI SDK Provider] 处理 ${toolResponses.length} 个 XML 工具调用${hasCompletion ? '（含 attempt_completion）' : ''}`);
+    logger.debug(`处理 ${toolResponses.length} 个 XML 工具调用${hasCompletion ? '（含 attempt_completion）' : ''}`);
 
     const results = await parseAndCallTools(content, mcpTools, onChunk);
     const messages: any[] = [];
@@ -281,7 +285,7 @@ export abstract class BaseOpenAIAISDKProvider extends AbstractBaseProvider {
 export class OpenAIAISDKProvider extends BaseOpenAIAISDKProvider {
   constructor(model: Model) {
     super(model);
-    console.log(`[OpenAIAISDKProvider] 初始化完成，模型: ${model.id}`);
+    logger.debug(`初始化完成，模型: ${model.id}`);
   }
 
   /**
@@ -300,7 +304,7 @@ export class OpenAIAISDKProvider extends BaseOpenAIAISDKProvider {
       assistant?: any;
     }
   ): Promise<string | { content: string; reasoning?: string; reasoningTime?: number }> {
-    console.log(`[OpenAIAISDKProvider] 开始 API 调用, 模型: ${this.model.id}`);
+    logger.debug(`开始 API 调用, 模型: ${this.model.id}`);
 
     const {
       onChunk,
@@ -329,7 +333,7 @@ export class OpenAIAISDKProvider extends BaseOpenAIAISDKProvider {
     const { unified, apiParams } = this.getApiParams(assistant);
     const streamEnabled = unified.stream ?? true;
 
-    console.log(`[OpenAIAISDKProvider] API 请求参数:`, {
+    logger.debug(`API 请求参数:`, {
       model: this.model.id,
       apiParams,
       stream: streamEnabled,
@@ -338,7 +342,7 @@ export class OpenAIAISDKProvider extends BaseOpenAIAISDKProvider {
 
     // 检查 API 密钥
     if (!this.model.apiKey) {
-      console.error('[OpenAIAISDKProvider] 错误: API 密钥未设置');
+      logger.error('错误: API 密钥未设置');
       throw new Error('API 密钥未设置，请在设置中配置 OpenAI API 密钥');
     }
 
@@ -374,7 +378,7 @@ export class OpenAIAISDKProvider extends BaseOpenAIAISDKProvider {
       }
     } catch (error: any) {
       if (error?.name === 'AbortError' || error?.message?.includes('aborted')) {
-        console.log('[OpenAIAISDKProvider] 请求被用户中断');
+        logger.debug('请求被用户中断');
         throw new DOMException('Operation aborted', 'AbortError');
       }
 
@@ -383,7 +387,7 @@ export class OpenAIAISDKProvider extends BaseOpenAIAISDKProvider {
         throw new Error(`模型 ${modelName} 不支持当前的最大输出 token 设置 (${apiParams.max_tokens})。`);
       }
 
-      console.error('[OpenAIAISDKProvider] API 请求失败:', error);
+      logger.error('API 请求失败:', error);
       throw error;
     }
   }
@@ -422,7 +426,7 @@ export class OpenAIAISDKProvider extends BaseOpenAIAISDKProvider {
 
     while (iteration < maxIterations) {
       iteration++;
-      console.log(`[OpenAIAISDKProvider] 流式工具调用迭代 ${iteration}`);
+      logger.debug(`流式工具调用迭代 ${iteration}`);
 
       // 准备工具配置
       const usePromptMode = this.getUseSystemPromptForTools();
@@ -448,7 +452,7 @@ export class OpenAIAISDKProvider extends BaseOpenAIAISDKProvider {
 
       // 检查是否有工具调用
       if (result.hasToolCalls) {
-        console.log(`[OpenAIAISDKProvider] 检测到工具调用`);
+        logger.debug(`检测到工具调用`);
 
         const content = result.content;
         const nativeToolCalls = result.nativeToolCalls;
@@ -468,7 +472,7 @@ export class OpenAIAISDKProvider extends BaseOpenAIAISDKProvider {
             currentMessages.push(...xmlToolResults);
 
             if (hasCompletion) {
-              console.log(`[OpenAIAISDKProvider] attempt_completion 已执行`);
+              logger.debug(`attempt_completion 已执行`);
               return this.formatResult(result);
             }
             continue;
@@ -511,7 +515,7 @@ export class OpenAIAISDKProvider extends BaseOpenAIAISDKProvider {
             currentMessages.push(...toolResults);
 
             if (hasCompletion) {
-              console.log(`[OpenAIAISDKProvider] attempt_completion 已执行`);
+              logger.debug(`attempt_completion 已执行`);
               return this.formatResult(result);
             }
             continue;
@@ -523,7 +527,7 @@ export class OpenAIAISDKProvider extends BaseOpenAIAISDKProvider {
       return this.formatResult(result);
     }
 
-    console.warn(`[OpenAIAISDKProvider] 达到最大迭代次数 ${maxIterations}`);
+    logger.warn(`达到最大迭代次数 ${maxIterations}`);
     return '';
   }
 

--- a/src/shared/api/openai-aisdk/stream.ts
+++ b/src/shared/api/openai-aisdk/stream.ts
@@ -14,6 +14,11 @@ import type { Model, MCPTool } from '../../types';
 import type { ModelProvider } from '../../config/defaultModels';
 import { convertMcpToolsToAISDK } from './tools';
 import store from '../../store';
+import { createLogger } from '../../services/infra/logger';
+
+const logger = createLogger('AI SDK Stream');
+const nonStreamLogger = createLogger('AI SDK NonStream');
+
 
 /**
  * 获取模型对应的供应商配置
@@ -31,7 +36,7 @@ function getProviderConfig(model: Model): ModelProvider | null {
     const provider = providers.find((p: ModelProvider) => p.id === model.provider);
     return provider || null;
   } catch (error) {
-    console.error('[AI SDK Stream] 获取供应商配置失败:', error);
+    logger.error('获取供应商配置失败:', error);
     return null;
   }
 }
@@ -194,7 +199,7 @@ export async function streamCompletion(
   additionalParams?: StreamParams,
   onChunk?: (chunk: Chunk) => void
 ): Promise<StreamResult> {
-  console.log(`[AI SDK Stream] 开始流式响应, 模型: ${modelId}`);
+  logger.debug(`开始流式响应, 模型: ${modelId}`);
 
   const startTime = Date.now();
   const signal = additionalParams?.signal;
@@ -263,7 +268,7 @@ export async function streamCompletion(
     let tools: any = undefined;
     if (enableTools && mcpTools.length > 0 && mcpMode === 'function') {
       tools = convertMcpToolsToAISDK(mcpTools);
-      console.log(`[AI SDK Stream] 启用 ${Object.keys(tools).length} 个工具`);
+      logger.debug(`启用 ${Object.keys(tools).length} 个工具`);
     }
 
     // 🛡️ Prompt 模式防幻觉：添加 stopSequences
@@ -279,7 +284,7 @@ export async function streamCompletion(
       providerOptions = {
         openai: extraBody
       };
-      console.log(`[AI SDK Stream] 合并自定义请求体参数: ${Object.keys(extraBody).join(', ')}`);
+      logger.debug(`合并自定义请求体参数: ${Object.keys(extraBody).join(', ')}`);
     }
 
     // 根据 useResponsesAPI 开关选择 API 类型
@@ -289,7 +294,7 @@ export async function streamCompletion(
       ? client.responses(modelId)  // Responses API
       : client.chat(modelId);       // Chat Completions API
 
-    console.log(`[AI SDK Stream] 使用 ${useResponsesAPI ? 'Responses' : 'Chat Completions'} API`);
+    logger.debug(`使用 ${useResponsesAPI ? 'Responses' : 'Chat Completions'} API`);
 
     const result = await streamText({
       model: modelInstance,
@@ -335,7 +340,7 @@ export async function streamCompletion(
           break;
 
         case 'tool-call':
-          console.log(`[AI SDK Stream] 检测到工具调用: ${part.toolName}`);
+          logger.debug(`检测到工具调用: ${part.toolName}`);
           // AI SDK v6 使用 input 而不是 args
           const toolInput = (part as any).input || (part as any).args || {};
           toolCalls.push({
@@ -406,7 +411,7 @@ export async function streamCompletion(
           break;
 
         case 'finish':
-          console.log(`[AI SDK Stream] 流式响应完成`);
+          logger.debug(`流式响应完成`);
           break;
       }
     }
@@ -456,7 +461,7 @@ export async function streamCompletion(
 
     // 检查工具使用标签（XML 模式）
     if (hasToolUseTags(fullContent)) {
-      console.log(`[AI SDK Stream] 检测到 XML 工具使用标签`);
+      logger.debug(`检测到 XML 工具使用标签`);
       EventEmitter.emit(EVENT_NAMES.TOOL_USE_DETECTED, {
         content: fullContent,
         model: modelId
@@ -464,7 +469,7 @@ export async function streamCompletion(
     }
 
     const endTime = Date.now();
-    console.log(`[AI SDK Stream] 完成，耗时: ${endTime - startTime}ms`);
+    logger.debug(`完成，耗时: ${endTime - startTime}ms`);
 
     // 返回结果
     return {
@@ -476,7 +481,7 @@ export async function streamCompletion(
     };
 
   } catch (error: any) {
-    console.error('[AI SDK Stream] 流式响应失败:', error);
+    logger.error('流式响应失败:', error);
 
     EventEmitter.emit(EVENT_NAMES.STREAM_ERROR, {
       provider: 'openai-aisdk',
@@ -500,7 +505,7 @@ export async function nonStreamCompletion(
   maxTokens?: number,
   additionalParams?: StreamParams
 ): Promise<StreamResult> {
-  console.log(`[AI SDK NonStream] 开始非流式响应, 模型: ${modelId}`);
+  nonStreamLogger.debug(`开始非流式响应, 模型: ${modelId}`);
 
   const startTime = Date.now();
   const signal = additionalParams?.signal;
@@ -543,7 +548,7 @@ export async function nonStreamCompletion(
       providerOptions = {
         openai: extraBody
       };
-      console.log(`[AI SDK NonStream] 合并自定义请求体参数: ${Object.keys(extraBody).join(', ')}`);
+      nonStreamLogger.debug(`合并自定义请求体参数: ${Object.keys(extraBody).join(', ')}`);
     }
 
     // 根据 useResponsesAPI 开关选择 API 类型
@@ -551,7 +556,7 @@ export async function nonStreamCompletion(
       ? client.responses(modelId)  // Responses API
       : client.chat(modelId);       // Chat Completions API
 
-    console.log(`[AI SDK NonStream] 使用 ${useResponsesAPI ? 'Responses' : 'Chat Completions'} API`);
+    nonStreamLogger.debug(`使用 ${useResponsesAPI ? 'Responses' : 'Chat Completions'} API`);
 
     const result = await generateText({
       model: modelInstance,
@@ -565,7 +570,7 @@ export async function nonStreamCompletion(
     });
 
     const endTime = Date.now();
-    console.log(`[AI SDK NonStream] 完成，耗时: ${endTime - startTime}ms`);
+    nonStreamLogger.debug(`完成，耗时: ${endTime - startTime}ms`);
 
     // 提取推理内容（如果有）
     const reasoning = (result as any).reasoning;
@@ -579,7 +584,7 @@ export async function nonStreamCompletion(
     };
 
   } catch (error: any) {
-    console.error('[AI SDK NonStream] 非流式响应失败:', error);
+    nonStreamLogger.error('非流式响应失败:', error);
     throw error;
   }
 }

--- a/src/shared/api/openai-aisdk/tools.ts
+++ b/src/shared/api/openai-aisdk/tools.ts
@@ -4,6 +4,10 @@
  */
 import type { MCPTool, MCPToolResponse, MCPCallToolResponse, Model } from '../../types';
 import { splitMcpToolContent, toImageDataUrl } from '../../utils/mcpToolResultContent';
+import { createLogger } from '../../services/infra/logger';
+
+const logger = createLogger('AI SDK Tools');
+
 
 // 复用 openai/tools.ts 中的类型定义
 export { WEB_SEARCH_TOOL } from '../openai/tools';
@@ -64,7 +68,7 @@ export function convertToolCallsToMcpResponses(
         args = toolCall.input;
       }
     } catch (e) {
-      console.warn(`[AI SDK Tools] 解析工具参数失败: ${e}`);
+      logger.warn(`解析工具参数失败: ${e}`);
       args = toolCall.function?.arguments || toolCall.args || {};
     }
 

--- a/src/shared/api/openai/chat.ts
+++ b/src/shared/api/openai/chat.ts
@@ -8,6 +8,10 @@ import type { Chunk } from '../../types/chunk';
 import { logApiRequest } from '../../services/infra/LoggerService';
 import { isAbortError } from '../../utils/abortController';
 import { OpenAIProvider } from './provider';
+import { createLogger } from '../../services/infra/logger';
+
+const logger = createLogger('OpenAI Chat');
+
 
 /**
  * 聊天选项接口
@@ -68,7 +72,7 @@ function normalizeChatOptions(options?: ChatOptions): NormalizedChatOptions {
 function validateAndNormalizeMessages(messages: Message[]): Message[] {
   // 检查消息数组是否有效
   if (!messages || !Array.isArray(messages) || messages.length === 0) {
-    console.warn('[OpenAI Chat] 消息数组为空或无效，创建默认消息');
+    logger.warn('消息数组为空或无效，创建默认消息');
 
     // 创建默认消息
     const defaultMessage: Message = {
@@ -93,8 +97,8 @@ function validateAndNormalizeMessages(messages: Message[]): Message[] {
  * 记录聊天请求日志
  */
 function logChatRequest(messages: Message[], model: Model, options: NormalizedChatOptions): void {
-  console.log(`[OpenAI Chat] 发送聊天请求 - 模型: ${model.id}, 消息数量: ${messages.length}`);
-  console.log(`[OpenAI Chat] 配置 - 网页搜索: ${options.enableWebSearch}, 工具: ${options.enableTools}, 系统提示: ${options.systemPrompt ? '有' : '无'}`);
+  logger.debug(`发送聊天请求 - 模型: ${model.id}, 消息数量: ${messages.length}`);
+  logger.debug(`配置 - 网页搜索: ${options.enableWebSearch}, 工具: ${options.enableTools}, 系统提示: ${options.systemPrompt ? '有' : '无'}`);
 
   // 记录API请求到日志服务
   logApiRequest('OpenAI Chat', 'INFO', {
@@ -121,7 +125,7 @@ function logChatRequest(messages: Message[], model: Model, options: NormalizedCh
 function handleChatError(error: any, model: Model): never {
   // 用户主动中断是正常控制流，不按错误打印堆栈
   if (isAbortError(error)) {
-    console.log('[OpenAI Chat] 聊天请求已取消:', {
+    logger.debug('聊天请求已取消:', {
       model: model.id,
       provider: model.provider,
       message: error instanceof Error ? error.message : String(error)
@@ -129,8 +133,8 @@ function handleChatError(error: any, model: Model): never {
     throw new DOMException('Operation aborted', 'AbortError');
   }
 
-  console.error('[OpenAI Chat] 聊天请求失败:', error);
-  console.error('[OpenAI Chat] 错误详情:', {
+  logger.error('聊天请求失败:', error);
+  logger.error('错误详情:', {
     message: error instanceof Error ? error.message : '未知错误',
     model: model.id,
     provider: model.provider,
@@ -176,13 +180,13 @@ export async function sendChatMessage(
     // 记录工具状态
     if (normalizedOptions.enableTools) {
       if (normalizedOptions.enableWebSearch && model.capabilities?.webSearch) {
-        console.log(`[OpenAI Chat] 启用网页搜索功能`);
+        logger.debug(`启用网页搜索功能`);
       }
       if (normalizedOptions.mcpTools && normalizedOptions.mcpTools.length > 0) {
-        console.log(`[OpenAI Chat] 启用 ${normalizedOptions.mcpTools.length} 个MCP工具`);
+        logger.debug(`启用 ${normalizedOptions.mcpTools.length} 个MCP工具`);
       }
     } else {
-      console.log(`[OpenAI Chat] 工具功能已禁用`);
+      logger.debug(`工具功能已禁用`);
     }
 
     // 调用Provider发送消息
@@ -197,7 +201,7 @@ export async function sendChatMessage(
       assistant: normalizedOptions.assistant
     });
 
-    console.log(`[OpenAI Chat] 聊天请求成功完成`);
+    logger.debug(`聊天请求成功完成`);
     return result;
 
   } catch (error) {

--- a/src/shared/api/openai/client.ts
+++ b/src/shared/api/openai/client.ts
@@ -8,6 +8,10 @@ import type { Model } from '../../types';
 import { logApiRequest } from '../../services/infra/LoggerService';
 import { isReasoningModel } from '../../../config/models';
 import { createPlatformFetch, createHeaderFilterFetch } from '../../utils/universalFetch';
+import { createLogger } from '../../services/infra/logger';
+
+const logger = createLogger('OpenAI Client');
+
 
 /**
  * 创建OpenAI客户端
@@ -18,7 +22,7 @@ export function createClient(model: Model): OpenAI {
   try {
     const apiKey = model.apiKey;
     if (!apiKey) {
-      console.error('[OpenAI createClient] 错误: 未提供API密钥');
+      logger.error('错误: 未提供API密钥');
       throw new Error('未提供OpenAI API密钥，请在设置中配置');
     }
 
@@ -33,7 +37,7 @@ export function createClient(model: Model): OpenAI {
         // 使用当前页面的 origin 构造完整的代理 URL
         const proxyPath = baseURL.replace('https://code.newcli.com', '/api/newcli');
         baseURL = `${window.location.origin}${proxyPath}`;
-        console.log(`[OpenAI createClient] 开发环境代理转换: ${originalURL} -> ${baseURL}`);
+        logger.debug(`开发环境代理转换: ${originalURL} -> ${baseURL}`);
       }
     }
 
@@ -62,11 +66,11 @@ export function createClient(model: Model): OpenAI {
       baseURL = `${baseURL}/v1`;
     }
 
-    console.log(`[OpenAI createClient] 创建客户端, 模型ID: ${model.id}, baseURL: ${baseURL.substring(0, 20)}...`);
+    logger.debug(`创建客户端, 模型ID: ${model.id}, baseURL: ${baseURL.substring(0, 20)}...`);
 
     // 检查是否为Azure OpenAI
     if (isAzureOpenAI(model)) {
-      console.log(`[OpenAI createClient] 检测到Azure OpenAI，使用Azure配置`);
+      logger.debug(`检测到Azure OpenAI，使用Azure配置`);
     }
 
     // 创建配置对象
@@ -94,7 +98,7 @@ export function createClient(model: Model): OpenAI {
     // 添加组织信息（如果有）
     if ((model as any).organization) {
       config.organization = (model as any).organization;
-      console.log(`[OpenAI createClient] 设置组织ID: ${(model as any).organization}`);
+      logger.debug(`设置组织ID: ${(model as any).organization}`);
     }
 
     // 添加额外头部（如果有）
@@ -103,7 +107,7 @@ export function createClient(model: Model): OpenAI {
         ...config.defaultHeaders,
         ...model.extraHeaders
       };
-      console.log(`[OpenAI createClient] 设置模型额外头部: ${Object.keys(model.extraHeaders).join(', ')}`);
+      logger.debug(`设置模型额外头部: ${Object.keys(model.extraHeaders).join(', ')}`);
     }
 
     // 添加供应商级别的额外头部（如果有）
@@ -139,7 +143,7 @@ export function createClient(model: Model): OpenAI {
             keysToDelete.forEach(key => headers.delete(key));
           }
         );
-        console.log(`[OpenAI createClient] 配置删除请求头: ${headersToRemove.join(', ')}`);
+        logger.debug(`配置删除请求头: ${headersToRemove.join(', ')}`);
       }
 
       // 添加自定义头部
@@ -148,17 +152,17 @@ export function createClient(model: Model): OpenAI {
           ...config.defaultHeaders,
           ...filteredHeaders
         };
-        console.log(`[OpenAI createClient] 设置供应商额外头部: ${Object.keys(filteredHeaders).join(', ')}`);
+        logger.debug(`设置供应商额外头部: ${Object.keys(filteredHeaders).join(', ')}`);
       }
     }
 
     // 创建客户端
     const client = new OpenAI(config);
-    console.log(`[OpenAI createClient] 客户端创建成功`);
+    logger.debug(`客户端创建成功`);
     return client;
 
   } catch (error) {
-    console.error('[OpenAI createClient] 创建客户端失败:', error);
+    logger.error('创建客户端失败:', error);
     // 即使没有API密钥，也尝试创建一个客户端，以便调用代码不会崩溃
     // 后续API调用将失败，但至少不会在这里抛出异常
     const fallbackConfig: ClientOptions = {
@@ -167,7 +171,7 @@ export function createClient(model: Model): OpenAI {
       timeout: 30000,
       dangerouslyAllowBrowser: true
     };
-    console.warn('[OpenAI createClient] 使用后备客户端配置');
+    logger.warn('使用后备客户端配置');
     return new OpenAI(fallbackConfig);
   }
 }
@@ -300,7 +304,7 @@ export async function testConnection(model: Model): Promise<boolean> {
 
     return Boolean(response.choices[0].message);
   } catch (error) {
-    console.error('OpenAI API连接测试失败:', error);
+    logger.error('OpenAI API连接测试失败:', error);
     return false;
   }
 }

--- a/src/shared/api/openai/index.ts
+++ b/src/shared/api/openai/index.ts
@@ -85,6 +85,10 @@ export {
   type ChatOptions,
   type ChatResponse
 } from './chat';
+import { createLogger } from '../../services/infra/logger';
+
+const logger = createLogger('OpenAI Index');
+
 
 // 使用统一聊天模块的包装函数
 export async function sendChatRequest(
@@ -98,7 +102,7 @@ export async function sendChatRequest(
 ): Promise<string | { content: string; reasoning?: string; reasoningTime?: number }> {
   const systemPrompt = options?.systemPrompt || '';
 
-  console.log(`[openai/index.ts] 使用统一聊天模块 - 模型ID: ${model.id}, 消息数量: ${messages.length}`);
+  logger.debug(`使用统一聊天模块 - 模型ID: ${model.id}, 消息数量: ${messages.length}`);
 
   return sendChatMessage(messages, model, {
     systemPrompt,
@@ -122,7 +126,7 @@ export async function sendChatRequest(
  * ```
  */
 export function createOpenAIAPI(model: Model) {
-  console.log(`[openai/index.ts] 创建OpenAI API适配器 - 模型ID: ${model.id}`);
+  logger.debug(`创建OpenAI API适配器 - 模型ID: ${model.id}`);
   const provider = new OpenAIProvider(model);
 
   return {
@@ -141,7 +145,7 @@ export function createOpenAIAPI(model: Model) {
         assistant?: any;
       }
     ) => {
-      console.log(`[openai/index.ts] 通过统一聊天模块发送消息 - 模型ID: ${model.id}, 消息数量: ${messages.length}`);
+      logger.debug(`通过统一聊天模块发送消息 - 模型ID: ${model.id}, 消息数量: ${messages.length}`);
       return sendChatMessage(messages, model, options);
     },
 

--- a/src/shared/api/openai/models.ts
+++ b/src/shared/api/openai/models.ts
@@ -7,6 +7,10 @@ import type { Model } from '../../types';
 import { createClient } from './client';
 import { logApiRequest, logApiResponse } from '../../services/infra/LoggerService';
 import { universalFetch } from '../../utils/universalFetch';
+import { createLogger } from '../../services/infra/logger';
+
+const logger = createLogger('OpenAI Models');
+
 
 /**
  * 解析模型列表响应 - 支持多种格式
@@ -17,55 +21,55 @@ import { universalFetch } from '../../utils/universalFetch';
 export function parseModelsResponse(data: any): any[] {
   // 空数据检查
   if (!data) {
-    console.warn('[parseModelsResponse] 响应数据为空');
+    logger.warn('响应数据为空');
     return [];
   }
 
   // 格式1: 标准 OpenAI 格式 {object: "list", data: [...]}
   if (data.object === 'list' && Array.isArray(data.data)) {
-    console.log(`[parseModelsResponse] 检测到标准OpenAI格式, ${data.data.length}个模型`);
+    logger.debug(`检测到标准OpenAI格式, ${data.data.length}个模型`);
     return data.data;
   }
 
   // 格式2: 简化格式 {data: [...]}
   if (data.data && Array.isArray(data.data)) {
-    console.log(`[parseModelsResponse] 检测到简化data格式, ${data.data.length}个模型`);
+    logger.debug(`检测到简化data格式, ${data.data.length}个模型`);
     return data.data;
   }
 
   // 格式3: 直接数组格式 [...]
   if (Array.isArray(data)) {
-    console.log(`[parseModelsResponse] 检测到直接数组格式, ${data.length}个模型`);
+    logger.debug(`检测到直接数组格式, ${data.length}个模型`);
     return data;
   }
 
   // 格式4: {models: [...]} 格式（某些中转站使用）
   if (data.models && Array.isArray(data.models)) {
-    console.log(`[parseModelsResponse] 检测到models字段格式, ${data.models.length}个模型`);
+    logger.debug(`检测到models字段格式, ${data.models.length}个模型`);
     return data.models;
   }
 
   // 格式5: {result: [...]} 格式（某些中转站使用）
   if (data.result && Array.isArray(data.result)) {
-    console.log(`[parseModelsResponse] 检测到result字段格式, ${data.result.length}个模型`);
+    logger.debug(`检测到result字段格式, ${data.result.length}个模型`);
     return data.result;
   }
 
   // 格式6: {results: [...]} 格式
   if (data.results && Array.isArray(data.results)) {
-    console.log(`[parseModelsResponse] 检测到results字段格式, ${data.results.length}个模型`);
+    logger.debug(`检测到results字段格式, ${data.results.length}个模型`);
     return data.results;
   }
 
   // 格式7: {items: [...]} 格式
   if (data.items && Array.isArray(data.items)) {
-    console.log(`[parseModelsResponse] 检测到items字段格式, ${data.items.length}个模型`);
+    logger.debug(`检测到items字段格式, ${data.items.length}个模型`);
     return data.items;
   }
 
   // 格式8: {list: [...]} 格式
   if (data.list && Array.isArray(data.list)) {
-    console.log(`[parseModelsResponse] 检测到list字段格式, ${data.list.length}个模型`);
+    logger.debug(`检测到list字段格式, ${data.list.length}个模型`);
     return data.list;
   }
 
@@ -73,11 +77,11 @@ export function parseModelsResponse(data: any): any[] {
   if (data.data && typeof data.data === 'object' && !Array.isArray(data.data)) {
     const nested = data.data;
     if (Array.isArray(nested.models)) {
-      console.log(`[parseModelsResponse] 检测到嵌套data.models格式, ${nested.models.length}个模型`);
+      logger.debug(`检测到嵌套data.models格式, ${nested.models.length}个模型`);
       return nested.models;
     }
     if (Array.isArray(nested.data)) {
-      console.log(`[parseModelsResponse] 检测到嵌套data.data格式, ${nested.data.length}个模型`);
+      logger.debug(`检测到嵌套data.data格式, ${nested.data.length}个模型`);
       return nested.data;
     }
   }
@@ -93,13 +97,13 @@ export function parseModelsResponse(data: any): any[] {
     const arr = data[preferredKey];
     // 验证数组内容看起来像模型对象（有id字段）
     if (arr.length > 0 && (arr[0].id || arr[0].model || arr[0].name)) {
-      console.log(`[parseModelsResponse] 自动检测到字段 "${preferredKey}", ${arr.length}个模型`);
+      logger.debug(`自动检测到字段 "${preferredKey}", ${arr.length}个模型`);
       return arr;
     }
   }
 
   // 无法识别的格式
-  console.warn('[parseModelsResponse] 无法识别的响应格式:', JSON.stringify(data).substring(0, 200));
+  logger.warn('无法识别的响应格式:', JSON.stringify(data).substring(0, 200));
   return [];
 }
 
@@ -134,7 +138,7 @@ export async function fetchModels(provider: any): Promise<any[]> {
     const apiKey = provider.apiKey;
     
     if (!apiKey) {
-      console.warn('[fetchOpenAIModels] 警告: 未提供API密钥，可能导致请求失败');
+      logger.warn('警告: 未提供API密钥，可能导致请求失败');
     }
     
     // 构建API端点
@@ -150,7 +154,7 @@ export async function fetchModels(provider: any): Promise<any[]> {
       endpoint = `${cleanBaseUrl}/v1/models`;
     }
     
-    console.log(`[fetchOpenAIModels] 请求端点: ${endpoint}`);
+    logger.debug(`请求端点: ${endpoint}`);
     
     // 构建请求头 (GET 请求不应包含 Content-Type)
     // 参考 Cherry Studio 的请求头配置，确保与各种中转站兼容
@@ -184,7 +188,7 @@ export async function fetchModels(provider: any): Promise<any[]> {
     
     if (!response.ok) {
       const errorText = await response.text();
-      console.warn(`[fetchOpenAIModels] API请求失败: ${response.status}, ${errorText}`);
+      logger.warn(`API请求失败: ${response.status}, ${errorText}`);
       
       // 记录API响应
       logApiResponse('OpenAI Models', response.status, {
@@ -204,7 +208,7 @@ export async function fetchModels(provider: any): Promise<any[]> {
       .map(normalizeModel)
       .filter((m: any) => m && m.id); // 过滤掉无效模型
     
-    console.log(`[fetchOpenAIModels] 成功获取模型列表, 找到 ${normalizedModels.length} 个模型`);
+    logger.debug(`成功获取模型列表, 找到 ${normalizedModels.length} 个模型`);
     
     // 记录API响应
     logApiResponse('OpenAI Models', 200, {
@@ -214,7 +218,7 @@ export async function fetchModels(provider: any): Promise<any[]> {
     
     return normalizedModels;
   } catch (error) {
-    console.error('[fetchOpenAIModels] 获取模型失败:', error);
+    logger.error('获取模型失败:', error);
     throw error;
   }
 }
@@ -251,7 +255,7 @@ export async function fetchModelsWithSDK(model: Model): Promise<any[]> {
     
     return models;
   } catch (error) {
-    console.error('[fetchModelsWithSDK] 获取模型失败:', error);
+    logger.error('获取模型失败:', error);
     throw error;
   }
 }

--- a/src/shared/api/openai/multimodal.ts
+++ b/src/shared/api/openai/multimodal.ts
@@ -14,6 +14,10 @@ import {
   isGemmaModel
 } from '../../../config/models';
 import { mobileFileStorage } from '../../services/files/MobileFileStorageService';
+import { createLogger } from '../../services/infra/logger';
+
+const logger = createLogger('OpenAI Multimodal');
+
 
 // 定义消息参数类型，避免使用OpenAI类型
 export interface ChatCompletionMessageParam {
@@ -58,7 +62,7 @@ export function convertToOpenAIMessages(messages: Message[]): Array<ChatCompleti
     const hasDirectImages = Array.isArray(apiMsg.images) && apiMsg.images.length > 0;
 
     // 添加调试日志
-    console.log(`[OpenAI API] 处理消息类型: ${apiMsg.role}, 复杂内容: ${isComplexContent}, 直接图片: ${hasDirectImages}`);
+    logger.debug(`处理消息类型: ${apiMsg.role}, 复杂内容: ${isComplexContent}, 直接图片: ${hasDirectImages}`);
 
     // 保持原始角色，不再将system角色转换为user角色
     const role = apiMsg.role;
@@ -84,7 +88,7 @@ export function convertToOpenAIMessages(messages: Message[]): Array<ChatCompleti
       if (isComplexContent) {
         const content = apiMsg.content as {text?: string; images?: ImageContent[]};
         if (content.images && content.images.length > 0) {
-          console.log(`[OpenAI API] 处理旧格式图片，数量: ${content.images.length}`);
+          logger.debug(`处理旧格式图片，数量: ${content.images.length}`);
           content.images.forEach((image, index) => {
             if (image.base64Data) {
               contentArray.push({
@@ -94,7 +98,7 @@ export function convertToOpenAIMessages(messages: Message[]): Array<ChatCompleti
                   detail: 'auto'
                 }
               });
-              console.log(`[OpenAI API] 添加base64图片 ${index+1}, 开头: ${image.base64Data.substring(0, 30)}...`);
+              logger.debug(`添加base64图片 ${index+1}, 开头: ${image.base64Data.substring(0, 30)}...`);
             } else if (image.url) {
               contentArray.push({
                 type: 'image_url',
@@ -103,7 +107,7 @@ export function convertToOpenAIMessages(messages: Message[]): Array<ChatCompleti
                   detail: 'auto'
                 }
               });
-              console.log(`[OpenAI API] 添加URL图片 ${index+1}: ${image.url}`);
+              logger.debug(`添加URL图片 ${index+1}: ${image.url}`);
             }
           });
         }
@@ -111,7 +115,7 @@ export function convertToOpenAIMessages(messages: Message[]): Array<ChatCompleti
 
       // 添加直接附加的图片（新格式）
       if (hasDirectImages) {
-        console.log(`[OpenAI API] 处理新格式图片，数量: ${apiMsg.images!.length}`);
+        logger.debug(`处理新格式图片，数量: ${apiMsg.images!.length}`);
         apiMsg.images!.forEach((imgFormat, index) => {
           if (imgFormat.image_url && imgFormat.image_url.url) {
             contentArray.push({
@@ -121,16 +125,16 @@ export function convertToOpenAIMessages(messages: Message[]): Array<ChatCompleti
                 detail: 'auto'
               }
             });
-            console.log(`[OpenAI API] 添加新格式图片 ${index+1}: ${imgFormat.image_url.url.substring(0, 30)}...`);
+            logger.debug(`添加新格式图片 ${index+1}: ${imgFormat.image_url.url.substring(0, 30)}...`);
           }
         });
       }
 
-      console.log(`[OpenAI API] 转换后内容数组长度: ${contentArray.length}, 包含图片数量: ${contentArray.filter(item => item.type === 'image_url').length}`);
+      logger.debug(`转换后内容数组长度: ${contentArray.length}, 包含图片数量: ${contentArray.filter(item => item.type === 'image_url').length}`);
 
       // 处理空内容的极端情况
       if (contentArray.length === 0) {
-        console.warn('[OpenAI API] 警告: 生成了空内容数组，添加默认文本');
+        logger.warn('警告: 生成了空内容数组，添加默认文本');
         contentArray.push({
           type: 'text',
           text: '图片'
@@ -226,7 +230,7 @@ export async function processMessageWithFiles(
     // 默认返回文本内容
     return handleTextOnlyMessage(textContent, message.role, model);
   } catch (error) {
-    console.error('[multimodal] 处理消息内容失败:', error);
+    logger.error('处理消息内容失败:', error);
     // 降级处理：返回基础文本消息
     return handleTextOnlyMessage(getMainTextContent(message), message.role, model);
   }
@@ -341,7 +345,7 @@ async function handleClaudeMultimodal(
             }
           });
         } catch (error) {
-          console.error('[multimodal] Claude PDF处理失败:', error);
+          logger.error('Claude PDF处理失败:', error);
           // 降级为文本处理
           const fileContent = await readFileContent(block.file);
           parts.push({
@@ -358,7 +362,7 @@ async function handleClaudeMultimodal(
             text: `文件: ${block.file.origin_name}\n\n${fileContent}`
           });
         } catch (error) {
-          console.error('[multimodal] Claude文本文件处理失败:', error);
+          logger.error('Claude文本文件处理失败:', error);
         }
       }
     }
@@ -411,7 +415,7 @@ async function handleGeminiMultimodal(
             text: `文件: ${block.file.origin_name}\n\n${fileContent}`
           });
         } catch (error) {
-          console.error('[multimodal] Gemini文件处理失败:', error);
+          logger.error('Gemini文件处理失败:', error);
         }
       }
     }
@@ -471,7 +475,7 @@ async function handleOpenAIMultimodal(
             text: `文件: ${block.file.origin_name}\n\n${fileContent}`
           });
         } catch (error) {
-          console.error('[multimodal] OpenAI文件处理失败:', error);
+          logger.error('OpenAI文件处理失败:', error);
         }
       }
     }
@@ -501,7 +505,7 @@ async function handleTextWithFiles(
           const fileContent = await readFileContent(block.file);
           combinedContent += `文件: ${block.file.origin_name}\n\n${fileContent}\n\n`;
         } catch (error) {
-          console.error('[multimodal] 文件内容读取失败:', error);
+          logger.error('文件内容读取失败:', error);
           combinedContent += `文件: ${block.file.origin_name} (读取失败)\n\n`;
         }
       }

--- a/src/shared/api/openai/provider.ts
+++ b/src/shared/api/openai/provider.ts
@@ -27,6 +27,10 @@ import {
 } from './tools';
 import { ChunkType } from '../../types/chunk';
 import { isAbortError } from '../../utils/abortController';
+import { createLogger } from '../../services/infra/logger';
+
+const logger = createLogger('OpenAIProvider');
+
 
 /**
  * 工具调用循环的最大迭代次数（安全阀，防止模型反复发起工具调用导致死循环）。
@@ -141,7 +145,7 @@ export abstract class BaseOpenAIProvider extends AbstractBaseProvider {
           });
         }
       } catch (error) {
-        console.error(`[OpenAIProvider] 处理消息失败:`, error);
+        logger.error(`处理消息失败:`, error);
         // 降级处理
         const content = (message as any).content;
         if (content && typeof content === 'string' && content.trim()) {
@@ -180,7 +184,7 @@ export abstract class BaseOpenAIProvider extends AbstractBaseProvider {
       });
       return Boolean(response.choices[0].message);
     } catch (error) {
-      console.error('API连接测试失败:', error);
+      logger.error('API连接测试失败:', error);
       return false;
     }
   }
@@ -230,7 +234,7 @@ export abstract class BaseOpenAIProvider extends AbstractBaseProvider {
     const toolNames = toolCalls.map(tc => tc.function?.name || tc.name || '');
     const hasCompletion = this.hasCompletionTool(toolNames);
 
-    console.log(`[OpenAI] 处理 ${toolCalls.length} 个工具调用${hasCompletion ? '（含 attempt_completion）' : ''}`);
+    logger.debug(`处理 ${toolCalls.length} 个工具调用${hasCompletion ? '（含 attempt_completion）' : ''}`);
 
     const mcpToolResponses = this.convertToolCallsToMcpResponses(toolCalls, mcpTools);
     const results = await parseAndCallTools(mcpToolResponses, mcpTools, onChunk);
@@ -267,7 +271,7 @@ export abstract class BaseOpenAIProvider extends AbstractBaseProvider {
     const toolNames = toolResponses.map(tr => tr.tool?.name || tr.tool?.id || '');
     const hasCompletion = this.hasCompletionTool(toolNames);
 
-    console.log(`[OpenAI] 处理 ${toolResponses.length} 个 XML 工具调用${hasCompletion ? '（含 attempt_completion）' : ''}`);
+    logger.debug(`处理 ${toolResponses.length} 个 XML 工具调用${hasCompletion ? '（含 attempt_completion）' : ''}`);
 
     const results = await parseAndCallTools(content, mcpTools, onChunk);
     const messages: any[] = [];
@@ -331,7 +335,7 @@ export class OpenAIProvider extends BaseOpenAIProvider {
       assistant?: any;
     }
   ): Promise<string | { content: string; reasoning?: string; reasoningTime?: number }> {
-    console.log(`[OpenAIProvider] 开始API调用, 模型: ${this.model.id}`);
+    logger.debug(`开始API调用, 模型: ${this.model.id}`);
 
     const {
       onChunk,
@@ -376,12 +380,12 @@ export class OpenAIProvider extends BaseOpenAIProvider {
 
     // 检查API密钥和基础URL是否设置
     if (!this.model.apiKey) {
-      console.error('[OpenAIProvider.sendChatMessage] 错误: API密钥未设置');
+      logger.error('错误: API密钥未设置');
       throw new Error('API密钥未设置，请在设置中配置OpenAI API密钥');
     }
 
     if (!this.model.baseUrl) {
-      console.warn('[OpenAIProvider.sendChatMessage] 警告: 基础URL未设置，使用默认值');
+      logger.warn('警告: 基础URL未设置，使用默认值');
     }
 
     // 添加网页搜索参数
@@ -405,7 +409,7 @@ export class OpenAIProvider extends BaseOpenAIProvider {
     } catch (error: any) {
       // 检查是否为中断错误
       if (error?.name === 'AbortError' || error?.message?.includes('aborted')) {
-        console.log('[OpenAIProvider.sendChatMessage] 请求被用户中断');
+        logger.debug('请求被用户中断');
         throw new DOMException('Operation aborted', 'AbortError');
       }
 
@@ -413,11 +417,11 @@ export class OpenAIProvider extends BaseOpenAIProvider {
       if (error?.status === 400 && error?.message?.includes('max_tokens')) {
         const modelName = this.model.name || this.model.id;
         const currentMaxTokens = requestParams.max_tokens;
-        console.error(`[OpenAIProvider] ${modelName} 模型的 max_tokens 参数超出限制: ${currentMaxTokens}`);
+        logger.error(`${modelName} 模型的 max_tokens 参数超出限制: ${currentMaxTokens}`);
         throw new Error(`模型 ${modelName} 不支持当前的最大输出token设置 (${currentMaxTokens})。请在模型设置中降低最大输出token数量。`, { cause: error });
       }
 
-      console.error('[OpenAIProvider.sendChatMessage] API请求失败:', error);
+      logger.error('API请求失败:', error);
       throw error;
     }
   }
@@ -455,7 +459,7 @@ export class OpenAIProvider extends BaseOpenAIProvider {
 
       while (iteration < MAX_TOOL_ITERATIONS) {
         iteration++;
-        console.log(`[OpenAIProvider] 流式工具调用迭代 ${iteration}`);
+        logger.debug(`流式工具调用迭代 ${iteration}`);
 
         // 准备请求参数
         const iterationParams = {
@@ -468,7 +472,7 @@ export class OpenAIProvider extends BaseOpenAIProvider {
         if (this.getUseSystemPromptForTools()) {
           delete iterationParams.tools;
           delete iterationParams.tool_choice;
-          console.log(`[OpenAIProvider] 提示词模式：移除 API 中的 tools 参数`);
+          logger.debug(`提示词模式：移除 API 中的 tools 参数`);
         }
 
         // 构建流参数
@@ -490,11 +494,11 @@ export class OpenAIProvider extends BaseOpenAIProvider {
 
         lastResult = result;
 
-        console.log(`[OpenAIProvider] 流式响应结果类型: ${typeof result}, hasToolCalls: ${typeof result === 'object' && (result as any)?.hasToolCalls}`);
+        logger.debug(`流式响应结果类型: ${typeof result}, hasToolCalls: ${typeof result === 'object' && (result as any)?.hasToolCalls}`);
 
         // 检查是否有工具调用标记
         if (typeof result === 'object' && (result as any).hasToolCalls) {
-          console.log(`[OpenAIProvider] 流式响应检测到工具调用`);
+          logger.debug(`流式响应检测到工具调用`);
 
           const content = result.content;
           const nativeToolCalls = (result as any).nativeToolCalls;
@@ -503,12 +507,12 @@ export class OpenAIProvider extends BaseOpenAIProvider {
           // 根据用户设置决定工具调用方式
           if (usePromptMode) {
             // 提示词注入模式：使用 XML 格式工具调用
-            console.log(`[OpenAIProvider] 提示词注入模式：处理 XML 格式工具调用`);
+            logger.debug(`提示词注入模式：处理 XML 格式工具调用`);
             const { messages: xmlToolResults, hasCompletion } = await this.processToolUses(content, mcpTools, onChunk);
 
             if (xmlToolResults.length > 0) {
               // 保留完整内容（包含工具调用），让模型知道自己调用了什么工具
-              console.log(`[OpenAIProvider] 流式：对话历史保留完整内容（含工具调用），长度: ${content.length}`);
+              logger.debug(`流式：对话历史保留完整内容（含工具调用），长度: ${content.length}`);
 
               // 添加助手消息到对话历史（保留工具调用标签）
               // 同样需要保留 reasoning_content 以兼容 DeepSeek V4 thinking 模式
@@ -524,17 +528,17 @@ export class OpenAIProvider extends BaseOpenAIProvider {
 
               // 检测到 attempt_completion 时提前退出
               if (hasCompletion) {
-                console.log(`[OpenAIProvider] 检测到 attempt_completion，返回结果让上层处理终止`);
+                logger.debug(`检测到 attempt_completion，返回结果让上层处理终止`);
                 return result;
               }
 
-              console.log(`[OpenAIProvider] 流式 XML 工具调用完成，继续下一轮对话`);
+              logger.debug(`流式 XML 工具调用完成，继续下一轮对话`);
               continue;
             }
           } else {
             // 函数调用模式：使用原生 Function Calling
             if (nativeToolCalls && nativeToolCalls.length > 0) {
-              console.log(`[OpenAIProvider] 函数调用模式：检测到 ${nativeToolCalls.length} 个原生工具调用`);
+              logger.debug(`函数调用模式：检测到 ${nativeToolCalls.length} 个原生工具调用`);
 
               // 添加助手消息到对话历史（包含 tool_calls）
               // 注意：DeepSeek V4 thinking 模式要求把 reasoning_content 原样回传，
@@ -557,11 +561,11 @@ export class OpenAIProvider extends BaseOpenAIProvider {
 
                 // 如果检测到 attempt_completion，结束循环
                 if (hasCompletion) {
-                  console.log(`[OpenAIProvider] attempt_completion 已执行，结束工具调用循环`);
+                  logger.debug(`attempt_completion 已执行，结束工具调用循环`);
                   return result;
                 }
 
-                console.log(`[OpenAIProvider] 流式原生工具调用完成，继续下一轮对话`);
+                logger.debug(`流式原生工具调用完成，继续下一轮对话`);
                 continue;
               }
             }
@@ -573,15 +577,15 @@ export class OpenAIProvider extends BaseOpenAIProvider {
       }
 
       // 达到最大迭代次数：返回最后一轮结果而非丢弃内容（安全阀触发）
-      console.warn(`[OpenAIProvider] 流式工具调用达到最大迭代次数 ${MAX_TOOL_ITERATIONS}，提前结束循环`);
+      logger.warn(`流式工具调用达到最大迭代次数 ${MAX_TOOL_ITERATIONS}，提前结束循环`);
       return lastResult ?? '';
     } catch (error) {
       if (isAbortError(error)) {
-        console.log('[OpenAIProvider] 流式请求已取消:', error instanceof Error ? error.message : String(error));
+        logger.debug('流式请求已取消:', error instanceof Error ? error.message : String(error));
         throw new DOMException('Operation aborted', 'AbortError');
       }
 
-      console.error('[OpenAIProvider] 流式请求失败:', error);
+      logger.error('流式请求失败:', error);
       throw error;
     }
   }
@@ -716,7 +720,7 @@ export class OpenAIProvider extends BaseOpenAIProvider {
 
         // 如果检测到 attempt_completion，结束循环
         if (hasCompletion) {
-          console.log(`[OpenAIProvider] 非流式：attempt_completion 已执行，结束工具调用循环`);
+          logger.debug(`非流式：attempt_completion 已执行，结束工具调用循环`);
           if (toolResults.length > 0) {
             currentMessages.push(...toolResults);
           }
@@ -753,7 +757,7 @@ export class OpenAIProvider extends BaseOpenAIProvider {
         return finalContent;
       }
     } catch (error) {
-      console.error('[OpenAIProvider.handleNonStreamResponse] 非流式API请求失败:', error);
+      logger.error('非流式API请求失败:', error);
       throw error;
     }
   }

--- a/src/shared/api/openai/tools.ts
+++ b/src/shared/api/openai/tools.ts
@@ -13,6 +13,10 @@ import {
 import { isReasoningModel } from '../../../config/models';
 import type { MCPTool, MCPToolResponse, MCPCallToolResponse, Model } from '../../types';
 import { splitMcpToolContent, toImageDataUrl } from '../../utils/mcpToolResultContent';
+import { createLogger } from '../../services/infra/logger';
+
+const logger = createLogger('OpenAI Tools');
+
 
 // 重新导出工具类型和工具定义，保持向后兼容
 export const ToolType = ToolTypeEnum;
@@ -60,7 +64,7 @@ export function parseThinkingToolCall(toolCall: any): string | null {
       }
     }
   } catch (e) {
-    console.error('解析思考工具调用失败', e);
+    logger.error('解析思考工具调用失败', e);
   }
 
   return null;
@@ -99,14 +103,14 @@ export function parseToolCall(toolCall: any): { toolName: string; args: any } | 
       try {
         args = JSON.parse(toolCall.function.arguments);
       } catch (e) {
-        console.error(`解析工具参数失败: ${toolName}`, e);
+        logger.error(`解析工具参数失败: ${toolName}`, e);
         args = { raw: toolCall.function.arguments };
       }
     }
 
     return { toolName, args };
   } catch (e) {
-    console.error('解析工具调用失败', e);
+    logger.error('解析工具调用失败', e);
     return null;
   }
 }
@@ -165,7 +169,7 @@ export function openAIToolToTool(tools: any[], toolCall: any): any {
 
   // 如果找不到工具，返回undefined
   if (!tool) {
-    console.warn('未找到匹配的工具:', toolCall);
+    logger.warn('未找到匹配的工具:', toolCall);
     return undefined;
   }
 
@@ -206,7 +210,7 @@ export function convertMcpToolsToOpenAI<T>(mcpTools: MCPTool[]): T[] {
       toolName = `tool_${toolName}`;
     }
 
-    console.log(`[OpenAI] 转换工具名称: ${tool.id || tool.name} -> ${toolName}`);
+    logger.debug(`转换工具名称: ${tool.id || tool.name} -> ${toolName}`);
 
     return {
       type: 'function',

--- a/src/shared/api/openai/unifiedStreamProcessor.ts
+++ b/src/shared/api/openai/unifiedStreamProcessor.ts
@@ -17,6 +17,10 @@ import { ChunkType } from '../../types/chunk';
 import { hasToolUseTags } from '../../utils/mcpToolParser';
 import type { Model } from '../../types';
 import type { Chunk } from '../../types/chunk';
+import { createLogger } from '../../services/infra/logger';
+
+const logger = createLogger('UnifiedStreamProcessor');
+
 
 /**
  * 统一流处理选项
@@ -112,10 +116,10 @@ export class UnifiedStreamProcessor {
       return await this.processAdvancedStream(stream);
     } catch (error) {
       if (isAbortError(error)) {
-        console.log('[UnifiedStreamProcessor] 流式响应被用户中断');
+        logger.debug('流式响应被用户中断');
         throw new DOMException('Operation aborted', 'AbortError');
       }
-      console.error('[UnifiedStreamProcessor] 处理流式响应失败:', error);
+      logger.error('处理流式响应失败:', error);
       throw error;
     } finally {
       if (this.cleanup) {
@@ -128,7 +132,7 @@ export class UnifiedStreamProcessor {
    * 流处理模式 - 使用中间件和完整功能
    */
   private async processAdvancedStream(stream: AsyncIterable<any>): Promise<StreamProcessingResult> {
-    console.log(`[UnifiedStreamProcessor] 处理流式响应，模型: ${this.options.model.id}`);
+    logger.debug(`处理流式响应，模型: ${this.options.model.id}`);
 
     this.state.startTime = Date.now();
 
@@ -188,7 +192,7 @@ export class UnifiedStreamProcessor {
 
       // 如果是推理阶段结束，先发送推理完成事件
       if (isFirstContent && this.options.onChunk && this.state.reasoning && !this.state.thinkingCompleteSent) {
-        console.log('[UnifiedStreamProcessor] 推理阶段结束，发送 THINKING_COMPLETE');
+        logger.debug('推理阶段结束，发送 THINKING_COMPLETE');
         this.state.thinkingCompleteSent = true;
         await this.options.onChunk({
           type: ChunkType.THINKING_COMPLETE,
@@ -250,7 +254,7 @@ export class UnifiedStreamProcessor {
     } else if (chunk.type === 'finish') {
       // 先发送 THINKING_COMPLETE（如果有推理内容且还没发送过）
       if (this.state.reasoning && this.options.onChunk && !this.state.thinkingCompleteSent) {
-        console.log('[UnifiedStreamProcessor] finish: 发送 THINKING_COMPLETE');
+        logger.debug('finish: 发送 THINKING_COMPLETE');
         this.state.thinkingCompleteSent = true;
         await this.options.onChunk({
           type: ChunkType.THINKING_COMPLETE,
@@ -262,7 +266,7 @@ export class UnifiedStreamProcessor {
 
       // 处理完成 - 对于只有推理内容没有普通内容的模型（如纯推理模型）
       if (this.state.content.trim() === '' && this.state.reasoning && this.state.reasoning.trim() !== '') {
-        console.log('[UnifiedStreamProcessor] 纯推理模型：使用推理内容作为最终回复');
+        logger.debug('纯推理模型：使用推理内容作为最终回复');
         // 将推理内容设置为最终内容
         this.state.content = this.state.reasoning;
 
@@ -357,7 +361,7 @@ export class UnifiedStreamProcessor {
       if (!this.state.emittedToolIndices.has(index) && this.state.toolCalls[index].function.name) {
         this.state.emittedToolIndices.add(index);
         const toolCall = this.state.toolCalls[index];
-        console.log(`[UnifiedStreamProcessor] 检测到原生工具调用: ${toolCall.function.name} (等待参数完整后处理)`);
+        logger.debug(`检测到原生工具调用: ${toolCall.function.name} (等待参数完整后处理)`);
       }
     }
   }
@@ -376,7 +380,7 @@ export class UnifiedStreamProcessor {
     if (this.state.toolCalls.length > 0) {
       result.hasToolCalls = true;
       result.nativeToolCalls = this.state.toolCalls;
-      console.log(`[UnifiedStreamProcessor] 流式积累完成，原生工具调用数量: ${this.state.toolCalls.length}`);
+      logger.debug(`流式积累完成，原生工具调用数量: ${this.state.toolCalls.length}`);
     }
 
     // 检查 XML 格式工具调用
@@ -395,7 +399,7 @@ export class UnifiedStreamProcessor {
    */
   public setThinkingBlockId(blockId: string): void {
     if (blockId && blockId !== this.options.thinkingBlockId) {
-      console.log(`[UnifiedStreamProcessor] 更新思考块ID: ${blockId}`);
+      logger.debug(`更新思考块ID: ${blockId}`);
       this.options.thinkingBlockId = blockId;
     }
   }

--- a/src/shared/api/parameters/UnifiedParameterManager.ts
+++ b/src/shared/api/parameters/UnifiedParameterManager.ts
@@ -15,6 +15,10 @@ import type {
   UnifiedReasoningParameters
 } from './types';
 import { parameterSyncService } from '../../services/assistant/ParameterSyncService';
+import { createLogger } from '../../services/infra/logger';
+
+const logger = createLogger('UnifiedParameterManager');
+
 
 /**
  * 统一参数管理器类
@@ -220,7 +224,7 @@ export class UnifiedParameterManager {
       customParameters, // 🆕 添加
     };
 
-    console.log('[UnifiedParameterManager] 参数:', unified);
+    logger.debug('参数:', unified);
 
     return unified;
   }

--- a/src/shared/api/parameters/adapters/openai.ts
+++ b/src/shared/api/parameters/adapters/openai.ts
@@ -15,6 +15,10 @@ import { UnifiedParameterManager } from '../UnifiedParameterManager';
 import { isReasoningModel } from '../../../../config/models';
 import { encodeReasoningParams, type ReasoningApiFlavor } from '../reasoning/encodeReasoning';
 import { getDefaultThinkingEffort, getAppSettings } from '../../../utils/settingsUtils';
+import { createLogger } from '../../../services/infra/logger';
+
+const logger = createLogger('OpenAIParameterAdapter');
+
 
 /**
  * Chat Completions API 推理参数接口
@@ -325,7 +329,7 @@ export class OpenAIParameterAdapter implements ParameterAdapter<'openai'> {
     const extraBody = model.extraBody || model.providerExtraBody;
     if (extraBody && typeof extraBody === 'object') {
       Object.assign(completeParams, extraBody);
-      console.log(`[OpenAIParameterAdapter] 合并自定义请求体参数: ${Object.keys(extraBody).join(', ')}`);
+      logger.debug(`合并自定义请求体参数: ${Object.keys(extraBody).join(', ')}`);
     }
 
     return completeParams;

--- a/src/shared/api/providerFactory.ts
+++ b/src/shared/api/providerFactory.ts
@@ -5,6 +5,10 @@
 import { OpenAIProvider } from './openai/provider';
 import { OpenAIAISDKProvider } from './openai-aisdk/provider';
 import type { Model } from '../types';
+import { createLogger } from '../services/infra/logger';
+
+const logger = createLogger('ProviderFactory');
+
 
 /**
  * 创建 Provider 实例
@@ -14,7 +18,7 @@ import type { Model } from '../types';
 export function createProvider(model: Model): any {
   const providerType = model.providerType || model.provider;
   
-  console.log(`[ProviderFactory] 创建 Provider，类型: ${providerType}, 模型: ${model.id}`);
+  logger.debug(`创建 Provider，类型: ${providerType}, 模型: ${model.id}`);
   
   switch (providerType) {
     case 'openai':
@@ -38,7 +42,7 @@ export function createProvider(model: Model): any {
       
     default:
       // 默认使用 OpenAI Provider
-      console.warn(`[ProviderFactory] 未知的供应商类型: ${providerType}，使用默认 OpenAI Provider`);
+      logger.warn(`未知的供应商类型: ${providerType}，使用默认 OpenAI Provider`);
       return new OpenAIProvider(model);
   }
 }


### PR DESCRIPTION
## Summary
把 `src/shared/api` 下 **30 个文件、264 处裸 `console.*`** 迁移到统一日志器 `createLogger`(阶段4 分模块迁移,沿用 mcp #241 / store #242 / 文档 §13 规范)。纯日志出口改造,**不改任何业务逻辑**。请求层日志规范化后,后续可统一加脱敏 Processor(本仓 `logApiRequest/Response` 会打 API Key/token)。

每文件按层级用**相对路径**引入(仓库 tsconfig 无 `@/` 别名,tsc 不认 `@`),新增模块级 logger:
```ts
import { createLogger } from '../../services/infra/logger'; // 顶层 '../', adapters '../../../'
const logger = createLogger('OpenAIProvider');
// console.log('[OpenAIProvider] 开始 API 调用:', id)  ->  logger.debug('开始 API 调用:', id)
```

## 迁移规则
- 级别映射:`console.log`→`logger.debug`(诊断/冗余,生产默认隐藏)、`warn`→`warn`、`error`→`error`(本目录无 `console.info/debug`)。剥掉消息开头的 `[前缀]`(命名空间已携带),其余参数/模板字符串/错误对象尾参**原样保留**。
- **同一模块内不一致/方法级前缀归并为一个规范 context**(不滥建 logger):
  - `anthropic-aisdk/provider.ts`:`[Anthropic SDK Provider]`/`[AnthropicAISDKProvider]`/`[AnthropicProvider]` → `Anthropic SDK Provider`
  - `gemini-aisdk/provider.ts`、`openai-aisdk/provider.ts` 同理归并
  - `openai/provider.ts`:`[OpenAIProvider.sendChatMessage]`/`[OpenAIProvider.handleNonStreamResponse]`/`[OpenAI]` → `OpenAIProvider`
  - `openai/models.ts`、`index.ts`(函数级前缀)、`openai/multimodal.ts` 同理
- **stream 文件保留两个 logger**(`Stream` / `NonStream`)区分流式与非流式响应处理。
- 7 处无前缀的 `error`/`warn`(index.ts、openai/client.ts、openai/provider.ts、openai/tools.ts)归入所在文件的模块级 logger,消息不变。

## 验证
- `npm run type-check`:通过(0.28s)。
- `npm run build`(vite):通过(8060 modules transformed,✓ built in 4.53s)。
- `src/shared/api` 内 `console.*` 归零;`npx eslint src/shared/api` 无新增 `no-console` 告警。
- **CJK 字符数迁移前后完全一致**(17651 = 17651),确认仅剥离 ASCII `[前缀]`、无任何中文消息丢失。

## 范围
仅 `src/shared/api/**`(30 文件,+387/−264)。不涉及 logger 核心、旧 LoggerService/debugLogger、ESLint 配置或其他子系统。

Link to Devin session: https://app.devin.ai/sessions/b18b37124c694c8ab02698a24264d4aa
Requested by: @1600822305