### PR TITLE
重构(日志): messages 子系统 console.* 迁移到统一 createLogger（Phase 4 分模块）

### DIFF
--- a/src/shared/services/messages/ApiProvider.ts
+++ b/src/shared/services/messages/ApiProvider.ts
@@ -10,6 +10,8 @@ import { ModelComboProvider } from './ModelComboProvider';
 import { EnhancedApiProvider } from '../network/EnhancedApiProvider';
 import { OpenAIResponseProvider } from '../../providers/OpenAIResponseProvider';
 import store from '../../store';
+import { createLogger } from '../infra/logger';
+const logger = createLogger('ApiProvider');
 
 /**
  * 获取模型对应的供应商配置
@@ -27,7 +29,7 @@ function getProviderConfig(model: Model): ModelProvider | null {
     const provider = providers.find((p: ModelProvider) => p.id === model.provider);
     return provider || null;
   } catch (error) {
-    console.error('[ApiProvider] 获取供应商配置失败:', error);
+    logger.error('获取供应商配置失败:', error);
     return null;
   }
 }
@@ -62,11 +64,11 @@ function createProviderInstance(model: Model, providerType: string): any {
 function createEnhancedProvider(model: Model, providerConfig: ModelProvider | null, providerType: string) {
   // 如果没有多 Key 配置，创建单 Key 的 Provider
   if (!providerConfig?.apiKeys || providerConfig.apiKeys.length === 0) {
-    console.log(`[ApiProvider] 📝 单 Key 模式，直接创建 Provider`);
+    logger.debug(`📝 单 Key 模式，直接创建 Provider`);
     return createProviderInstance(model, providerType);
   }
 
-  console.log(`[ApiProvider] 🚀 多 Key 模式，支持 ${providerConfig.apiKeys.length} 个 Key，策略: ${providerConfig.keyManagement?.strategy || 'round_robin'}`);
+  logger.debug(`🚀 多 Key 模式，支持 ${providerConfig.apiKeys.length} 个 Key，策略: ${providerConfig.keyManagement?.strategy || 'round_robin'}`);
 
   const enhancedApiProvider = new EnhancedApiProvider();
 
@@ -83,11 +85,11 @@ function createEnhancedProvider(model: Model, providerConfig: ModelProvider | nu
         
         if (!selectedKey) {
           lastError = '没有可用的 API Key';
-          console.error(`[ApiProvider] ❌ ${lastError}`);
+          logger.error(`❌ ${lastError}`);
           break;
         }
 
-        console.log(`[ApiProvider] 🔑 [第${attempt + 1}次尝试] 使用 Key: ${selectedKey.name || selectedKey.id.substring(0, 8)}`);
+        logger.debug(`🔑 [第${attempt + 1}次尝试] 使用 Key: ${selectedKey.name || selectedKey.id.substring(0, 8)}`);
 
         try {
           // 🔧 每次请求时动态创建 Provider，使用当前选中的 Key
@@ -101,17 +103,17 @@ function createEnhancedProvider(model: Model, providerConfig: ModelProvider | nu
           // 🔧 直接调用并返回，让流式回调能实时工作
           const result = await provider.sendChatMessage(messages, options);
           
-          console.log(`[ApiProvider] ✅ Key ${selectedKey.name || selectedKey.id.substring(0, 8)} 调用成功`);
+          logger.debug(`✅ Key ${selectedKey.name || selectedKey.id.substring(0, 8)} 调用成功`);
           return result;
 
         } catch (error) {
           lastError = error instanceof Error ? error.message : String(error);
-          console.error(`[ApiProvider] ❌ Key ${selectedKey.name || selectedKey.id.substring(0, 8)} 调用失败:`, lastError);
+          logger.error(`❌ Key ${selectedKey.name || selectedKey.id.substring(0, 8)} 调用失败:`, lastError);
 
           // 如果不是最后一次尝试，等待后重试
           if (attempt < maxRetries - 1) {
             const delay = retryDelay * (attempt + 1);
-            console.log(`[ApiProvider] ⏳ 等待 ${delay}ms 后重试...`);
+            logger.debug(`⏳ 等待 ${delay}ms 后重试...`);
             await new Promise(resolve => setTimeout(resolve, delay));
           }
         }
@@ -152,13 +154,13 @@ function shouldUseResponsesAPI(model: Model): boolean {
   // 1. 检查供应商级别的 useResponsesAPI 设置
   const providerConfig = getProviderConfig(model);
   if (providerConfig?.useResponsesAPI === true) {
-    console.log(`[ApiProvider] 供应商 ${providerConfig.name} 启用了 Responses API`);
+    logger.debug(`供应商 ${providerConfig.name} 启用了 Responses API`);
     return true;
   }
 
   // 2. 检查模型级别是否明确启用了 Responses API
   if ((model as any).useResponsesAPI === true) {
-    console.log(`[ApiProvider] 模型 ${model.id} 启用了 Responses API`);
+    logger.debug(`模型 ${model.id} 启用了 Responses API`);
     return true;
   }
 
@@ -179,14 +181,14 @@ export const ApiProviderRegistry = {
   get(model: Model) {
     // 🎬 检查是否为视频生成模型
     if (isVideoGenerationModel(model)) {
-      console.log(`[ApiProviderRegistry] 检测到视频生成模型: ${model.id}`);
+      logger.withContext('ApiProviderRegistry').debug(`检测到视频生成模型: ${model.id}`);
       throw new Error(`模型 ${model.name || model.id} 是视频生成模型，不支持聊天对话。请使用专门的视频生成功能。`);
     }
 
     // 获取供应商配置
     const providerConfig = getProviderConfig(model);
     
-    console.log(`[ApiProvider] 📊 获取供应商配置:`, {
+    logger.debug(`📊 获取供应商配置:`, {
       modelId: model.id,
       modelProvider: model.provider,
       modelApiKey: model.apiKey ? `${model.apiKey.substring(0, 10)}...` : 'undefined',
@@ -209,7 +211,7 @@ export const ApiProviderRegistry = {
     // 🔧 检查是否需要使用 OpenAI Responses API
     let actualProviderType = providerType;
     if (providerType === 'openai' && shouldUseResponsesAPI(model)) {
-      console.log(`[ApiProvider] 🚀 自动使用 OpenAI Responses API for ${model.id}`);
+      logger.debug(`🚀 自动使用 OpenAI Responses API for ${model.id}`);
       actualProviderType = 'openai-response';
     }
 

--- a/src/shared/services/messages/MessageBlockCreator.ts
+++ b/src/shared/services/messages/MessageBlockCreator.ts
@@ -6,6 +6,8 @@ import { upsertOneBlock } from '../../store/slices/messageBlocksSlice';
 import { MessageBlockType, MessageBlockStatus } from '../../types/newMessage';
 import type { MessageBlock } from '../../types/newMessage';
 import type { AppDispatch } from '../../store';
+import { createLogger } from '../infra/logger';
+const logger = createLogger('MessageBlockCreator');
 
 /**
  * MessageBlockCreator 依赖接口
@@ -73,7 +75,7 @@ export class MessageBlockCreator {
       status: MessageBlockStatus.PENDING
     } as MessageBlock;
 
-    console.log(`[MessageBlockCreator] 创建主文本块 - ID: ${blockId}, 消息ID: ${messageId}`);
+    logger.debug(`创建主文本块 - ID: ${blockId}, 消息ID: ${messageId}`);
 
     // 添加到Redux
     this.deps.dispatch(upsertOneBlock(block));
@@ -103,7 +105,7 @@ export class MessageBlockCreator {
       status: MessageBlockStatus.PENDING
     } as MessageBlock;
 
-    console.log(`[MessageBlockCreator] 创建思考过程块 - ID: ${blockId}, 消息ID: ${messageId}`);
+    logger.debug(`创建思考过程块 - ID: ${blockId}, 消息ID: ${messageId}`);
 
     // 添加到Redux
     this.deps.dispatch(upsertOneBlock(block));
@@ -134,7 +136,7 @@ export class MessageBlockCreator {
       status: MessageBlockStatus.ERROR
     } as MessageBlock;
 
-    console.log(`[MessageBlockCreator] 创建错误块 - ID: ${blockId}, 消息ID: ${messageId}, 错误: ${errorMessage}`);
+    logger.debug(`创建错误块 - ID: ${blockId}, 消息ID: ${messageId}, 错误: ${errorMessage}`);
 
     // 添加到Redux
     this.deps.dispatch(upsertOneBlock(block));
@@ -167,7 +169,7 @@ export class MessageBlockCreator {
       status: MessageBlockStatus.SUCCESS
     } as MessageBlock;
 
-    console.log(`[MessageBlockCreator] 创建代码块 - ID: ${blockId}, 消息ID: ${messageId}, 语言: ${language || 'text'}`);
+    logger.debug(`创建代码块 - ID: ${blockId}, 消息ID: ${messageId}, 语言: ${language || 'text'}`);
 
     // 添加到Redux
     this.deps.dispatch(upsertOneBlock(block));
@@ -214,7 +216,7 @@ export class MessageBlockCreator {
       status: MessageBlockStatus.SUCCESS
     } as MessageBlock;
 
-    console.log(`[MessageBlockCreator] 创建视频块 - ID: ${blockId}, 消息ID: ${messageId}, 类型: ${videoData.mimeType}`);
+    logger.debug(`创建视频块 - ID: ${blockId}, 消息ID: ${messageId}, 类型: ${videoData.mimeType}`);
 
     // 添加到Redux
     this.deps.dispatch(upsertOneBlock(block));

--- a/src/shared/services/messages/MessageBlockRepository.ts
+++ b/src/shared/services/messages/MessageBlockRepository.ts
@@ -8,6 +8,8 @@ import {
   isTerminalBlockStatus
 } from '../../types/newMessage';
 import type { Message, MessageBlock, ThinkingMessageBlock } from '../../types/newMessage';
+import { createLogger } from '../infra/logger';
+const logger = createLogger('MessageBlockRepository');
 
 export type BlockAttachPosition =
   | { type: 'append' }
@@ -157,7 +159,7 @@ export class MessageBlockRepository {
     }
 
     if (finalized > 0) {
-      console.log(`[MessageBlockRepository] 收尾非终态块 ${finalized} 个 - 消息ID: ${messageId}`);
+      logger.debug(`收尾非终态块 ${finalized} 个 - 消息ID: ${messageId}`);
     }
 
     return finalized;

--- a/src/shared/services/messages/MessageContext.ts
+++ b/src/shared/services/messages/MessageContext.ts
@@ -1,5 +1,7 @@
 import { applyContextLimits, getContextSettings } from './messageService';
 import { dexieStorage } from '../storage/DexieStorageService';
+import { createLogger } from '../infra/logger';
+const logger = createLogger('MessageContext');
 
 /**
  * 消息上下文管理模块
@@ -27,7 +29,7 @@ export const MessageContext = {
       contextSettings.maxOutputTokens
     );
 
-    console.log(`[MessageContext] 准备消息上下文 - 主题ID: ${topicId}, 原始消息数: ${messages.length}, 限制后: ${limitedMessages.length}`);
+    logger.debug(`准备消息上下文 - 主题ID: ${topicId}, 原始消息数: ${messages.length}, 限制后: ${limitedMessages.length}`);
 
     return {
       messages: limitedMessages,

--- a/src/shared/services/messages/ModelComboProvider.ts
+++ b/src/shared/services/messages/ModelComboProvider.ts
@@ -9,13 +9,15 @@ import { getMainTextContent, createMessage } from '../../utils/messageUtils';
 import { ApiProviderRegistry } from './ApiProvider';
 import store from '../../store';
 import { modelMatchesIdentity, parseModelIdentityKey } from '../../utils/modelUtils';
+import { createLogger } from '../infra/logger';
+const logger = createLogger('ModelComboProvider');
 
 export class ModelComboProvider {
   private model: Model;
 
   constructor(model: Model) {
     this.model = model;
-    console.log(`[ModelComboProvider] 初始化模型组合提供商: ${model.id}`);
+    logger.debug(`初始化模型组合提供商: ${model.id}`);
   }
 
   /**
@@ -38,7 +40,7 @@ export class ModelComboProvider {
     }
   ): Promise<string | { content: string; reasoning?: string; reasoningTime?: number }> {
     try {
-      console.log(`[ModelComboProvider] 开始处理模型组合请求: ${this.model.id}`);
+      logger.debug(`开始处理模型组合请求: ${this.model.id}`);
 
       // 从模型配置中获取组合配置
       const comboConfig = (this.model as any).comboConfig;
@@ -46,8 +48,8 @@ export class ModelComboProvider {
         throw new Error(`模型组合 ${this.model.id} 的配置信息不存在`);
       }
 
-      console.log(`[ModelComboProvider] 传递完整消息历史，消息数量: ${messages.length}`);
-      console.log(`[ModelComboProvider] 组合策略: ${comboConfig.strategy}`);
+      logger.debug(`传递完整消息历史，消息数量: ${messages.length}`);
+      logger.debug(`组合策略: ${comboConfig.strategy}`);
 
       // 根据策略选择执行方法
       if (comboConfig.strategy === 'comparison') {
@@ -57,7 +59,7 @@ export class ModelComboProvider {
         return await this.executeComboWithStreaming(comboConfig, messages, options);
       }
     } catch (error) {
-      console.error('[ModelComboProvider] 模型组合请求失败:', error);
+      logger.error('模型组合请求失败:', error);
       throw new Error(`模型组合执行失败: ${error instanceof Error ? error.message : String(error)}`);
     }
   }
@@ -74,12 +76,12 @@ export class ModelComboProvider {
     }
   ): Promise<{ content: string; reasoning?: string; reasoningTime?: number; comboResult?: any }> {
     const startTime = Date.now();
-    console.log(`[ModelComboProvider] 执行对比策略，模型数量: ${comboConfig.models.length}`);
+    logger.debug(`执行对比策略，模型数量: ${comboConfig.models.length}`);
 
     // 并行调用所有模型
     const promises = comboConfig.models.map(async (modelConfig: any) => {
       try {
-        console.log(`[ModelComboProvider] 调用模型: ${modelConfig.modelId}`);
+        logger.debug(`调用模型: ${modelConfig.modelId}`);
 
         const model = await this.getModelById(modelConfig.modelId);
         if (!model) {
@@ -113,7 +115,7 @@ export class ModelComboProvider {
           status: 'success' as const
         };
       } catch (error) {
-        console.error(`[ModelComboProvider] 模型 ${modelConfig.modelId} 调用失败:`, error);
+        logger.error(`模型 ${modelConfig.modelId} 调用失败:`, error);
         return {
           modelId: modelConfig.modelId,
           role: modelConfig.role || 'assistant',
@@ -155,7 +157,7 @@ export class ModelComboProvider {
       }
     };
 
-    console.log(`[ModelComboProvider] 对比策略完成，成功模型: ${successResults.length}/${results.length}`);
+    logger.debug(`对比策略完成，成功模型: ${successResults.length}/${results.length}`);
 
     // 通过 onChunk 发送对比结果
     if (options?.onChunk) {
@@ -204,7 +206,7 @@ export class ModelComboProvider {
 
     try {
       // 第一阶段：调用推理模型，实时显示推理过程
-      console.log(`[ModelComboProvider] 第一阶段：调用推理模型 ${thinkingModel.modelId}`);
+      logger.debug(`第一阶段：调用推理模型 ${thinkingModel.modelId}`);
 
       const thinkingMessages: Message[] = messages;
 
@@ -226,7 +228,7 @@ export class ModelComboProvider {
           if (hasResolved) return;
           hasResolved = true;
           const fullReasoning = reasoningContent.join('');
-          console.log(`[ModelComboProvider] 推理完成 (来源: ${source})，总长度: ${fullReasoning.length}`);
+          logger.debug(`推理完成 (来源: ${source})，总长度: ${fullReasoning.length}`);
           resolve(fullReasoning);
         };
 
@@ -246,7 +248,7 @@ export class ModelComboProvider {
             // 处理推理完成 - 立即 resolve
             if (chunk.type === ChunkType.THINKING_COMPLETE) {
               reasoningComplete = true;
-              console.log(`[ModelComboProvider] 收到 THINKING_COMPLETE`);
+              logger.debug(`收到 THINKING_COMPLETE`);
               // 转发推理完成事件
               if (options?.onChunk) {
                 options.onChunk(chunk);
@@ -271,10 +273,10 @@ export class ModelComboProvider {
       const thinkingResponse = await reasoningPromise;
       accumulatedReasoning = thinkingResponse;
 
-      console.log(`[ModelComboProvider] 推理阶段完成，推理内容长度: ${accumulatedReasoning.length}`);
+      logger.debug(`推理阶段完成，推理内容长度: ${accumulatedReasoning.length}`);
 
       // 第二阶段：调用生成模型，基于推理结果生成答案
-      console.log(`[ModelComboProvider] 第二阶段：调用生成模型 ${generatingModel.modelId}`);
+      logger.debug(`第二阶段：调用生成模型 ${generatingModel.modelId}`);
 
       // 按照参考项目逻辑：直接复制完整消息历史并修改最后一个用户消息
       const generatingMessages: Message[] = JSON.parse(JSON.stringify(messages)); // 深拷贝
@@ -293,15 +295,15 @@ ${accumulatedReasoning}
       for (let i = generatingMessages.length - 1; i >= 0; i--) {
         if (generatingMessages[i].role === 'user') {
           const originalContent = getMainTextContent(generatingMessages[i]);
-          console.log(`[ModelComboProvider] 找到最后一个用户消息，原始内容: ${originalContent.substring(0, 50)}...`);
+          logger.debug(`找到最后一个用户消息，原始内容: ${originalContent.substring(0, 50)}...`);
 
           const fixedContent = `这是我的原始输入：
 ${originalContent}
 
 ${combinedContent}`;
 
-          console.log(`[ModelComboProvider] 修改后的内容长度: ${fixedContent.length}`);
-          console.log(`[ModelComboProvider] 修改后的内容预览: ${fixedContent.substring(0, 200)}...`);
+          logger.debug(`修改后的内容长度: ${fixedContent.length}`);
+          logger.debug(`修改后的内容预览: ${fixedContent.substring(0, 200)}...`);
 
           // 创建新的消息来替换最后一个用户消息
           const { message: modifiedMessage } = createMessage({
@@ -317,18 +319,18 @@ ${combinedContent}`;
           // 替换最后一个用户消息
           generatingMessages[i] = modifiedMessage;
           lastUserMessageFound = true;
-          console.log(`[ModelComboProvider] 已替换索引 ${i} 的用户消息`);
+          logger.debug(`已替换索引 ${i} 的用户消息`);
           break;
         }
       }
 
       if (!lastUserMessageFound) {
-        console.error(`[ModelComboProvider] 警告：没有找到用户消息进行修改`);
+        logger.error(`警告：没有找到用户消息进行修改`);
       }
 
-      console.log(`[ModelComboProvider] 最终消息数组长度: ${generatingMessages.length}`);
-      console.log(`[ModelComboProvider] 最后一个消息角色: ${generatingMessages[generatingMessages.length - 1]?.role}`);
-      console.log(`[ModelComboProvider] 最后一个消息内容预览: ${getMainTextContent(generatingMessages[generatingMessages.length - 1] || {} as any).substring(0, 100)}...`);
+      logger.debug(`最终消息数组长度: ${generatingMessages.length}`);
+      logger.debug(`最后一个消息角色: ${generatingMessages[generatingMessages.length - 1]?.role}`);
+      logger.debug(`最后一个消息内容预览: ${getMainTextContent(generatingMessages[generatingMessages.length - 1] || {} as any).substring(0, 100)}...`);
 
       // 获取生成模型配置并调用
       const generatingModelConfig = await this.getModelById(generatingModel.modelId);
@@ -339,10 +341,10 @@ ${combinedContent}`;
       const generatingProvider = ApiProviderRegistry.get(generatingModelConfig);
 
       // 调试：打印即将传递给生成模型的消息
-      console.log(`[ModelComboProvider] 即将传递给生成模型的消息数量: ${generatingMessages.length}`);
+      logger.debug(`即将传递给生成模型的消息数量: ${generatingMessages.length}`);
       generatingMessages.forEach((msg, index) => {
         const content = getMainTextContent(msg);
-        console.log(`[ModelComboProvider] 消息 ${index}: 角色=${msg.role}, 内容长度=${content.length}, 内容预览=${content.substring(0, 100)}...`);
+        logger.debug(`消息 ${index}: 角色=${msg.role}, 内容长度=${content.length}, 内容预览=${content.substring(0, 100)}...`);
       });
 
       // 调用生成模型，通过 onChunk 实时显示生成内容
@@ -372,7 +374,7 @@ ${combinedContent}`;
       });
 
       // Provider API 直接返回内容，不需要检查 success 字段
-      console.log(`[ModelComboProvider] 生成模型调用完成，响应类型:`, typeof generatingResponse);
+      logger.debug(`生成模型调用完成，响应类型:`, typeof generatingResponse);
 
       // 如果没有通过流式获取到最终内容，使用响应内容
       if (!finalContent && typeof generatingResponse === 'object' && generatingResponse.content) {
@@ -384,7 +386,7 @@ ${combinedContent}`;
         finalContent = generatingResponse;
       }
 
-      console.log(`[ModelComboProvider] 生成阶段完成，最终内容长度: ${finalContent.length}`);
+      logger.debug(`生成阶段完成，最终内容长度: ${finalContent.length}`);
 
       // 返回完整结果
       return {
@@ -394,7 +396,7 @@ ${combinedContent}`;
       };
 
     } catch (error) {
-      console.error('[ModelComboProvider] 流式执行失败:', error);
+      logger.error('流式执行失败:', error);
       throw error;
     }
   }
@@ -405,25 +407,25 @@ ${combinedContent}`;
    */
   async testConnection(): Promise<boolean> {
     try {
-      console.log(`[ModelComboProvider] 测试模型组合连接: ${this.model.id}`);
+      logger.debug(`测试模型组合连接: ${this.model.id}`);
 
       // 对于模型组合，我们检查组合配置是否存在
       const comboConfig = (this.model as any).comboConfig;
       if (!comboConfig) {
-        console.error(`[ModelComboProvider] 模型组合配置不存在: ${this.model.id}`);
+        logger.error(`模型组合配置不存在: ${this.model.id}`);
         return false;
       }
 
       // 检查组合中是否有模型
       if (!comboConfig.models || comboConfig.models.length === 0) {
-        console.error(`[ModelComboProvider] 模型组合中没有配置任何模型: ${this.model.id}`);
+        logger.error(`模型组合中没有配置任何模型: ${this.model.id}`);
         return false;
       }
 
-      console.log(`[ModelComboProvider] 模型组合连接测试通过: ${this.model.id}`);
+      logger.debug(`模型组合连接测试通过: ${this.model.id}`);
       return true;
     } catch (error) {
-      console.error(`[ModelComboProvider] 模型组合连接测试失败:`, error);
+      logger.error(`模型组合连接测试失败:`, error);
       return false;
     }
   }
