### PR TITLE
refactor(webSearch): 将 webSearch 子系统裸 console.* 迁移到统一日志器 createLogger

### DIFF
--- a/src/shared/services/webSearch/AIIntentAnalyzer.ts
+++ b/src/shared/services/webSearch/AIIntentAnalyzer.ts
@@ -11,6 +11,9 @@
 import { sendChatRequest } from '../../api';
 import store from '../../store';
 import type { ExtractedSearchKeywords } from './WebSearchTool';
+import { createLogger } from '../infra/logger';
+
+const logger = createLogger('IntentAnalyzer');
 
 // ==================== 类型定义 ====================
 
@@ -381,7 +384,7 @@ function parseUnifiedResponse(response: string, options: IntentAnalysisOptions):
       }
     }
   } catch (error) {
-    console.error('[IntentAnalyzer] 解析 AI 响应失败:', error);
+    logger.error('解析 AI 响应失败:', error);
   }
 
   return result;
@@ -477,7 +480,7 @@ export async function analyzeUnifiedSearchIntent(
       .replace('{chat_history}', () => chatHistory)
       .replace('{question}', () => userMessage);
 
-    console.log('[IntentAnalyzer] 开始统一意图分析', {
+    logger.debug('开始统一意图分析', {
       modelId,
       web: options.shouldWebSearch,
       knowledge: options.shouldKnowledgeSearch,
@@ -490,16 +493,16 @@ export async function analyzeUnifiedSearchIntent(
     });
 
     if (!response.success || !response.content) {
-      console.warn('[IntentAnalyzer] AI 请求失败，使用 fallback');
+      logger.warn('AI 请求失败，使用 fallback');
       return buildFallbackResult(userMessage, options);
     }
 
     const result = parseUnifiedResponse(response.content, options);
-    console.log('[IntentAnalyzer] 意图分析完成:', result);
+    logger.debug('意图分析完成:', result);
 
     return result;
   } catch (error) {
-    console.error('[IntentAnalyzer] 意图分析失败:', error);
+    logger.error('意图分析失败:', error);
     return buildFallbackResult(userMessage, options);
   }
 }

--- a/src/shared/services/webSearch/BingFreeSearchService.ts
+++ b/src/shared/services/webSearch/BingFreeSearchService.ts
@@ -17,6 +17,9 @@ import {
   searchYandex,
   fetchResultsContent
 } from './BingSearchModules';
+import { createLogger } from '../infra/logger';
+
+const logger = createLogger('BingFreeSearchService');
 
 // 重新导出类型，保持向后兼容
 export type { BingSearchOptions, BingSearchResult, BingSearchResponse };
@@ -56,7 +59,7 @@ export class BingFreeSearchService {
       throw new Error('搜索查询不能为空');
     }
 
-    console.log(`[BingFreeSearchService] 开始搜索: ${query}，使用搜索引擎: ${searchEngine}`);
+    logger.debug(`开始搜索: ${query}，使用搜索引擎: ${searchEngine}`);
 
     try {
       // 根据搜索引擎使用不同的搜索策略
@@ -83,11 +86,11 @@ export class BingFreeSearchService {
           results = await searchBing(query, searchOptions, timeout);
       }
 
-      console.log(`[BingFreeSearchService] 搜索完成，找到 ${results.length} 个结果`);
+      logger.debug(`搜索完成，找到 ${results.length} 个结果`);
 
       // 如果需要抓取内容，则抓取每个链接的内容
       if (options.fetchContent && results.length > 0) {
-        console.log('[BingFreeSearchService] 开始抓取链接内容...');
+        logger.debug('开始抓取链接内容...');
         await fetchResultsContent(results, options.maxContentLength || 2000, timeout);
       }
 
@@ -98,7 +101,7 @@ export class BingFreeSearchService {
       };
 
     } catch (error: any) {
-      console.error('[BingFreeSearchService] 搜索失败:', error);
+      logger.error('搜索失败:', error);
       throw new Error(`Bing搜索失败: ${error.message}`);
     }
   }
@@ -109,7 +112,7 @@ export class BingFreeSearchService {
   public async batchSearch(queries: string[], options: Omit<BingSearchOptions, 'query'> = {}): Promise<BingSearchResponse[]> {
     const promises = queries.map(query =>
       this.search({ ...options, query }).catch(error => {
-        console.error(`[BingFreeSearchService] 批量搜索失败 - ${query}:`, error);
+        logger.error(`批量搜索失败 - ${query}:`, error);
         return { results: [], query, totalResults: 0 };
       })
     );

--- a/src/shared/services/webSearch/BingMobileSDK.ts
+++ b/src/shared/services/webSearch/BingMobileSDK.ts
@@ -4,6 +4,10 @@
  * 无需API密钥，完全免费使用
  */
 
+import { createLogger } from '../infra/logger';
+
+const logger = createLogger('BingMobileSDK');
+
 export interface BingSearchOptions {
   maxResults?: number;
   language?: string;
@@ -66,14 +70,14 @@ export class BingMobileClient {
     const startTime = Date.now();
     
     try {
-      console.log(`[BingMobileSDK] 开始搜索: ${query}`);
+      logger.debug(`开始搜索: ${query}`);
 
       // 检查缓存
       if (this.enableCache) {
         const cacheKey = this.getCacheKey(query, options);
         const cached = this.cache.get(cacheKey);
         if (cached && Date.now() - cached.timestamp < this.CACHE_DURATION) {
-          console.log(`[BingMobileSDK] 使用缓存结果`);
+          logger.debug(`使用缓存结果`);
           return cached.data;
         }
       }
@@ -123,12 +127,12 @@ export class BingMobileClient {
         this.cleanExpiredCache();
       }
 
-      console.log(`[BingMobileSDK] 搜索完成，找到 ${result.results.length} 个结果，耗时 ${responseTime}ms`);
+      logger.debug(`搜索完成，找到 ${result.results.length} 个结果，耗时 ${responseTime}ms`);
       
       return result;
 
     } catch (error: any) {
-      console.error('[BingMobileSDK] 搜索失败:', error);
+      logger.error('搜索失败:', error);
 
       if (error.name === 'AbortError') {
         throw new Error('Bing搜索请求超时');
@@ -234,7 +238,7 @@ export class BingMobileClient {
       }
       
     } catch (error) {
-      console.error('[BingMobileSDK] 解析搜索结果失败:', error);
+      logger.error('解析搜索结果失败:', error);
     }
     
     return results;
@@ -265,7 +269,7 @@ export class BingMobileClient {
         }
       }
     } catch (error) {
-      console.error('[BingMobileSDK] 提取搜索建议失败:', error);
+      logger.error('提取搜索建议失败:', error);
     }
     
     return suggestions.slice(0, 5);
@@ -295,7 +299,7 @@ export class BingMobileClient {
         }
       }
     } catch (error) {
-      console.error('[BingMobileSDK] 提取相关搜索失败:', error);
+      logger.error('提取相关搜索失败:', error);
     }
     
     return relatedSearches.slice(0, 8);
@@ -380,7 +384,7 @@ export class BingMobileClient {
       await this.search('test', { maxResults: 1 });
       return true;
     } catch (error) {
-      console.error('[BingMobileSDK] 连接测试失败:', error);
+      logger.error('连接测试失败:', error);
       return false;
     }
   }

--- a/src/shared/services/webSearch/BingSearchModules/contentFetcher.ts
+++ b/src/shared/services/webSearch/BingSearchModules/contentFetcher.ts
@@ -6,6 +6,9 @@ import { CorsBypass } from 'capacitor-cors-bypass-enhanced';
 import { Capacitor } from '@capacitor/core';
 import type { BingSearchResult } from './types';
 import { shouldSkipUrl, extractTextContent } from './utils';
+import { createLogger } from '../../infra/logger';
+
+const logger = createLogger('ContentFetcher');
 
 /**
  * 抓取搜索结果的页面内容
@@ -17,15 +20,15 @@ export async function fetchResultsContent(
 ): Promise<void> {
   const fetchPromises = results.map(async (result, index) => {
     try {
-      console.log(`[ContentFetcher] 抓取内容 ${index + 1}/${results.length}: ${result.url}`);
+      logger.debug(`抓取内容 ${index + 1}/${results.length}: ${result.url}`);
 
       const content = await fetchPageContent(result.url, maxContentLength, timeout);
       result.content = content;
       result.contentLength = content.length;
 
-      console.log(`[ContentFetcher] 内容抓取成功 ${index + 1}: ${content.length} 字符`);
+      logger.debug(`内容抓取成功 ${index + 1}: ${content.length} 字符`);
     } catch (error) {
-      console.warn(`[ContentFetcher] 内容抓取失败 ${index + 1}:`, error);
+      logger.warn(`内容抓取失败 ${index + 1}:`, error);
       result.content = `内容抓取失败: ${error}`;
       result.contentLength = 0;
     }

--- a/src/shared/services/webSearch/BingSearchModules/parsers.ts
+++ b/src/shared/services/webSearch/BingSearchModules/parsers.ts
@@ -6,6 +6,9 @@ import { parse } from 'node-html-parser';
 import { v4 as uuidv4 } from 'uuid';
 import type { BingSearchResult } from './types';
 import { cleanText, normalizeUrl } from './utils';
+import { createLogger } from '../../infra/logger';
+
+const logger = createLogger('Parsers');
 
 /**
  * 解析Bing搜索结果
@@ -14,7 +17,7 @@ export function parseBingResults(html: string, maxResults: number): BingSearchRe
   const results: BingSearchResult[] = [];
 
   try {
-    console.log('[Parsers] 解析Bing搜索结果，HTML长度:', html.length);
+    logger.debug('解析Bing搜索结果，HTML长度:', html.length);
 
     const root = parse(html, {
       lowerCaseTagName: false,
@@ -35,7 +38,7 @@ export function parseBingResults(html: string, maxResults: number): BingSearchRe
     for (const selector of selectors) {
       resultElements = root.querySelectorAll(selector);
       if (resultElements.length > 0) {
-        console.log(`[Parsers] 使用选择器 "${selector}" 找到 ${resultElements.length} 个结果`);
+        logger.debug(`使用选择器 "${selector}" 找到 ${resultElements.length} 个结果`);
         break;
       }
     }
@@ -81,12 +84,12 @@ export function parseBingResults(html: string, maxResults: number): BingSearchRe
           });
         }
       } catch (error) {
-        console.warn(`[Parsers] 解析Bing结果失败:`, error);
+        logger.warn(`解析Bing结果失败:`, error);
       }
     });
 
   } catch (error) {
-    console.error('[Parsers] Bing结果解析失败:', error);
+    logger.error('Bing结果解析失败:', error);
   }
 
   return results;
@@ -99,7 +102,7 @@ export function parseGoogleResults(html: string, maxResults: number): BingSearch
   const results: BingSearchResult[] = [];
 
   try {
-    console.log('[Parsers] 解析Google搜索结果，HTML长度:', html.length);
+    logger.debug('解析Google搜索结果，HTML长度:', html.length);
 
     const root = parse(html, {
       lowerCaseTagName: false,
@@ -110,12 +113,12 @@ export function parseGoogleResults(html: string, maxResults: number): BingSearch
 
     // 基于SearXNG的Google选择器
     const resultElements = root.querySelectorAll('div[jscontroller*="SC7lYd"]');
-    console.log(`[Parsers] Google找到 ${resultElements.length} 个结果容器`);
+    logger.debug(`Google找到 ${resultElements.length} 个结果容器`);
 
     if (resultElements.length === 0) {
       // 备用选择器
       const fallbackElements = root.querySelectorAll('.g, .rc, .yuRUbf');
-      console.log(`[Parsers] Google备用选择器找到 ${fallbackElements.length} 个结果`);
+      logger.debug(`Google备用选择器找到 ${fallbackElements.length} 个结果`);
 
       fallbackElements.forEach((element: any, index: number) => {
         if (results.length >= maxResults) return;
@@ -129,7 +132,7 @@ export function parseGoogleResults(html: string, maxResults: number): BingSearch
     }
 
   } catch (error) {
-    console.error('[Parsers] Google结果解析失败:', error);
+    logger.error('Google结果解析失败:', error);
   }
 
   return results;
@@ -142,7 +145,7 @@ function parseGoogleResultElement(element: any, results: BingSearchResult[], ind
   try {
     const titleElement = element.querySelector('a h3');
     if (!titleElement) {
-      console.debug('[Parsers] Google结果缺少标题，跳过');
+      logger.debug('Google结果缺少标题，跳过');
       return;
     }
 
@@ -150,13 +153,13 @@ function parseGoogleResultElement(element: any, results: BingSearchResult[], ind
 
     const linkElement = element.querySelector('a[href]');
     if (!linkElement) {
-      console.debug('[Parsers] Google结果缺少链接，跳过');
+      logger.debug('Google结果缺少链接，跳过');
       return;
     }
 
     const url = linkElement.getAttribute('href') || '';
     if (!url || !url.startsWith('http')) {
-      console.debug('[Parsers] Google结果链接无效，跳过');
+      logger.debug('Google结果链接无效，跳过');
       return;
     }
 
@@ -183,10 +186,10 @@ function parseGoogleResultElement(element: any, results: BingSearchResult[], ind
         provider: 'bing-free',
         score: 1.0 - (index * 0.1)
       });
-      console.log(`[Parsers] Google解析成功 ${results.length}: ${title.substring(0, 50)}`);
+      logger.debug(`Google解析成功 ${results.length}: ${title.substring(0, 50)}`);
     }
   } catch (error) {
-    console.warn(`[Parsers] 解析Google单个结果失败:`, error);
+    logger.warn(`解析Google单个结果失败:`, error);
   }
 }
 
@@ -197,7 +200,7 @@ export function parseBaiduResults(html: string, maxResults: number): BingSearchR
   const results: BingSearchResult[] = [];
 
   try {
-    console.log('[Parsers] 解析百度搜索结果，HTML长度:', html.length);
+    logger.debug('解析百度搜索结果，HTML长度:', html.length);
 
     const root = parse(html, {
       lowerCaseTagName: false,
@@ -207,11 +210,11 @@ export function parseBaiduResults(html: string, maxResults: number): BingSearchR
     });
 
     const resultElements = root.querySelectorAll('.result, .c-container, .result-op');
-    console.log(`[Parsers] 百度找到 ${resultElements.length} 个结果容器`);
+    logger.debug(`百度找到 ${resultElements.length} 个结果容器`);
 
     if (resultElements.length === 0) {
       const fallbackElements = root.querySelectorAll('h3');
-      console.log(`[Parsers] 百度备用选择器找到 ${fallbackElements.length} 个h3标签`);
+      logger.debug(`百度备用选择器找到 ${fallbackElements.length} 个h3标签`);
 
       fallbackElements.forEach((element: any, index: number) => {
         if (results.length >= maxResults) return;
@@ -225,7 +228,7 @@ export function parseBaiduResults(html: string, maxResults: number): BingSearchR
     }
 
   } catch (error) {
-    console.error('[Parsers] 百度结果解析失败:', error);
+    logger.error('百度结果解析失败:', error);
   }
 
   return results;
@@ -238,7 +241,7 @@ function parseBaiduResultElement(element: any, results: BingSearchResult[], inde
   try {
     const titleElement = element.querySelector('h3 a, .t a, .c-title a, a[href]');
     if (!titleElement) {
-      console.debug('[Parsers] 百度结果缺少标题，跳过');
+      logger.debug('百度结果缺少标题，跳过');
       return;
     }
 
@@ -246,7 +249,7 @@ function parseBaiduResultElement(element: any, results: BingSearchResult[], inde
     const url = titleElement.getAttribute('href') || '';
 
     if (!title || !url) {
-      console.debug('[Parsers] 百度结果标题或链接无效，跳过');
+      logger.debug('百度结果标题或链接无效，跳过');
       return;
     }
 
@@ -274,10 +277,10 @@ function parseBaiduResultElement(element: any, results: BingSearchResult[], inde
         provider: 'bing-free',
         score: 1.0 - (index * 0.1)
       });
-      console.log(`[Parsers] 百度解析成功 ${results.length}: ${title.substring(0, 50)}`);
+      logger.debug(`百度解析成功 ${results.length}: ${title.substring(0, 50)}`);
     }
   } catch (error) {
-    console.warn(`[Parsers] 解析百度单个结果失败:`, error);
+    logger.warn(`解析百度单个结果失败:`, error);
   }
 }
 
@@ -288,7 +291,7 @@ export function parseSogouResults(html: string, maxResults: number): BingSearchR
   const results: BingSearchResult[] = [];
 
   try {
-    console.log('[Parsers] 解析搜狗搜索结果，HTML长度:', html.length);
+    logger.debug('解析搜狗搜索结果，HTML长度:', html.length);
 
     const root = parse(html, {
       lowerCaseTagName: false,
@@ -298,11 +301,11 @@ export function parseSogouResults(html: string, maxResults: number): BingSearchR
     });
 
     const resultElements = root.querySelectorAll('div.vrwrap');
-    console.log(`[Parsers] 搜狗找到 ${resultElements.length} 个结果容器`);
+    logger.debug(`搜狗找到 ${resultElements.length} 个结果容器`);
 
     if (resultElements.length === 0) {
       const fallbackElements = root.querySelectorAll('.results, .result, .rb');
-      console.log(`[Parsers] 搜狗备用选择器找到 ${fallbackElements.length} 个结果`);
+      logger.debug(`搜狗备用选择器找到 ${fallbackElements.length} 个结果`);
 
       fallbackElements.forEach((element: any, index: number) => {
         if (results.length >= maxResults) return;
@@ -316,7 +319,7 @@ export function parseSogouResults(html: string, maxResults: number): BingSearchR
     }
 
   } catch (error) {
-    console.error('[Parsers] 搜狗结果解析失败:', error);
+    logger.error('搜狗结果解析失败:', error);
   }
 
   return results;
@@ -329,7 +332,7 @@ function parseSogouResultElement(element: any, results: BingSearchResult[], inde
   try {
     const titleElement = element.querySelector('h3.vr-title a, h3 a');
     if (!titleElement) {
-      console.debug('[Parsers] 搜狗结果缺少标题，跳过');
+      logger.debug('搜狗结果缺少标题，跳过');
       return;
     }
 
@@ -342,7 +345,7 @@ function parseSogouResultElement(element: any, results: BingSearchResult[], inde
     }
 
     if (!title || !url) {
-      console.debug('[Parsers] 搜狗结果标题或链接无效，跳过');
+      logger.debug('搜狗结果标题或链接无效，跳过');
       return;
     }
 
@@ -377,10 +380,10 @@ function parseSogouResultElement(element: any, results: BingSearchResult[], inde
         provider: 'bing-free',
         score: 1.0 - (index * 0.1)
       });
-      console.log(`[Parsers] 搜狗解析成功 ${results.length}: ${title.substring(0, 50)}`);
+      logger.debug(`搜狗解析成功 ${results.length}: ${title.substring(0, 50)}`);
     }
   } catch (error) {
-    console.warn(`[Parsers] 解析搜狗单个结果失败:`, error);
+    logger.warn(`解析搜狗单个结果失败:`, error);
   }
 }
 
@@ -391,7 +394,7 @@ export function parseYandexResults(html: string, maxResults: number): BingSearch
   const results: BingSearchResult[] = [];
 
   try {
-    console.log('[Parsers] 解析Yandex搜索结果，HTML长度:', html.length);
+    logger.debug('解析Yandex搜索结果，HTML长度:', html.length);
 
     const root = parse(html, {
       lowerCaseTagName: false,
@@ -402,7 +405,7 @@ export function parseYandexResults(html: string, maxResults: number): BingSearch
 
     // 基于SearXNG的Yandex选择器
     const resultElements = root.querySelectorAll('li.serp-item');
-    console.log(`[Parsers] Yandex找到 ${resultElements.length} 个结果容器`);
+    logger.debug(`Yandex找到 ${resultElements.length} 个结果容器`);
 
     if (resultElements.length === 0) {
       // 更广泛的备用选择器
@@ -420,7 +423,7 @@ export function parseYandexResults(html: string, maxResults: number): BingSearch
       for (const selector of fallbackSelectors) {
         fallbackElements = root.querySelectorAll(selector);
         if (fallbackElements.length > 0) {
-          console.log(`[Parsers] Yandex备用选择器 "${selector}" 找到 ${fallbackElements.length} 个结果`);
+          logger.debug(`Yandex备用选择器 "${selector}" 找到 ${fallbackElements.length} 个结果`);
           break;
         }
       }
@@ -428,7 +431,7 @@ export function parseYandexResults(html: string, maxResults: number): BingSearch
       if (fallbackElements.length === 0) {
         // 最后尝试：查找所有包含链接的元素
         const allLinks = root.querySelectorAll('a[href]');
-        console.log(`[Parsers] Yandex找到 ${allLinks.length} 个链接`);
+        logger.debug(`Yandex找到 ${allLinks.length} 个链接`);
 
         // 过滤出可能是搜索结果的链接
         const possibleResults = allLinks.filter((link: any) => {
@@ -441,7 +444,7 @@ export function parseYandexResults(html: string, maxResults: number): BingSearch
                  text.length > 10;
         });
 
-        console.log(`[Parsers] Yandex过滤后的可能结果: ${possibleResults.length} 个`);
+        logger.debug(`Yandex过滤后的可能结果: ${possibleResults.length} 个`);
 
         possibleResults.slice(0, maxResults).forEach((element: any, index: number) => {
           parseYandexResultElement(element, results, index);
@@ -460,7 +463,7 @@ export function parseYandexResults(html: string, maxResults: number): BingSearch
     }
 
   } catch (error) {
-    console.error('[Parsers] Yandex结果解析失败:', error);
+    logger.error('Yandex结果解析失败:', error);
   }
 
   return results;
@@ -536,13 +539,13 @@ function parseYandexResultElement(element: any, results: BingSearchResult[], ind
 
     // 验证URL有效性
     if (!title || !url || url.startsWith('#') || url.startsWith('javascript:')) {
-      console.debug('[Parsers] Yandex结果标题或链接无效，跳过');
+      logger.debug('Yandex结果标题或链接无效，跳过');
       return;
     }
 
     // 过滤掉Yandex内部链接
     if (url.includes('yandex.') && !url.startsWith('http')) {
-      console.debug('[Parsers] Yandex内部链接，跳过');
+      logger.debug('Yandex内部链接，跳过');
       return;
     }
 
@@ -555,8 +558,8 @@ function parseYandexResultElement(element: any, results: BingSearchResult[], ind
       provider: 'bing-free',
       score: 1.0 - (index * 0.1)
     });
-    console.log(`[Parsers] Yandex解析成功 ${results.length}: ${title.substring(0, 50)}`);
+    logger.debug(`Yandex解析成功 ${results.length}: ${title.substring(0, 50)}`);
   } catch (error) {
-    console.warn(`[Parsers] 解析Yandex单个结果失败:`, error);
+    logger.warn(`解析Yandex单个结果失败:`, error);
   }
 }

--- a/src/shared/services/webSearch/BingSearchModules/searchEngines.ts
+++ b/src/shared/services/webSearch/BingSearchModules/searchEngines.ts
@@ -11,6 +11,9 @@ import {
   parseSogouResults,
   parseYandexResults
 } from './parsers';
+import { createLogger } from '../../infra/logger';
+
+const logger = createLogger('SearchEngines');
 
 /**
  * 构建Bing搜索URL
@@ -121,7 +124,7 @@ export function buildYandexSearchUrl(query: string, _options: SearchEngineOption
  */
 export async function searchBing(query: string, options: SearchEngineOptions, timeout: number): Promise<BingSearchResult[]> {
   const searchUrl = buildBingSearchUrl(query, options);
-  console.log(`[SearchEngines] Bing搜索URL: ${searchUrl}`);
+  logger.debug(`Bing搜索URL: ${searchUrl}`);
 
   const response = await fetchSearchPage(searchUrl, timeout);
   return parseBingResults(response.data, options.count);
@@ -132,7 +135,7 @@ export async function searchBing(query: string, options: SearchEngineOptions, ti
  */
 export async function searchGoogle(query: string, options: SearchEngineOptions, timeout: number): Promise<BingSearchResult[]> {
   const searchUrl = buildGoogleSearchUrl(query, options);
-  console.log(`[SearchEngines] Google搜索URL: ${searchUrl}`);
+  logger.debug(`Google搜索URL: ${searchUrl}`);
 
   const response = await fetchSearchPage(searchUrl, timeout);
   return parseGoogleResults(response.data, options.count);
@@ -143,7 +146,7 @@ export async function searchGoogle(query: string, options: SearchEngineOptions, 
  */
 export async function searchBaidu(query: string, options: SearchEngineOptions, timeout: number): Promise<BingSearchResult[]> {
   const searchUrl = buildBaiduSearchUrl(query, options);
-  console.log(`[SearchEngines] 百度搜索URL: ${searchUrl}`);
+  logger.debug(`百度搜索URL: ${searchUrl}`);
 
   const response = await fetchSearchPage(searchUrl, timeout);
   return parseBaiduResults(response.data, options.count);
@@ -154,7 +157,7 @@ export async function searchBaidu(query: string, options: SearchEngineOptions, t
  */
 export async function searchSogou(query: string, options: SearchEngineOptions, timeout: number): Promise<BingSearchResult[]> {
   const searchUrl = buildSogouSearchUrl(query, options);
-  console.log(`[SearchEngines] 搜狗搜索URL: ${searchUrl}`);
+  logger.debug(`搜狗搜索URL: ${searchUrl}`);
 
   const response = await fetchSearchPage(searchUrl, timeout);
   return parseSogouResults(response.data, options.count);
@@ -165,7 +168,7 @@ export async function searchSogou(query: string, options: SearchEngineOptions, t
  */
 export async function searchYandex(query: string, options: SearchEngineOptions, timeout: number): Promise<BingSearchResult[]> {
   const searchUrl = buildYandexSearchUrl(query, options);
-  console.log(`[SearchEngines] Yandex搜索URL: ${searchUrl}`);
+  logger.debug(`Yandex搜索URL: ${searchUrl}`);
 
   // 注意：Yandex搜索可能需要特殊的headers和cookies才能正常工作
   // 目前使用通用的fetchSearchPage，如果需要可以后续优化

--- a/src/shared/services/webSearch/BingSearchModules/utils.ts
+++ b/src/shared/services/webSearch/BingSearchModules/utils.ts
@@ -4,6 +4,9 @@
 
 import { CorsBypass } from 'capacitor-cors-bypass-enhanced';
 import { Capacitor } from '@capacitor/core';
+import { createLogger } from '../../infra/logger';
+
+const logger = createLogger('SearchUtils');
 
 /**
  * 清理文本内容
@@ -45,7 +48,7 @@ export function normalizeUrl(url: string, baseUrl: string = 'https://cn.bing.com
 
     return url;
   } catch (error) {
-    console.warn('[SearchUtils] URL标准化失败:', error);
+    logger.warn('URL标准化失败:', error);
     return url;
   }
 }
@@ -65,7 +68,7 @@ export async function fetchSearchPage(url: string, timeout: number): Promise<any
 
   if (Capacitor.isNativePlatform()) {
     // 移动端使用 CorsBypass 插件
-    console.log('[SearchUtils] 使用 CorsBypass 插件请求');
+    logger.debug('使用 CorsBypass 插件请求');
 
     const response = await CorsBypass.request({
       url,
@@ -75,7 +78,7 @@ export async function fetchSearchPage(url: string, timeout: number): Promise<any
       responseType: 'text'
     });
 
-    console.log('[SearchUtils] 插件响应:', {
+    logger.debug('插件响应:', {
       status: response.status,
       dataLength: response.data?.length || 0,
       headers: Object.keys(response.headers || {})
@@ -84,7 +87,7 @@ export async function fetchSearchPage(url: string, timeout: number): Promise<any
     return response;
   } else {
     // Web端使用标准fetch（可能需要代理）
-    console.log('[SearchUtils] 使用标准 fetch 请求');
+    logger.debug('使用标准 fetch 请求');
 
     const response = await fetch(url, {
       method: 'GET',
@@ -174,7 +177,7 @@ export function extractTextContent(html: string, maxLength: number): string {
 
     return textContent || '无法提取内容';
   } catch (error) {
-    console.warn('[SearchUtils] 文本提取失败:', error);
+    logger.warn('文本提取失败:', error);
     return '内容解析失败';
   }
 }

--- a/src/shared/services/webSearch/EnhancedWebSearchService.ts
+++ b/src/shared/services/webSearch/EnhancedWebSearchService.ts
@@ -7,6 +7,9 @@ import { AssistantMessageStatus } from '../../types/newMessage';
 import { bingFreeSearchService } from './BingFreeSearchService';
 import { searchHttpRequest } from './httpClient';
 import { customProviderToConfig, isCustomProviderConfigured, executeProtocolSearch } from './customProtocols';
+import { createLogger } from '../infra/logger';
+
+const logger = createLogger('EnhancedWebSearchService');
 
 /**
  * 增强版网络搜索服务
@@ -143,7 +146,7 @@ class EnhancedWebSearchService {
     try {
       // 🚀 获取选择的搜索引擎
       const selectedSearchEngine = websearch.selectedSearchEngine || 'bing';
-      console.log(`[EnhancedWebSearchService] 开始免费搜索: ${query}，使用搜索引擎: ${selectedSearchEngine}`);
+      logger.debug(`开始免费搜索: ${query}，使用搜索引擎: ${selectedSearchEngine}`);
 
       // 使用免费搜索服务（支持多种搜索引擎）
       const response = await bingFreeSearchService.search({
@@ -178,10 +181,10 @@ class EnhancedWebSearchService {
         };
       });
 
-      console.log(`[EnhancedWebSearchService] 免费${selectedSearchEngine}搜索完成，找到 ${results.length} 个结果`);
+      logger.debug(`免费${selectedSearchEngine}搜索完成，找到 ${results.length} 个结果`);
       return { results };
     } catch (error: any) {
-      console.error('[EnhancedWebSearchService] 免费Bing搜索失败:', error);
+      logger.error('免费Bing搜索失败:', error);
       throw new Error(`免费搜索失败: ${error.message}`);
     }
   }
@@ -199,7 +202,7 @@ class EnhancedWebSearchService {
         throw new Error('Tavily API密钥未配置');
       }
 
-      console.log(`[EnhancedWebSearchService] 开始Tavily移动端SDK搜索: ${query}`);
+      logger.debug(`开始Tavily移动端SDK搜索: ${query}`);
 
       // 创建移动端兼容的Tavily客户端
       const tvly = tavily({ apiKey: provider.apiKey });
@@ -258,10 +261,10 @@ class EnhancedWebSearchService {
         };
       }) || [];
 
-      console.log(`[EnhancedWebSearchService] Tavily移动端SDK搜索完成，找到 ${results.length} 个结果`);
+      logger.debug(`Tavily移动端SDK搜索完成，找到 ${results.length} 个结果`);
       return { results };
     } catch (error: any) {
-      console.error('[EnhancedWebSearchService] Tavily移动端SDK搜索失败:', error);
+      logger.error('Tavily移动端SDK搜索失败:', error);
       throw new Error(`Tavily搜索失败: ${error.message}`);
     }
   }
@@ -281,7 +284,7 @@ class EnhancedWebSearchService {
         throw new Error('Exa API密钥未配置');
       }
 
-      console.log(`[EnhancedWebSearchService] 开始Exa搜索: ${query}`);
+      logger.debug(`开始Exa搜索: ${query}`);
 
       const requestBody = {
         query,
@@ -312,10 +315,10 @@ class EnhancedWebSearchService {
         provider: 'exa'
       })) || [];
 
-      console.log(`[EnhancedWebSearchService] Exa搜索完成，找到 ${results.length} 个结果`);
+      logger.debug(`Exa搜索完成，找到 ${results.length} 个结果`);
       return { results };
     } catch (error: any) {
-      console.error('[EnhancedWebSearchService] Exa搜索失败:', error);
+      logger.error('Exa搜索失败:', error);
       throw new Error(`Exa搜索失败: ${error.message}`);
     }
   }
@@ -333,7 +336,7 @@ class EnhancedWebSearchService {
         throw new Error('Bocha API密钥未配置');
       }
 
-      console.log(`[EnhancedWebSearchService] 开始Bocha搜索: ${query}`);
+      logger.debug(`开始Bocha搜索: ${query}`);
 
       const requestBody = {
         query,
@@ -364,10 +367,10 @@ class EnhancedWebSearchService {
         provider: 'bocha'
       }));
 
-      console.log(`[EnhancedWebSearchService] Bocha搜索完成，找到 ${results.length} 个结果`);
+      logger.debug(`Bocha搜索完成，找到 ${results.length} 个结果`);
       return { results };
     } catch (error: any) {
-      console.error('[EnhancedWebSearchService] Bocha搜索失败:', error);
+      logger.error('Bocha搜索失败:', error);
       throw new Error(`Bocha搜索失败: ${error.message}`);
     }
   }
@@ -385,7 +388,7 @@ class EnhancedWebSearchService {
         throw new Error('Firecrawl API密钥未配置');
       }
 
-      console.log(`[EnhancedWebSearchService] 开始Firecrawl搜索: ${query}`);
+      logger.debug(`开始Firecrawl搜索: ${query}`);
 
       const requestBody = {
         query,
@@ -412,10 +415,10 @@ class EnhancedWebSearchService {
         content: result.markdown
       })) || [];
 
-      console.log(`[EnhancedWebSearchService] Firecrawl搜索完成，找到 ${results.length} 个结果`);
+      logger.debug(`Firecrawl搜索完成，找到 ${results.length} 个结果`);
       return { results };
     } catch (error: any) {
-      console.error('[EnhancedWebSearchService] Firecrawl搜索失败:', error);
+      logger.error('Firecrawl搜索失败:', error);
       throw new Error(`Firecrawl搜索失败: ${error.message}`);
     }
   }
@@ -441,7 +444,7 @@ class EnhancedWebSearchService {
         throw new Error('Cloudflare AutoRAG 名称未配置');
       }
 
-      console.log(`[EnhancedWebSearchService] 开始Cloudflare AI Search搜索: ${query}`);
+      logger.debug(`开始Cloudflare AI Search搜索: ${query}`);
 
       const requestBody = {
         query,
@@ -503,10 +506,10 @@ class EnhancedWebSearchService {
         };
       });
 
-      console.log(`[EnhancedWebSearchService] Cloudflare AI Search搜索完成，找到 ${results.length} 个结果`);
+      logger.debug(`Cloudflare AI Search搜索完成，找到 ${results.length} 个结果`);
       return { results };
     } catch (error: any) {
-      console.error('[EnhancedWebSearchService] Cloudflare AI Search搜索失败:', error);
+      logger.error('Cloudflare AI Search搜索失败:', error);
       throw new Error(`Cloudflare AI Search搜索失败: ${error.message}`);
     }
   }
@@ -524,7 +527,7 @@ class EnhancedWebSearchService {
         throw new Error('Zhipu API密钥未配置');
       }
 
-      console.log(`[EnhancedWebSearchService] 开始Zhipu搜索: ${query}`);
+      logger.debug(`开始Zhipu搜索: ${query}`);
 
       const { data } = await searchHttpRequest({
         url: provider.apiHost || 'https://open.bigmodel.cn/api/paas/v4/web_search',
@@ -550,10 +553,10 @@ class EnhancedWebSearchService {
         provider: 'zhipu'
       }));
 
-      console.log(`[EnhancedWebSearchService] Zhipu搜索完成，找到 ${results.length} 个结果`);
+      logger.debug(`Zhipu搜索完成，找到 ${results.length} 个结果`);
       return { results };
     } catch (error: any) {
-      console.error('[EnhancedWebSearchService] Zhipu搜索失败:', error);
+      logger.error('Zhipu搜索失败:', error);
       throw new Error(`Zhipu搜索失败: ${error.message}`, { cause: error });
     }
   }
@@ -571,7 +574,7 @@ class EnhancedWebSearchService {
         throw new Error('Jina API密钥未配置');
       }
 
-      console.log(`[EnhancedWebSearchService] 开始Jina搜索: ${query}`);
+      logger.debug(`开始Jina搜索: ${query}`);
 
       const baseUrl = (provider.apiHost || 'https://s.jina.ai').replace(/\/+$/, '');
       const { data } = await searchHttpRequest({
@@ -594,10 +597,10 @@ class EnhancedWebSearchService {
         provider: 'jina'
       }));
 
-      console.log(`[EnhancedWebSearchService] Jina搜索完成，找到 ${results.length} 个结果`);
+      logger.debug(`Jina搜索完成，找到 ${results.length} 个结果`);
       return { results };
     } catch (error: any) {
-      console.error('[EnhancedWebSearchService] Jina搜索失败:', error);
+      logger.error('Jina搜索失败:', error);
       throw new Error(`Jina搜索失败: ${error.message}`, { cause: error });
     }
   }
@@ -615,7 +618,7 @@ class EnhancedWebSearchService {
         throw new Error('Querit API密钥未配置');
       }
 
-      console.log(`[EnhancedWebSearchService] 开始Querit搜索: ${query}`);
+      logger.debug(`开始Querit搜索: ${query}`);
 
       const requestBody: any = {
         query,
@@ -650,10 +653,10 @@ class EnhancedWebSearchService {
         provider: 'querit'
       }));
 
-      console.log(`[EnhancedWebSearchService] Querit搜索完成，找到 ${results.length} 个结果`);
+      logger.debug(`Querit搜索完成，找到 ${results.length} 个结果`);
       return { results };
     } catch (error: any) {
-      console.error('[EnhancedWebSearchService] Querit搜索失败:', error);
+      logger.error('Querit搜索失败:', error);
       throw new Error(`Querit搜索失败: ${error.message}`, { cause: error });
     }
   }
@@ -667,7 +670,7 @@ class EnhancedWebSearchService {
     websearch: any
   ): Promise<WebSearchProviderResponse> {
     try {
-      console.log(`[EnhancedWebSearchService] 开始Exa MCP搜索: ${query}`);
+      logger.debug(`开始Exa MCP搜索: ${query}`);
 
       const maxResults = websearch.maxResults || 10;
       const { data } = await searchHttpRequest({
@@ -706,10 +709,10 @@ class EnhancedWebSearchService {
         provider: 'exa-mcp'
       }));
 
-      console.log(`[EnhancedWebSearchService] Exa MCP搜索完成，找到 ${results.length} 个结果`);
+      logger.debug(`Exa MCP搜索完成，找到 ${results.length} 个结果`);
       return { results };
     } catch (error: any) {
-      console.error('[EnhancedWebSearchService] Exa MCP搜索失败:', error);
+      logger.error('Exa MCP搜索失败:', error);
       throw new Error(`Exa MCP搜索失败: ${error.message}`, { cause: error });
     }
   }

--- a/src/shared/services/webSearch/TavilyMobileSDK.ts
+++ b/src/shared/services/webSearch/TavilyMobileSDK.ts
@@ -3,6 +3,10 @@
  * 基于官方 API 文档实现，避免 Node.js 依赖
  */
 
+import { createLogger } from '../infra/logger';
+
+const logger = createLogger('TavilyMobileSDK');
+
 export interface TavilySearchOptions {
   searchDepth?: 'basic' | 'advanced';
   topic?: 'general' | 'news';
@@ -87,7 +91,7 @@ export class TavilyMobileClient {
       processedResults = processedResults.filter(result =>
         result.score !== undefined && result.score >= options.minScore!
       );
-      console.log(`[TavilyMobileSDK] 基于分数过滤：${results.length} -> ${processedResults.length} 个结果`);
+      logger.debug(`基于分数过滤：${results.length} -> ${processedResults.length} 个结果`);
     }
 
     // 按分数排序（如果有分数）
@@ -163,7 +167,7 @@ export class TavilyMobileClient {
     );
 
     try {
-      console.log(`[TavilyMobileSDK] 开始搜索: ${query}`);
+      logger.debug(`开始搜索: ${query}`);
 
       const response = await fetch(`${this.baseUrl}/search`, {
         method: 'POST',
@@ -185,27 +189,27 @@ export class TavilyMobileClient {
       const responseText = await response.text();
       const data = JSON.parse(responseText);
 
-      console.log(`[TavilyMobileSDK] 搜索完成，找到 ${data.results?.length || 0} 个结果`);
+      logger.debug(`搜索完成，找到 ${data.results?.length || 0} 个结果`);
 
       // 🚀 结果后处理
       if (options.enablePostProcessing !== false && data.results) {
         data.results = this.postProcessResults(data.results, options);
-        console.log(`[TavilyMobileSDK] 后处理完成，最终结果数量: ${data.results.length}`);
+        logger.debug(`后处理完成，最终结果数量: ${data.results.length}`);
       }
 
       // 🚀 调试：检查第一个结果的内容编码
       if (data.results && data.results.length > 0) {
         const firstResult = data.results[0];
-        console.log(`[TavilyMobileSDK] 第一个结果标题: "${firstResult.title}"`);
-        console.log(`[TavilyMobileSDK] 第一个结果内容预览: "${(firstResult.content || '').substring(0, 100)}..."`);
+        logger.debug(`第一个结果标题: "${firstResult.title}"`);
+        logger.debug(`第一个结果内容预览: "${(firstResult.content || '').substring(0, 100)}..."`);
         if (firstResult.score !== undefined) {
-          console.log(`[TavilyMobileSDK] 第一个结果相关性分数: ${firstResult.score}`);
+          logger.debug(`第一个结果相关性分数: ${firstResult.score}`);
         }
       }
 
       return data as TavilySearchResponse;
     } catch (error: any) {
-      console.error('[TavilyMobileSDK] 搜索失败:', error);
+      logger.error('搜索失败:', error);
 
       if (error.name === 'AbortError') {
         throw new Error('搜索请求超时');
@@ -223,7 +227,7 @@ export class TavilyMobileClient {
     options: TavilySearchOptions = {},
     concurrencyLimit: number = 3
   ): Promise<Array<TavilySearchResponse | Error>> {
-    console.log(`[TavilyMobileSDK] 开始批量搜索，查询数量: ${queries.length}，并发限制: ${concurrencyLimit}`);
+    logger.debug(`开始批量搜索，查询数量: ${queries.length}，并发限制: ${concurrencyLimit}`);
 
     // 分批处理以避免超过速率限制
     const results: Array<TavilySearchResponse | Error> = [];
@@ -236,7 +240,7 @@ export class TavilyMobileClient {
         try {
           return await this.search(query, options);
         } catch (error) {
-          console.error(`[TavilyMobileSDK] 查询失败: "${query}"`, error);
+          logger.error(`查询失败: "${query}"`, error);
           return error instanceof Error ? error : new Error(String(error));
         }
       });
@@ -250,7 +254,7 @@ export class TavilyMobileClient {
       }
     }
 
-    console.log(`[TavilyMobileSDK] 批量搜索完成，成功: ${results.filter(r => !(r instanceof Error)).length}，失败: ${results.filter(r => r instanceof Error).length}`);
+    logger.debug(`批量搜索完成，成功: ${results.filter(r => !(r instanceof Error)).length}，失败: ${results.filter(r => r instanceof Error).length}`);
     return results;
   }
 
@@ -281,7 +285,7 @@ export class TavilyMobileClient {
       await this.search('test', { maxResults: 1 });
       return true;
     } catch (error) {
-      console.error('[TavilyMobileSDK] 连接测试失败:', error);
+      logger.error('连接测试失败:', error);
       return false;
     }
   }

--- a/src/shared/services/webSearch/WebSearchTool.ts
+++ b/src/shared/services/webSearch/WebSearchTool.ts
@@ -7,6 +7,9 @@
 
 import type { WebSearchResult } from '../../types';
 import EnhancedWebSearchService from './EnhancedWebSearchService';
+import { createLogger } from '../infra/logger';
+
+const logger = createLogger('WebSearchTool');
 
 /**
  * 网络搜索工具输入参数
@@ -132,7 +135,7 @@ export async function executeWebSearch(
   _requestId?: string
 ): Promise<WebSearchToolOutput> {
   try {
-    console.log('[WebSearchTool] 开始执行搜索:', {
+    logger.debug('开始执行搜索:', {
       input,
       providerId: webSearchProviderId,
       extractedKeywords
@@ -162,7 +165,7 @@ export async function executeWebSearch(
 
     // 如果没有查询，返回空结果
     if (searchQueries.length === 0) {
-      console.log('[WebSearchTool] 无需搜索');
+      logger.debug('无需搜索');
       return {
         query: '',
         results: [],
@@ -171,13 +174,13 @@ export async function executeWebSearch(
     }
 
     // 🚀 并行执行多个搜索查询（复刻 Cherry Studio 的 processWebsearch）
-    console.log('[WebSearchTool] 并行执行搜索，查询数量:', searchQueries.length);
+    logger.debug('并行执行搜索，查询数量:', searchQueries.length);
     
     const searchPromises = searchQueries.map(query => 
       EnhancedWebSearchService.search(provider, query)
         .then(response => ({ query, results: response.results, success: true }))
         .catch(error => {
-          console.warn(`[WebSearchTool] 搜索失败 "${query}":`, error);
+          logger.warn(`搜索失败 "${query}":`, error);
           return { query, results: [], success: false };
         })
     );
@@ -199,7 +202,7 @@ export async function executeWebSearch(
 
     const combinedQuery = searchQueries.join(' | ');
     
-    console.log('[WebSearchTool] 搜索完成:', {
+    logger.debug('搜索完成:', {
       queries: searchQueries,
       totalResults: allResults.length,
       successfulSearches: searchResults.filter(r => r.success).length
@@ -211,7 +214,7 @@ export async function executeWebSearch(
       success: true
     };
   } catch (error: any) {
-    console.error('[WebSearchTool] 搜索失败:', error);
+    logger.error('搜索失败:', error);
     return {
       query: input.query || '',
       results: [],

--- a/src/shared/services/webSearch/customProtocols.ts
+++ b/src/shared/services/webSearch/customProtocols.ts
@@ -8,6 +8,9 @@ import type {
 } from '../../types';
 import { searchHttpRequest, type SearchHttpRequest } from './httpClient';
 import { fetchPageContent } from './BingSearchModules/contentFetcher';
+import { createLogger } from '../infra/logger';
+
+const logger = createLogger('customProtocols');
 
 const SNIPPET_LIMIT = 1000;
 const FETCHED_CONTENT_LIMIT = 1500;
@@ -68,7 +71,7 @@ async function discoverSearxngEngines(baseUrl: string, headers: Record<string, s
     searxngEngineCache.set(baseUrl, { engines, timestamp: Date.now() });
     return engines;
   } catch (error) {
-    console.warn('[customProtocols] SearXNG 引擎自动发现失败，使用实例默认引擎:', error);
+    logger.warn('SearXNG 引擎自动发现失败，使用实例默认引擎:', error);
     return [];
   }
 }
@@ -87,7 +90,7 @@ async function enrichResultsWithPageContent(results: WebSearchResult[]): Promise
         };
       }
     } catch (error) {
-      console.warn(`[customProtocols] 页面内容抓取失败，回退使用搜索摘要: ${result.url}`, error);
+      logger.warn(`页面内容抓取失败，回退使用搜索摘要: ${result.url}`, error);
     }
   });
   for (let i = 0; i < tasks.length; i += CONTENT_FETCH_BATCH_SIZE) {


### PR DESCRIPTION
## Summary

日志系统 Phase 4 分模块迁移的又一个子系统样板，与已合并的 api(#244)、storage(#245)、messages(#246)配套。本 PR 只动 `src/shared/services/webSearch/**`，把 11 个文件、共 **120 处**裸 `console.*` 迁移到统一日志器 `createLogger`，**只改日志出口，不动任何业务逻辑/控制流/返回值**。

每个文件在 import 之后新增模块级 logger（相对路径，仓库 tsconfig 无 `@/` 别名）。相对路径按层级：

```ts
// 顶层文件（src/shared/services/webSearch/*.ts）
import { createLogger } from '../infra/logger';
const logger = createLogger('<Context>');

// 子目录文件（webSearch/BingSearchModules/*.ts）
import { createLogger } from '../../infra/logger';
const logger = createLogger('<Context>');
```

**级别映射**（本目录出现 log/debug/warn/error 四种）：

```
console.log   → logger.debug   (71)
console.debug → logger.debug   (9)   ── 合计 logger.debug = 80
console.warn  → logger.warn    (12)
console.error → logger.error   (28)
```

保持克制：未把任何 `console.log` 升级为 `logger.info`。

**剥前缀、保参数**：本子系统每个文件前缀单一、清晰、无无前缀调用，统一剥掉消息开头的 `[前缀]`（命名空间已携带），其余参数、顺序、`${}` 模板表达式、末尾 error 对象等原样保留。例：

```ts
console.log('[Parsers] 解析Bing搜索结果，HTML长度:', html.length)
// →
logger.debug('解析Bing搜索结果，HTML长度:', html.length)   // createLogger('Parsers')
```

**各文件 Context**：

| 文件 | Context | 迁移数 |
| --- | --- | --- |
| BingSearchModules/parsers.ts | `Parsers` | 39 |
| EnhancedWebSearchService.ts | `EnhancedWebSearchService` | 30 |
| TavilyMobileSDK.ts | `TavilyMobileSDK` | 12 |
| BingMobileSDK.ts | `BingMobileSDK` | 8 |
| WebSearchTool.ts | `WebSearchTool` | 6 |
| AIIntentAnalyzer.ts | `IntentAnalyzer` | 5 |
| BingFreeSearchService.ts | `BingFreeSearchService` | 5 |
| BingSearchModules/searchEngines.ts | `SearchEngines` | 5 |
| BingSearchModules/utils.ts | `SearchUtils` | 5 |
| BingSearchModules/contentFetcher.ts | `ContentFetcher` | 3 |
| customProtocols.ts | `customProtocols` | 2 |

> 说明：`BingMobileSDK.ts` 与 `TavilyMobileSDK.ts` 原本没有任何 import（纯类型 + 类），logger 插入在文件头部 doc 注释之后、首个 `export` 之前。

## 自检结果

- `grep -rnE "console\.(log|info|warn|error|debug|trace|group)" src/shared/services/webSearch` → **无输出（console.* 归零）**
- `npm run type-check` → 通过（`✅ TypeScript 类型检查通过`）
- `npm run build` → 通过（`✓ built in 4.25s`）
- 逐文件核对：`${}` 模板表达式数量与迁移前完全一致（无消息损坏/漏参）；仅改动 webSearch 目录下 11 个文件；未触碰 logger 核心、旧 LoggerService.ts/debugLogger.ts、eslint 配置及 webSearch 以外文件。


Link to Devin session: https://app.devin.ai/sessions/d9f1ab2601d7429c9fbf206005c281c1
Requested by: @1600822305