@@ -448,7 +450,7 @@ ${combinedContent}`;
       const identity = parseModelIdentityKey(modelId);
 
       if (!identity) {
-        console.warn(`[ModelComboProvider] 无法解析模型标识: ${modelId}`);
+        logger.warn(`无法解析模型标识: ${modelId}`);
         return null;
       }
 
@@ -469,10 +471,10 @@ ${combinedContent}`;
         }
       }
 
-      console.warn(`[ModelComboProvider] 未找到模型: ${modelId}`);
+      logger.warn(`未找到模型: ${modelId}`);
       return null;
     } catch (error) {
-      console.error('[ModelComboProvider] 获取模型失败:', error);
+      logger.error('获取模型失败:', error);
       return null;
     }
   }

--- a/src/shared/services/messages/OpenAIResponseHandler.ts
+++ b/src/shared/services/messages/OpenAIResponseHandler.ts
@@ -7,6 +7,8 @@ import type { Chunk } from '../../types/chunk';
 import { ChunkType } from '../../types/chunk';
 import { MessageBlockType, MessageBlockStatus } from '../../types/newMessage';
 import { v4 as uuidv4 } from 'uuid';
+import { createLogger } from '../infra/logger';
+const logger = createLogger('OpenAIResponseHandler');
 
 /**
  * OpenAI Responses API 响应处理器配置类型
@@ -78,10 +80,10 @@ export class OpenAIResponseHandler {
           break;
 
         default:
-          console.log(`[OpenAIResponseHandler] 未处理的块类型: ${chunk.type}`);
+          logger.debug(`未处理的块类型: ${chunk.type}`);
       }
     } catch (error) {
-      console.error('[OpenAIResponseHandler] 处理响应块失败:', error);
+      logger.error('处理响应块失败:', error);
       this.handleError({
         type: ChunkType.ERROR,
         error: {

--- a/src/shared/services/messages/OpenAIResponseService.ts
+++ b/src/shared/services/messages/OpenAIResponseService.ts
@@ -7,6 +7,8 @@ import type { Model, MCPTool } from '../../types';
 import type { Message, AssistantMessageStatus } from '../../types/newMessage';
 import { EventEmitter } from '../infra/EventService';
 import { getMainTextContent } from '../../utils/messageUtils';
+import { createLogger } from '../infra/logger';
+const logger = createLogger('OpenAIResponseService');
 
 /**
  * OpenAI Responses API 消息服务
@@ -105,12 +107,12 @@ export class OpenAIResponseService {
         mcpTools,
         onChunk: handleChunk,
         onFilterMessages: (filteredMessages) => {
-          console.log(`[OpenAIResponseService] 过滤后的消息数量: ${filteredMessages.length}`);
+          logger.debug(`过滤后的消息数量: ${filteredMessages.length}`);
         }
       });
 
     } catch (error) {
-      console.error('[OpenAIResponseService] 发送聊天消息失败:', error);
+      logger.error('发送聊天消息失败:', error);
       
       // 发送错误事件
       EventEmitter.emit('ASSISTANT_MESSAGE_ERROR', {
@@ -184,7 +186,7 @@ export class OpenAIResponseService {
 
       return true;
     } catch (error) {
-      console.error('[OpenAIResponseService] 连接测试失败:', error);
+      logger.error('连接测试失败:', error);
       return false;
     }
   }
@@ -254,7 +256,7 @@ export class OpenAIResponseService {
    */
   public dispose(): void {
     // 清理任何需要清理的资源
-    console.log('[OpenAIResponseService] 服务已清理');
+    logger.debug('服务已清理');
   }
 }
 

--- a/src/shared/services/messages/ResponseHandler.ts
+++ b/src/shared/services/messages/ResponseHandler.ts
@@ -18,6 +18,8 @@ import { dexieStorage } from '../storage/DexieStorageService';
 import { updateOneBlock, addOneBlock } from '../../store/slices/messageBlocksSlice';
 import { getHighPerformanceUpdateInterval } from '../../utils/performanceSettings';
 import { StreamIncrementTracker } from './responseHandlers/StreamIncrementTracker';
+import { createLogger } from '../infra/logger';
+const logger = createLogger('ResponseHandler');
 
 /**
  * 响应处理器配置类型
@@ -101,12 +103,12 @@ export function createResponseHandler({ messageId, blockId, topicId, toolNames =
 
   // 设置事件监听器
   const setupEventListeners = () => {
-    console.log(`[ResponseHandler] 设置知识库搜索事件监听器`);
+    logger.debug(`设置知识库搜索事件监听器`);
 
     // 监听知识库搜索完成事件
     const knowledgeSearchCleanup = EventEmitter.on(EVENT_NAMES.KNOWLEDGE_SEARCH_COMPLETED, async (data: any) => {
       if (data.messageId === messageId) {
-        console.log(`[ResponseHandler] 处理知识库搜索完成事件，结果数量: ${data.searchResults?.length || 0}`);
+        logger.debug(`处理知识库搜索完成事件，结果数量: ${data.searchResults?.length || 0}`);
         await knowledgeHandler.handleKnowledgeSearchComplete(data);
       }
     });
@@ -152,11 +154,11 @@ export function createResponseHandler({ messageId, blockId, topicId, toolNames =
           }
 
           default:
-            console.log(`[ResponseHandler] 忽略未处理的 chunk 类型: ${chunk.type}`);
+            logger.debug(`忽略未处理的 chunk 类型: ${chunk.type}`);
             break;
         }
       } catch (error) {
-        console.error(`[ResponseHandler] 处理 chunk 事件失败:`, error);
+        logger.error(`处理 chunk 事件失败:`, error);
         throw error;
       }
     },
@@ -233,10 +235,10 @@ export function createResponseHandler({ messageId, blockId, topicId, toolNames =
 
       if (newRound) {
         // ⭐ 新一轮响应开始：先完成当前文本块（保存内容），再准备新块
-        console.log(`[ResponseHandler] 检测到新一轮响应，先保存当前内容再准备新文本块`);
+        logger.debug(`检测到新一轮响应，先保存当前内容再准备新文本块`);
         const savedBlockId = chunkProcessor.completeCurrentTextBlock();
         if (savedBlockId) {
-          console.log(`[ResponseHandler] 已保存上一轮文本块: ${savedBlockId}`);
+          logger.debug(`已保存上一轮文本块: ${savedBlockId}`);
         }
         // ⭐ 新一轮正式回答开始前，把上一段（思考阶段）的思考块也定稿并重置，
         // 避免下一段思考复用同一块、覆盖上一段内容。
@@ -278,7 +280,7 @@ export function createResponseHandler({ messageId, blockId, topicId, toolNames =
               hasAnyToolUse = true;
               // 只完成当前文本块，不重置状态
               const completedBlockId = chunkProcessor.completeCurrentTextBlock();
-              console.log(`[ResponseHandler] 工具检测：完成文本块 ${completedBlockId}，标记 hasAnyToolUse=true`);
+              logger.debug(`工具检测：完成文本块 ${completedBlockId}，标记 hasAnyToolUse=true`);
             }
             break;
         }
@@ -294,7 +296,7 @@ export function createResponseHandler({ messageId, blockId, topicId, toolNames =
       const currentState = store.getState();
       const message = currentState.messages.entities[messageId];
       if (message?.status === AssistantMessageStatus.SUCCESS) {
-        console.log(`[ResponseHandler] 消息已完成，停止处理`);
+        logger.debug(`消息已完成，停止处理`);
         return chunkProcessor.content;
       }
 
@@ -306,7 +308,7 @@ export function createResponseHandler({ messageId, blockId, topicId, toolNames =
         };
         await this.handleChunk(textChunk);
       } catch (error) {
-        console.error('[ResponseHandler] 处理字符串内容失败:', error);
+        logger.error('处理字符串内容失败:', error);
         throw error;
       }
 
@@ -373,5 +375,5 @@ export const setResponseState = ({ topicId, status, loading }: { topicId: string
   store.dispatch(newMessagesActions.setTopicStreaming({ topicId, streaming }));
   store.dispatch(newMessagesActions.setTopicLoading({ topicId, loading }));
 
-  console.log(`[ResponseHandler] 设置响应状态: topicId=${topicId}, status=${status}, loading=${loading}`);
+  logger.debug(`设置响应状态: topicId=${topicId}, status=${status}, loading=${loading}`);
 };

--- a/src/shared/services/messages/StreamProcessingService.ts
+++ b/src/shared/services/messages/StreamProcessingService.ts
@@ -11,6 +11,8 @@ import type {
   BlockCompleteChunk
 } from '../../types/chunk';
 import { ChunkType } from '../../types/chunk';
+import { createLogger } from '../infra/logger';
+const logger = createLogger('StreamProcessingService');
 
 // 流处理器回调接口 - 简化版本，参考最佳实例
 export interface StreamProcessorCallbacks {
@@ -61,7 +63,7 @@ export function createStreamProcessor(callbacks: StreamProcessorCallbacks = {}) 
       }
 
     } catch (error) {
-      console.error('处理流数据块时出错:', error);
+      logger.error('处理流数据块时出错:', error);
       callbacks.onError?.(error);
     }
   };

--- a/src/shared/services/messages/VersionService.ts
+++ b/src/shared/services/messages/VersionService.ts
@@ -12,6 +12,8 @@ import type {
   MessageVersion,
   MessageBlock
 } from '../../types/newMessage';
+import { createLogger } from '../infra/logger';
+const logger = createLogger('VersionService');
 
 /**
  * 优化的版本管理服务
@@ -39,7 +41,7 @@ class VersionService {
     source: string = 'regenerate'
   ): Promise<string> {
     try {
-      console.log(`[VersionService] 保存当前内容为版本 - 消息ID: ${messageId}`);
+      logger.debug(`保存当前内容为版本 - 消息ID: ${messageId}`);
 
       // 获取消息
       const message = await dexieStorage.getMessage(messageId);
@@ -58,7 +60,7 @@ class VersionService {
       }
 
       if (!versionContent?.trim()) {
-        console.log(`[VersionService] 内容为空，跳过版本保存`);
+        logger.debug(`内容为空，跳过版本保存`);
         return '';
       }
 
@@ -124,7 +126,7 @@ class VersionService {
           await dexieStorage.deleteMessageBlocksByIds(blockIdsToDelete);
         }
         
-        console.log(`[VersionService] 清理旧版本，从 ${versions.length} 减少到 ${versionsToKeep.length}`);
+        logger.debug(`清理旧版本，从 ${versions.length} 减少到 ${versionsToKeep.length}`);
         versions.length = 0;
         versions.push(...versionsToKeep);
       }
@@ -142,10 +144,10 @@ class VersionService {
         }
       }));
 
-      console.log(`[VersionService] 版本保存成功 - 版本ID: ${versionId}, 总版本数: ${versions.length}`);
+      logger.debug(`版本保存成功 - 版本ID: ${versionId}, 总版本数: ${versions.length}`);
       return versionId;
     } catch (error) {
-      console.error(`[VersionService] 保存版本失败:`, error);
+      logger.error(`保存版本失败:`, error);
       throw error;
     }
   }
@@ -165,7 +167,7 @@ class VersionService {
       
       return this.saveCurrentAsVersion(messageId, content, message.model, 'manual');
     } catch (error) {
-      console.error(`[VersionService] 手动创建版本失败:`, error);
+      logger.error(`手动创建版本失败:`, error);
       throw error;
     }
   }
@@ -280,7 +282,7 @@ class VersionService {
             timestamp: Date.now()
           }
         });
-        console.log(`[VersionService] latest snapshot 已转正为版本 ${versionId}`);
+        logger.debug(`latest snapshot 已转正为版本 ${versionId}`);
       } else {
         // snapshot 没有有效内容，直接丢弃
         await dexieStorage.deleteMessageBlocksByIds(latestBlockIds);
@@ -306,7 +308,7 @@ class VersionService {
    */
   async switchToVersion(versionId: string): Promise<boolean> {
     try {
-      console.log(`[VersionService] 切换到版本 - 版本ID: ${versionId}`);
+      logger.debug(`切换到版本 - 版本ID: ${versionId}`);
 
       // 查找包含该版本的消息
       const allMessages = await dexieStorage.getAllMessages();
@@ -319,7 +321,7 @@ class VersionService {
         }
       }
       if (!targetMessage || !targetVersion) {
-        console.error(`[VersionService] 找不到版本 ${versionId}`);
+        logger.error(`找不到版本 ${versionId}`);
         return false;
       }
 
@@ -336,7 +338,7 @@ class VersionService {
           model: targetMessage.model || null,
           modelId: targetMessage.modelId || null
         }));
-        console.log(`[VersionService] 已保存 latest snapshot`);
+        logger.debug(`已保存 latest snapshot`);
       }
 
       // ── 2. 获取目标版本的块 ──
@@ -354,7 +356,7 @@ class VersionService {
         // 兜底：版本没有块副本（旧版本数据），用 contentSnapshot 恢复 main_text
         const contentSnapshot = targetVersion.metadata?.contentSnapshot;
         if (!contentSnapshot) {
-          console.error(`[VersionService] 版本 ${versionId} 没有内容快照`);
+          logger.error(`版本 ${versionId} 没有内容快照`);
           return false;
         }
         const currentBlocks = await dexieStorage.getMessageBlocksByIds(targetMessage.blocks || []);
@@ -363,7 +365,7 @@ class VersionService {
           await dexieStorage.updateMessageBlock(mainTextBlock.id, { content: contentSnapshot, updatedAt: new Date().toISOString() });
           store.dispatch(updateOneBlock({ id: mainTextBlock.id, changes: { content: contentSnapshot, updatedAt: new Date().toISOString() } }));
         } else {
-          console.error(`[VersionService] 找不到消息 ${messageId} 的主文本块`);
+          logger.error(`找不到消息 ${messageId} 的主文本块`);
           return false;
         }
       }
@@ -386,10 +388,10 @@ class VersionService {
         }
       }));
 
-      console.log(`[VersionService] 版本切换成功 - 版本ID: ${versionId}`);
+      logger.debug(`版本切换成功 - 版本ID: ${versionId}`);
       return true;
     } catch (error) {
-      console.error(`[VersionService] 切换版本失败:`, error);
+      logger.error(`切换版本失败:`, error);
       return false;
     }
   }
@@ -399,7 +401,7 @@ class VersionService {
    */
   async switchToLatest(messageId: string): Promise<boolean> {
     try {
-      console.log(`[VersionService] 切换到最新版本 - 消息ID: ${messageId}`);
+      logger.debug(`切换到最新版本 - 消息ID: ${messageId}`);
 
       const message = await dexieStorage.getMessage(messageId);
       if (!message) {
@@ -421,7 +423,7 @@ class VersionService {
         // ── 2. 用 latest snapshot 替换当前块 ──
         await this.replaceCurrentBlocks(messageId, message.blocks || [], latestBlocks);
       } else {
-        console.warn(`[VersionService] 没有 latest snapshot 块，保留当前块`);
+        logger.warn(`没有 latest snapshot 块，保留当前块`);
         // 没有 snapshot（可能旧数据），不改块，只清 currentVersionId
       }
 
@@ -459,10 +461,10 @@ class VersionService {
       await dexieStorage.deleteSetting(this.latestBlocksKey(messageId));
       await dexieStorage.deleteSetting(this.latestModelKey(messageId));
 
-      console.log(`[VersionService] 已切换到最新版本`);
+      logger.debug(`已切换到最新版本`);
       return true;
     } catch (error) {
-      console.error(`[VersionService] 切换到最新版本失败:`, error);
+      logger.error(`切换到最新版本失败:`, error);
       return false;
     }
   }
@@ -479,7 +481,7 @@ class VersionService {
       const mainTextBlock = blocks.find(block => block.type === 'main_text');
       return (mainTextBlock as any)?.content || '';
     } catch (error) {
-      console.error(`[VersionService] 获取消息内容失败:`, error);
+      logger.error(`获取消息内容失败:`, error);
       return '';
     }
   }
@@ -503,7 +505,7 @@ class VersionService {
         currentVersionId: message.currentVersionId
       };
     } catch (error) {
-      console.error(`[VersionService] 获取消息版本信息失败:`, error);
+      logger.error(`获取消息版本信息失败:`, error);
       return { versions: [] };
     }
   }
@@ -526,7 +528,7 @@ class VersionService {
       }
       
       if (!targetMessage) {
-        console.error(`[VersionService] 找不到包含版本 ${versionId} 的消息`);
+        logger.error(`找不到包含版本 ${versionId} 的消息`);
         return false;
       }
       
@@ -557,10 +559,10 @@ class VersionService {
         }
       }));
       
-      console.log(`[VersionService] 成功删除版本 ${versionId}`);
+      logger.debug(`成功删除版本 ${versionId}`);
       return true;
     } catch (error) {
-      console.error(`[VersionService] 删除版本失败:`, error);
+      logger.error(`删除版本失败:`, error);
       return false;
     }
   }

--- a/src/shared/services/messages/messageService.ts
+++ b/src/shared/services/messages/messageService.ts
@@ -6,6 +6,8 @@ import { sendMessage as sendMessageThunk } from '../../store/thunks/messageThunk
 import { ApiProviderRegistry } from './ApiProvider';
 import { getMainTextContent } from '../../utils/blockUtils';
 import { estimateTokens } from '../../utils';
+import { createLogger } from '../infra/logger';
+const logger = createLogger('messageService');
 
 // 类似 Roo Code 的 TOKEN_BUFFER_PERCENTAGE
 const TOKEN_BUFFER_PERCENTAGE = 0.1;
@@ -39,7 +41,7 @@ export function truncateConversation(messages: Message[], fracToRemove: number =
   const messagesToRemove = rawMessagesToRemove - (rawMessagesToRemove % 2);
   const remainingMessages = messages.slice(messagesToRemove + 1);
   
-  console.log(`[truncateConversation] 滑动窗口截断: 删除 ${messagesToRemove} 条消息，保留 ${remainingMessages.length + 1} 条`);
+  logger.debug(`滑动窗口截断: 删除 ${messagesToRemove} 条消息，保留 ${remainingMessages.length + 1} 条`);
   
   return [firstMessage, ...remainingMessages];
 }
@@ -81,7 +83,7 @@ export function applyContextLimits(
     // 只有当 allowedTokens 为正数时才进行限制
     if (allowedTokens > 0) {
       let currentTokens = estimateMessagesTokenCount(limitedMessages);
-      console.log(`[applyContextLimits] Token 检查: ${currentTokens}/${allowedTokens} (窗口: ${contextWindowSize})`);
+      logger.debug(`Token 检查: ${currentTokens}/${allowedTokens} (窗口: ${contextWindowSize})`);
       
       // 如果超出限制，进行滑动窗口截断（最多尝试 10 次，避免无限循环）
       let attempts = 0;
@@ -96,7 +98,7 @@ export function applyContextLimits(
         }
         
         currentTokens = estimateMessagesTokenCount(limitedMessages);
-        console.log(`[applyContextLimits] 截断后 Token: ${currentTokens}/${allowedTokens}, 消息数: ${limitedMessages.length}`);
+        logger.debug(`截断后 Token: ${currentTokens}/${allowedTokens}, 消息数: ${limitedMessages.length}`);
         attempts++;
       }
     }
@@ -127,7 +129,7 @@ export async function getContextSettings(): Promise<{
       if (appSettings.maxOutputTokens !== undefined) maxOutputTokens = appSettings.maxOutputTokens;
     }
   } catch (error) {
-    console.error('读取上下文设置失败:', error);
+    logger.error('读取上下文设置失败:', error);
   }
 
   // 最佳实例逻辑：如果contextCount为100，则视为无限制（100000）
@@ -147,7 +149,7 @@ export async function loadTopics(): Promise<ChatTopic[]> {
     const topics = await getAllTopicsFromDB();
     return topics;
   } catch (error) {
-    console.error('从数据库加载话题失败:', error);
+    logger.error('从数据库加载话题失败:', error);
     return [];
   }
 }
@@ -179,7 +181,7 @@ export async function saveTopics(topics: ChatTopic[]): Promise<ChatTopic[]> {
 
     return uniqueTopics;
   } catch (error) {
-    console.error('保存话题到数据库失败:', error);
+    logger.error('保存话题到数据库失败:', error);
     return topics;
   }
 }
@@ -201,7 +203,7 @@ export class MessageService {
       // 应用上下文限制（同时考虑消息轮数和 Token 限制）
       const limitedMessages = applyContextLimits(messages, contextCount, contextWindowSize, maxOutputTokens);
 
-      console.log(`[handleChatRequest] 消息数: ${limitedMessages.length}, 模型: ${model.id}, 窗口: ${contextWindowSize || '模型默认'}`);
+      logger.debug(`消息数: ${limitedMessages.length}, 模型: ${model.id}, 窗口: ${contextWindowSize || '模型默认'}`);
 
       // 获取API提供商
       const apiProvider = ApiProviderRegistry.get(model);
@@ -212,10 +214,10 @@ export class MessageService {
 
       // handleChatRequest 是向后兼容方法，不需要流式更新
       const response = await apiProvider.sendChatMessage(limitedMessages, {});
-      console.log(`[handleChatRequest] API请求成功返回`);
+      logger.debug(`API请求成功返回`);
       return response;
     } catch (error) {
-      console.error(`[handleChatRequest] API请求失败:`, error);
+      logger.error(`API请求失败:`, error);
       throw error;
     }
   }
@@ -236,7 +238,7 @@ export class MessageService {
     } catch (error) {
       // 处理错误
       const errorMessage = error instanceof Error ? error.message : '发送消息失败';
-      console.error('发送消息失败:', errorMessage);
+      logger.error('发送消息失败:', errorMessage);
 
       // 清除流式响应状态
       store.dispatch(newMessagesActions.setTopicStreaming({

--- a/src/shared/services/messages/responseHandlers/KnowledgeSearchHandler.ts
+++ b/src/shared/services/messages/responseHandlers/KnowledgeSearchHandler.ts
@@ -1,6 +1,8 @@
 import { createCitationBlock } from '../../../utils/messageUtils';
 import type { KnowledgeReferenceItem } from '../../../types/newMessage';
 import { messageBlockRepository } from '../MessageBlockRepository';
+import { createLogger } from '../../infra/logger';
+const logger = createLogger('KnowledgeSearchHandler');
 
 /**
  * 知识库搜索处理器 - 处理知识库搜索相关的逻辑
@@ -28,7 +30,7 @@ export class KnowledgeSearchHandler {
     references: any[];
   }) {
     try {
-      console.log(`[KnowledgeSearchHandler] 处理知识库搜索完成，创建统一引用块，包含 ${data.searchResults.length} 个结果`);
+      logger.debug(`处理知识库搜索完成，创建统一引用块，包含 ${data.searchResults.length} 个结果`);
 
       // 将搜索结果转换为统一的 KnowledgeReferenceItem 格式
       const knowledgeItems: KnowledgeReferenceItem[] = data.references.map((ref, index) => ({
@@ -49,17 +51,17 @@ export class KnowledgeSearchHandler {
         knowledgeBaseNames: data.knowledgeBaseNames || (data.knowledgeBaseName ? [data.knowledgeBaseName] : []),
       });
 
-      console.log(`[KnowledgeSearchHandler] 创建统一引用块: ${citationBlock.id}`);
+      logger.debug(`创建统一引用块: ${citationBlock.id}`);
 
       await messageBlockRepository.createBlockAndAttach(citationBlock, {
         position: { type: 'prepend' }
       });
-      console.log(`[KnowledgeSearchHandler] 统一引用块已添加到消息顶部: ${citationBlock.id}`);
+      logger.debug(`统一引用块已添加到消息顶部: ${citationBlock.id}`);
 
-      console.log(`[KnowledgeSearchHandler] 统一引用块创建完成，包含 ${knowledgeItems.length} 条知识库引用`);
+      logger.debug(`统一引用块创建完成，包含 ${knowledgeItems.length} 条知识库引用`);
 
     } catch (error) {
-      console.error(`[KnowledgeSearchHandler] 处理知识库搜索完成事件失败:`, error);
+      logger.error(`处理知识库搜索完成事件失败:`, error);
     }
   }
 }

--- a/src/shared/services/messages/responseHandlers/ResponseChunkProcessor.ts
+++ b/src/shared/services/messages/responseHandlers/ResponseChunkProcessor.ts
@@ -6,6 +6,11 @@ import type { Chunk, TextDeltaChunk, TextCompleteChunk, ThinkingDeltaChunk, Thin
 import { ChunkType } from '../../../types/chunk';
 import { v4 as uuid } from 'uuid';
 import { EventEmitter, EVENT_NAMES } from '../../infra/EventService';
+import { createLogger } from '../../infra/logger';
+const logger = createLogger('ResponseChunkProcessor');
+const textAccumulatorLogger = logger.withContext('TextAccumulator');
+const thinkingAccumulatorLogger = logger.withContext('ThinkingAccumulator');
+const smartThrottledBlockUpdaterLogger = logger.withContext('SmartThrottledBlockUpdater');
 
 // 1. 定义服务接口，便于测试和解耦
 interface StorageService {
@@ -69,7 +74,7 @@ class TextAccumulator extends ContentAccumulator {
   accumulate(newText: string): void {
     // 防御性检查：确保输入是字符串
     if (typeof newText !== 'string') {
-      console.warn('[TextAccumulator] 输入不是字符串，跳过:', typeof newText);
+      textAccumulatorLogger.warn('输入不是字符串，跳过:', typeof newText);
       return;
     }
     // 供应商已发送累积内容，直接替换即可
@@ -82,7 +87,7 @@ class ThinkingAccumulator extends ContentAccumulator {
   accumulate(newText: string): void {
     // 防御性检查：确保输入是字符串
     if (typeof newText !== 'string') {
-      console.warn('[ThinkingAccumulator] 输入不是字符串，跳过:', typeof newText);
+      thinkingAccumulatorLogger.warn('输入不是字符串，跳过:', typeof newText);
       return;
     }
     // 供应商已发送累积内容，直接替换即可
@@ -284,7 +289,7 @@ class SmartThrottledBlockUpdater implements BlockUpdater {
       this.stateService.updateBlock(blockId, changes);
       // ⭐ 数据库异步保存，不阻塞（参考 Cherry Studio）
       this.storageService.updateBlock(blockId, changes).catch(err => 
-        console.error('[SmartThrottledBlockUpdater] 数据库更新失败:', err)
+        smartThrottledBlockUpdaterLogger.error('数据库更新失败:', err)
       );
     } else {
       // 同类型连续更新：使用节流 + RAF
@@ -303,7 +308,7 @@ class SmartThrottledBlockUpdater implements BlockUpdater {
     this.stateService.addBlockReference(block.messageId, block.id, block.status);
     // ⭐ 数据库异步保存，不阻塞（参考 Cherry Studio）
     this.storageService.saveBlock(block).catch(err => 
-      console.error('[SmartThrottledBlockUpdater] 数据库保存失败:', err)
+      smartThrottledBlockUpdaterLogger.error('数据库保存失败:', err)
     );
     
     // ⭐ 设置新创建的块为活跃块
@@ -332,7 +337,7 @@ class SmartThrottledBlockUpdater implements BlockUpdater {
     this.stateService.updateBlock(blockId, changes);
     // ⭐ 数据库异步保存，不阻塞（参考 Cherry Studio）
     this.storageService.updateBlock(blockId, changes).catch(err => 
-      console.error('[SmartThrottledBlockUpdater] 强制更新数据库失败:', err)
+      smartThrottledBlockUpdaterLogger.error('强制更新数据库失败:', err)
     );
   }
 
@@ -504,11 +509,11 @@ export class ResponseChunkProcessor {
           this.handleThinkingComplete(chunk as ThinkingCompleteChunk);
           break;
         default:
-          console.warn(`[ResponseChunkProcessor] 未知的 chunk 类型: ${chunk.type}`);
+          logger.warn(`未知的 chunk 类型: ${chunk.type}`);
       }
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : '未知错误';
-      console.error(`[ResponseChunkProcessor] 处理 ${chunk.type} 失败: ${errorMessage}`, error);
+      logger.error(`处理 ${chunk.type} 失败: ${errorMessage}`, error);
       throw new Error(`处理 chunk 失败: ${errorMessage}`);
     }
   }

--- a/src/shared/services/messages/responseHandlers/ResponseCompletionHandler.ts
+++ b/src/shared/services/messages/responseHandlers/ResponseCompletionHandler.ts
@@ -12,6 +12,8 @@ import { refreshTopicPreview } from '../../topics/TopicPreviewService';
 import type { ChunkProcessorView } from './ResponseChunkProcessor';
 import { finalizeNonTerminalBlocks } from './blockFinalization';
 import { messageBlockRepository } from '../MessageBlockRepository';
+import { createLogger } from '../../infra/logger';
+const logger = createLogger('ResponseCompletionHandler');
 
 /**
  * 响应完成处理器 - 处理响应完成和中断的逻辑
@@ -92,7 +94,7 @@ export class ResponseCompletionHandler {
    * 响应被中断时的完成处理
    */
   async completeWithInterruption(chunkProcessor: ChunkProcessorView) {
-    console.log(`[ResponseCompletionHandler] 响应被中断 - 消息ID: ${this.messageId}`);
+    logger.debug(`响应被中断 - 消息ID: ${this.messageId}`);
 
     // 关键修复：先取消所有待处理的节流/RAF 块更新，再收尾。
     // 否则中断时最后一帧 thinking 更新（status=streaming）会在 finalize 之后才触发，
@@ -109,7 +111,7 @@ export class ResponseCompletionHandler {
       return interruptedContent;
 
     } catch (error) {
-      console.error(`[ResponseCompletionHandler] 中断处理失败:`, error);
+      logger.error(`中断处理失败:`, error);
       return await this.complete(chunkProcessor.content, chunkProcessor);
     }
   }
@@ -128,7 +130,7 @@ export class ResponseCompletionHandler {
       const b = store.getState().messageBlocks.entities[id];
       return b ? `${id.slice(0, 6)}:${b.type}/${b.status}` : `${id.slice(0, 6)}:MISSING`;
     });
-    console.log(`[ResponseCompletionHandler] 中断收尾 blockId=${this.blockId.slice(0, 6)} blocks=[${dbgBlocks.join(', ')}]`);
+    logger.debug(`中断收尾 blockId=${this.blockId.slice(0, 6)} blocks=[${dbgBlocks.join(', ')}]`);
 
     // 1. 主块收尾。
     //    关键修复：初始块在「推理优先 / 纯思考」时可能本身就是思考块（initialBlockId 被
@@ -223,10 +225,10 @@ export class ResponseCompletionHandler {
       // 然后在事务中更新消息和话题引用
       await this.updateMessageAndTopicReferences(finalBlockIds, now);
 
-      console.log(`[ResponseCompletionHandler] 批量数据库操作完成`);
+      logger.debug(`批量数据库操作完成`);
 
     } catch (error) {
-      console.error(`[ResponseCompletionHandler] 批量数据库操作失败:`, error);
+      logger.error(`批量数据库操作失败:`, error);
       throw error;
     }
   }
@@ -374,7 +376,7 @@ export class ResponseCompletionHandler {
    */
   private isComparisonResult(finalContent: string | undefined, chunkProcessor: ChunkProcessorView): boolean {
     if (finalContent === '__COMPARISON_RESULT__' || chunkProcessor.content === '__COMPARISON_RESULT__') {
-      console.log(`[ResponseCompletionHandler] 检测到对比结果，跳过常规完成处理`);
+      logger.debug(`检测到对比结果，跳过常规完成处理`);
       return true;
     }
     return false;
@@ -385,11 +387,11 @@ export class ResponseCompletionHandler {
    */
   private async waitForToolsCompletion(): Promise<void> {
     try {
-      console.log(`[ResponseCompletionHandler] 等待所有工具执行完成...`);
+      logger.debug(`等待所有工具执行完成...`);
       await globalToolTracker.waitForAllToolsComplete(60000);
-      console.log(`[ResponseCompletionHandler] 所有工具执行完成`);
+      logger.debug(`所有工具执行完成`);
     } catch (error) {
-      console.warn(`[ResponseCompletionHandler] 等待工具完成超时:`, error);
+      logger.warn(`等待工具完成超时:`, error);
     }
   }
 
@@ -613,7 +615,7 @@ export class ResponseCompletionHandler {
       return block != null;
     });
 
-    console.log(`[ResponseCompletionHandler] 最终块ID（保持流式顺序）: [${finalBlockIds.join(', ')}]`);
+    logger.debug(`最终块ID（保持流式顺序）: [${finalBlockIds.join(', ')}]`);
     return finalBlockIds;
   }
 
@@ -646,9 +648,9 @@ export class ResponseCompletionHandler {
   private cleanupToolTracker(): void {
     try {
       globalToolTracker.cleanup();
-      console.log(`[ResponseCompletionHandler] 工具跟踪器清理完成`);
+      logger.debug(`工具跟踪器清理完成`);
     } catch (error) {
-      console.error(`[ResponseCompletionHandler] 工具跟踪器清理失败:`, error);
+      logger.error(`工具跟踪器清理失败:`, error);
     }
   }
 
@@ -662,15 +664,15 @@ export class ResponseCompletionHandler {
         // 获取最新的话题数据
         const topic = await dexieStorage.topics.get(this.topicId);
         if (topic && TopicNamingService.shouldNameTopic(topic)) {
-          console.log(`[ResponseCompletionHandler] 触发话题自动命名: ${this.topicId}`);
+          logger.debug(`触发话题自动命名: ${this.topicId}`);
           const newName = await TopicNamingService.generateTopicName(topic);
           if (newName) {
-            console.log(`[ResponseCompletionHandler] 话题自动命名成功: ${newName}`);
+            logger.debug(`话题自动命名成功: ${newName}`);
           }
         }
       }, 1000); // 延迟1秒执行，确保消息已完全保存
     } catch (error) {
-      console.error('[ResponseCompletionHandler] 话题自动命名失败:', error);
+      logger.error('话题自动命名失败:', error);
     }
   }
 }

--- a/src/shared/services/messages/responseHandlers/ResponseErrorHandler.ts
+++ b/src/shared/services/messages/responseHandlers/ResponseErrorHandler.ts
@@ -15,6 +15,8 @@ import { finalizeNonTerminalBlocks } from './blockFinalization';
 import { messageBlockRepository } from '../MessageBlockRepository';
 import { AISDKError } from 'ai';
 import type { AiSdkErrorUnion } from '../../../types/error';
+import { createLogger } from '../../infra/logger';
+const logger = createLogger('ResponseErrorHandler');
 
 /**
  * 响应错误处理器 - 处理错误相关的逻辑
@@ -35,7 +37,7 @@ export class ResponseErrorHandler {
    * @param error 错误对象
    */
   async fail(error: Error) {
-    console.error(`[ResponseErrorHandler] 响应失败 - 消息ID: ${this.messageId}, 错误:`, error);
+    logger.error(`响应失败 - 消息ID: ${this.messageId}, 错误:`, error);
 
     // 新增：检测 API Key 问题并提供重试机制
     // 注意：现在 checkAndHandleApiKeyError 返回 false，让我们继续创建错误块
@@ -61,7 +63,7 @@ export class ResponseErrorHandler {
     
     // 检查是否为 AI SDK 错误并序列化
     if (AISDKError.isInstance(error)) {
-      console.log('[ResponseErrorHandler] 检测到 AI SDK 错误，进行序列化');
+      logger.debug('检测到 AI SDK 错误，进行序列化');
       errorRecord = serializeError(error as AiSdkErrorUnion);
     } else {
       // 普通错误，获取详细信息
@@ -186,9 +188,9 @@ export class ResponseErrorHandler {
     // 参考 Cline：清理工具跟踪器（错误情况）
     try {
       globalToolTracker.reset(); // 错误时重置所有状态
-      console.log(`[ResponseErrorHandler] 工具跟踪器重置完成（错误处理）`);
+      logger.debug(`工具跟踪器重置完成（错误处理）`);
     } catch (cleanupError) {
-      console.error(`[ResponseErrorHandler] 工具跟踪器重置失败:`, cleanupError);
+      logger.error(`工具跟踪器重置失败:`, cleanupError);
     }
 
     throw error;

--- a/src/shared/services/messages/responseHandlers/ToolResponseHandler.ts
+++ b/src/shared/services/messages/responseHandlers/ToolResponseHandler.ts
@@ -7,6 +7,8 @@ import { createToolBlock, createCitationBlock } from '../../../utils/messageUtil
 // callMCPTool 不再需要 - 工具执行由 Provider 层统一处理
 import type { MCPTool } from '../../../types';
 import { messageBlockRepository } from '../MessageBlockRepository';
+import { createLogger } from '../../infra/logger';
+const logger = createLogger('ToolResponseHandler');
 
 /**
  * 检查是否是 attempt_completion 工具（支持带前缀的名称）
@@ -81,9 +83,9 @@ export class ToolResponseHandler {
         await messageBlockRepository.createBlockAndAttach(toolBlock);
       }
 
-      console.log(`[ToolResponseHandler] 原子性工具块操作完成: ${operation} - toolId: ${toolId}, blockId: ${toolBlock.id}`);
+      logger.debug(`原子性工具块操作完成: ${operation} - toolId: ${toolId}, blockId: ${toolBlock.id}`);
     } catch (error) {
-      console.error(`[ToolResponseHandler] 原子性工具块操作失败: ${operation} - toolId: ${toolId}:`, error);
+      logger.error(`原子性工具块操作失败: ${operation} - toolId: ${toolId}:`, error);
       throw error;
     }
   }
@@ -108,7 +110,7 @@ export class ToolResponseHandler {
         await messageBlockRepository.updateBlock(existingBlockId, errorChanges);
       }
     } catch (updateError) {
-      console.error(`[ToolResponseHandler] 更新工具错误状态失败:`, updateError);
+      logger.error(`更新工具错误状态失败:`, updateError);
     }
   }
 
@@ -117,7 +119,7 @@ export class ToolResponseHandler {
    */
   async handleToolProgress(chunk: { type: 'mcp_tool_in_progress'; responses: any[] }) {
     try {
-      console.log(`[ToolResponseHandler] 处理工具进行中，工具数量: ${chunk.responses?.length || 0}`);
+      logger.debug(`处理工具进行中，工具数量: ${chunk.responses?.length || 0}`);
 
       if (!chunk.responses || chunk.responses.length === 0) {
         return;
@@ -126,14 +128,14 @@ export class ToolResponseHandler {
       // 参考 Cline 的顺序处理机制：逐个处理工具响应，确保稳定性
       for (const toolResponse of chunk.responses) {
         try {
-          console.log(`[ToolResponseHandler] 处理工具响应: toolResponse.id=${toolResponse.id}, tool.name=${toolResponse.tool.name}, tool.id=${toolResponse.tool.id}`);
+          logger.debug(`处理工具响应: toolResponse.id=${toolResponse.id}, tool.name=${toolResponse.tool.name}, tool.id=${toolResponse.tool.id}`);
 
           // 参考 Cline：如果是 invoking 状态，创建新的工具块
           if (toolResponse.status === 'invoking') {
             // 检查是否已存在该工具的块（防止重复创建）
             const existingBlockId = this.toolCallIdToBlockIdMap.get(toolResponse.id);
             if (existingBlockId) {
-              console.log(`[ToolResponseHandler] 工具块已存在: ${existingBlockId} (toolId: ${toolResponse.id})`);
+              logger.debug(`工具块已存在: ${existingBlockId} (toolId: ${toolResponse.id})`);
               continue;
             }
 
@@ -153,7 +155,7 @@ export class ToolResponseHandler {
               }
             });
 
-            console.log(`[ToolResponseHandler] 创建工具块: ${toolBlock.id} (${(toolBlock as ToolMessageBlock).toolName})`);
+            logger.debug(`创建工具块: ${toolBlock.id} (${(toolBlock as ToolMessageBlock).toolName})`);
 
             // 修复：简化操作，避免复杂事务
             // 1. 更新映射
@@ -163,16 +165,16 @@ export class ToolResponseHandler {
             await messageBlockRepository.createBlockAndAttach(toolBlock);
 
           } else {
-            console.warn(`[ToolResponseHandler] 收到未处理的工具状态: ${toolResponse.status} for ID: ${toolResponse.id}`);
+            logger.warn(`收到未处理的工具状态: ${toolResponse.status} for ID: ${toolResponse.id}`);
           }
         } catch (toolError) {
           // 参考 Cline 的错误处理：单个工具失败不影响其他工具
-          console.error(`[ToolResponseHandler] 处理单个工具失败 (toolId: ${toolResponse.id}):`, toolError);
+          logger.error(`处理单个工具失败 (toolId: ${toolResponse.id}):`, toolError);
           await this.handleSingleToolError(toolResponse.id, toolError);
         }
       }
     } catch (error) {
-      console.error(`[ToolResponseHandler] 处理工具进行中事件失败:`, error);
+      logger.error(`处理工具进行中事件失败:`, error);
     }
   }
 
@@ -183,9 +185,9 @@ export class ToolResponseHandler {
     try {
       await messageBlockRepository.updateBlock(blockId, changes);
 
-      console.log(`[ToolResponseHandler] 原子性工具块更新完成: blockId: ${blockId}`);
+      logger.debug(`原子性工具块更新完成: blockId: ${blockId}`);
     } catch (error) {
-      console.error(`[ToolResponseHandler] 原子性工具块更新失败: blockId: ${blockId}:`, error);
+      logger.error(`原子性工具块更新失败: blockId: ${blockId}:`, error);
       throw error;
     }
   }
@@ -209,7 +211,7 @@ export class ToolResponseHandler {
       const endTime = new Date().getTime();
       return endTime - startTime;
     } catch (error) {
-      console.error(`[ToolResponseHandler] 计算工具执行时长失败:`, error);
+      logger.error(`计算工具执行时长失败:`, error);
       return undefined;
     }
   }
@@ -238,7 +240,7 @@ export class ToolResponseHandler {
       }
 
       if (webSearchResults.length === 0) {
-        console.log(`[ToolResponseHandler] Web 搜索无结果，跳过引用块创建`);
+        logger.debug(`Web 搜索无结果，跳过引用块创建`);
         return;
       }
 
@@ -258,14 +260,14 @@ export class ToolResponseHandler {
         webSearchProvider: webSearchItems[0]?.provider,
       });
 
-      console.log(`[ToolResponseHandler] 创建 Web 搜索引用块: ${citationBlock.id}，包含 ${webSearchItems.length} 条结果`);
+      logger.debug(`创建 Web 搜索引用块: ${citationBlock.id}，包含 ${webSearchItems.length} 条结果`);
 
       await messageBlockRepository.createBlockAndAttach(citationBlock, {
         position: { type: 'after', anchorBlockId: _toolBlockId }
       });
-      console.log(`[ToolResponseHandler] Web 搜索引用块已添加到消息: ${citationBlock.id}`);
+      logger.debug(`Web 搜索引用块已添加到消息: ${citationBlock.id}`);
     } catch (error) {
-      console.error(`[ToolResponseHandler] 创建 Web 搜索引用块失败:`, error);
+      logger.error(`创建 Web 搜索引用块失败:`, error);
     }
   }
 
@@ -276,9 +278,9 @@ export class ToolResponseHandler {
     try {
       // 可以在这里添加工具执行完成后的清理逻辑
       // 例如：清理临时文件、释放资源等
-      console.log(`[ToolResponseHandler] 清理工具执行: toolId: ${toolId}`);
+      logger.debug(`清理工具执行: toolId: ${toolId}`);
     } catch (error) {
-      console.error(`[ToolResponseHandler] 清理工具执行失败:`, error);
+      logger.error(`清理工具执行失败:`, error);
     }
   }
 
@@ -287,7 +289,7 @@ export class ToolResponseHandler {
    */
   async handleToolComplete(chunk: { type: 'mcp_tool_complete'; responses: any[] }) {
     try {
-      console.log(`[ToolResponseHandler] 处理工具完成，工具数量: ${chunk.responses?.length || 0}`);
+      logger.debug(`处理工具完成，工具数量: ${chunk.responses?.length || 0}`);
 
       if (!chunk.responses || chunk.responses.length === 0) {
         return;
@@ -301,7 +303,7 @@ export class ToolResponseHandler {
 
           if (toolResponse.status === 'done' || toolResponse.status === 'error') {
             if (!existingBlockId) {
-              console.error(`[ToolResponseHandler] 未找到工具调用 ${toolResponse.id} 对应的工具块ID`);
+              logger.error(`未找到工具调用 ${toolResponse.id} 对应的工具块ID`);
               continue;
             }
 
@@ -323,7 +325,7 @@ export class ToolResponseHandler {
                 if (completionInfo.command) {
                   displayContent += `\n\n📋 **建议执行命令:**\n\`\`\`\n${completionInfo.command}\n\`\`\``;
                 }
-                console.log(`[ToolResponseHandler] attempt_completion 结果已格式化`);
+                logger.debug(`attempt_completion 结果已格式化`);
               }
             }
             
@@ -348,7 +350,7 @@ export class ToolResponseHandler {
               };
             }
 
-            console.log(`[ToolResponseHandler] 更新工具块 ${existingBlockId} (toolId: ${toolResponse.id}) 状态为 ${finalStatus}${isCompletion ? ' [attempt_completion]' : ''}`);
+            logger.debug(`更新工具块 ${existingBlockId} (toolId: ${toolResponse.id}) 状态为 ${finalStatus}${isCompletion ? ' [attempt_completion]' : ''}`);
 
             // 修复：简化更新操作，避免复杂事务
 
@@ -366,11 +368,11 @@ export class ToolResponseHandler {
             await this.cleanupToolExecution(toolResponse.id);
 
           } else {
-            console.warn(`[ToolResponseHandler] 收到未处理的工具状态: ${toolResponse.status} for ID: ${toolResponse.id}`);
+            logger.warn(`收到未处理的工具状态: ${toolResponse.status} for ID: ${toolResponse.id}`);
           }
         } catch (toolError) {
           // 参考 Cline 的错误处理：单个工具失败不影响其他工具
-          console.error(`[ToolResponseHandler] 处理单个工具完成失败 (toolId: ${toolResponse.id}):`, toolError);
+          logger.error(`处理单个工具完成失败 (toolId: ${toolResponse.id}):`, toolError);
 
           // 修复：即使处理失败也要标记工具完成，避免无限等待
           globalToolTracker.completeTool(toolResponse.id, false);
@@ -379,7 +381,7 @@ export class ToolResponseHandler {
         }
       }
     } catch (error) {
-      console.error(`[ToolResponseHandler] 处理工具完成事件失败:`, error);
+      logger.error(`处理工具完成事件失败:`, error);
     }
   }
 
@@ -406,7 +408,7 @@ export class ToolResponseHandler {
           break;
       }
     } catch (error) {
-      console.error(`[ToolResponseHandler] 处理 chunk 事件失败:`, error);
+      logger.error(`处理 chunk 事件失败:`, error);
       throw error;
     }
   }

--- a/src/shared/services/messages/responseHandlers/ToolUseExtractionProcessor.ts
+++ b/src/shared/services/messages/responseHandlers/ToolUseExtractionProcessor.ts
@@ -11,6 +11,8 @@ import { ToolTagExtractor } from '../../../utils/tagExtraction';
 import type { ToolTagExtractionResult } from '../../../utils/tagExtraction';
 import type { MCPToolResponse, TextDeltaChunk, Chunk } from '../../../types/chunk';
 import { ChunkType } from '../../../types/chunk';
+import { createLogger } from '../../infra/logger';
+const logger = createLogger('ToolUseExtractionProcessor');
 
 /**
  * 处理结果类型
@@ -40,7 +42,7 @@ export class ToolUseExtractionProcessor {
    */
   constructor(toolNames: string[] = []) {
     this.tagExtractor = new ToolTagExtractor(toolNames);
-    console.log(`[ToolUseExtractionProcessor] 初始化，工具数量: ${toolNames.length}`);
+    logger.debug(`初始化，工具数量: ${toolNames.length}`);
   }
 
   /**
@@ -78,7 +80,7 @@ export class ToolUseExtractionProcessor {
       if (toolResponses.length > 0) {
         this.toolUseCount += toolResponses.length;
 
-        console.log(`[ToolUseExtractionProcessor] 检测到工具调用，格式: ${result.format}, 数量: ${toolResponses.length}`);
+        logger.debug(`检测到工具调用，格式: ${result.format}, 数量: ${toolResponses.length}`);
 
         return {
           type: 'tool_created',
@@ -127,7 +129,7 @@ export class ToolUseExtractionProcessor {
         }
       }
     } catch (error) {
-      console.error(`[ToolUseExtractionProcessor] 解析工具内容失败:`, error);
+      logger.error(`解析工具内容失败:`, error);
     }
 
     return responses;
@@ -141,7 +143,7 @@ export class ToolUseExtractionProcessor {
       // 提取 <name> 标签内容
       const nameMatch = content.match(/<name>\s*([\s\S]*?)\s*<\/name>/);
       if (!nameMatch) {
-        console.warn(`[ToolUseExtractionProcessor] tool_use 格式缺少 <name> 标签`);
+        logger.warn(`tool_use 格式缺少 <name> 标签`);
         return null;
       }
       const name = nameMatch[1].trim();
@@ -172,7 +174,7 @@ export class ToolUseExtractionProcessor {
         toolCallId: id
       };
     } catch (error) {
-      console.error(`[ToolUseExtractionProcessor] 解析 tool_use 格式失败:`, error);
+      logger.error(`解析 tool_use 格式失败:`, error);
       return null;
     }
   }
@@ -206,7 +208,7 @@ export class ToolUseExtractionProcessor {
         toolCallId: id
       };
     } catch (error) {
-      console.error(`[ToolUseExtractionProcessor] 解析直接格式失败:`, error);
+      logger.error(`解析直接格式失败:`, error);
       return null;
     }
   }


### PR DESCRIPTION
## Summary

日志系统 Phase 4 分模块迁移的 messages 子系统，与已合并的 mcp(#241)、store(#242) 样板配套。将 `src/shared/services/messages/**` 下全部 **169 处裸 `console.*`** 迁移到统一日志器 `createLogger`，**仅替换日志出口**，不改任何业务逻辑/控制流/返回值。

每个文件在 import 之后新增模块级 logger：

```ts
import { createLogger } from '../infra/logger';      // responseHandlers/ 下用 '../../infra/logger'
const logger = createLogger('<Context>');
```

剥去消息开头的 `[前缀]`，其余参数/顺序/emoji/末尾 error 对象原样保留：

```ts
// before
console.log(`[ResponseHandler] 开始处理:`, id);
// after  (createLogger('ResponseHandler'))
logger.debug(`开始处理:`, id);
```

## 范围（仅 messages，17 个文件）

- 顶层（`'../infra/logger'`）：`ApiProvider.ts`(13)、`MessageBlockCreator.ts`(5)、`MessageBlockRepository.ts`(1)、`MessageContext.ts`(1)、`ModelComboProvider.ts`(35)、`OpenAIResponseHandler.ts`(2)、`OpenAIResponseService.ts`(4)、`ResponseHandler.ts`(10)、`StreamProcessingService.ts`(1)、`VersionService.ts`(23)、`messageService.ts`(10)
- `responseHandlers/`（`'../../infra/logger'`）：`KnowledgeSearchHandler.ts`(5)、`ResponseChunkProcessor.ts`(7)、`ResponseCompletionHandler.ts`(15)、`ResponseErrorHandler.ts`(4)、`ToolResponseHandler.ts`(27)、`ToolUseExtractionProcessor.ts`(6)
- 未触碰 logger 核心、旧 `LoggerService.ts`/`debugLogger.ts`、eslint 配置，以及 messages 以外的任何文件。
- 使用相对路径（仓库 tsconfig 无 `@/` 别名）。

## 级别映射

- `console.log → logger.debug`（绝大多数）
- `console.warn → logger.warn`、`console.error → logger.error`
- 本批无 `console.info/debug/trace`；保持克制，未将 log 升级为 info。

## Context 命名 / withContext 处理

- 各文件 context 取原 `[前缀]`/文件名（如 `ApiProvider`、`VersionService`、`messageService`）。
- `messageService.ts` 内函数级前缀 `[applyContextLimits]`/`[handleChatRequest]`/`[truncateConversation]` 一律归并到模块 logger（函数名在调用栈可见）。
- `ApiProvider.ts` 中 1 处 `[ApiProviderRegistry]` → `logger.withContext('ApiProviderRegistry')`。
- `ResponseChunkProcessor.ts` 主 logger 为 `ResponseChunkProcessor`，内含多类前缀分别派生子 logger：

```ts
const textAccumulatorLogger = logger.withContext('TextAccumulator');
const thinkingAccumulatorLogger = logger.withContext('ThinkingAccumulator');
const smartThrottledBlockUpdaterLogger = logger.withContext('SmartThrottledBlockUpdater');
```

- `StreamProcessingService.ts` 该处 console 无前缀，消息原样保留。

## 自检结果

- `grep -rnE "console\.(log|info|warn|error|debug|trace|group)" src/shared/services/messages` → 0 残留。
- `npm run type-check` 通过。
- `npm run build` 通过（`✓ built in 4.29s`）。
- 改动文件无新增 `no-console` 告警；`tsc -p tsconfig.app.json` 错误集合与 `origin/main` 完全一致（未引入新错误）。仓库既有、与本次迁移无关的告警（如 `preserve-caught-error`、`no-useless-assignment`）不在本任务范围，未改动。
- 完整 review git diff：消息内容、参数、末尾 error 对象均无损；中段非前缀的 `[...]`（如 `${isCompletion ? ' [attempt_completion]' : ''}`）保持不变。


Link to Devin session: https://app.devin.ai/sessions/48954296a9874bf396127b2fa8a9fd8e
Requested by: @1600822305