### PR TITLE
重构(日志): knowledge 子系统裸 console.* 迁移到统一 createLogger

### DIFF
--- a/src/shared/services/knowledge/EnhancedRAGService.ts
+++ b/src/shared/services/knowledge/EnhancedRAGService.ts
@@ -7,6 +7,9 @@ import { MobileEmbeddingService } from './MobileEmbeddingService';
 import { cosineSimilarity, textSimilarity } from '../../utils/vectorUtils';
 import { generateQuerySynonyms } from '../../config/synonyms';
 import type { KnowledgeBase, KnowledgeDocument, KnowledgeSearchResult } from '../../types/KnowledgeBase';
+import { createLogger } from '../infra/logger';
+
+const logger = createLogger('EnhancedRAGService');
 
 // RAG搜索配置
 interface RAGSearchConfig {
@@ -88,7 +91,7 @@ export class EnhancedRAGService {
         ...params.config
       };
 
-      console.log(`[EnhancedRAGService] 开始增强RAG搜索: "${params.query}"`);
+      logger.debug(`开始增强RAG搜索: "${params.query}"`);
 
       // 第一阶段：查询理解和扩展
       const queryExpansion = await this.expandQuery(params.query, knowledgeBase, config);
@@ -122,23 +125,23 @@ export class EnhancedRAGService {
       );
 
       const duration = Date.now() - startTime;
-      console.log(`[EnhancedRAGService] RAG搜索完成，耗时: ${duration}ms，结果: ${processedResults.length}条`);
+      logger.debug(`RAG搜索完成，耗时: ${duration}ms，结果: ${processedResults.length}条`);
 
       // 调试信息：如果没有结果，输出详细信息
       if (processedResults.length === 0) {
-        console.log(`[EnhancedRAGService] 调试信息 - 无结果原因分析:`);
-        console.log(`- 查询扩展结果:`, queryExpansion);
-        console.log(`- 检索策略数量: ${retrievalResults.length}`);
-        console.log(`- 融合结果数量: ${fusedResults.length}`);
-        console.log(`- 重排序结果数量: ${finalResults.length}`);
-        console.log(`- 阈值: ${params.threshold || 0.7}`);
-        console.log(`- 限制数量: ${params.limit || knowledgeBase.documentCount || 5}`);
+        logger.debug(`调试信息 - 无结果原因分析:`);
+        logger.debug(`- 查询扩展结果:`, queryExpansion);
+        logger.debug(`- 检索策略数量: ${retrievalResults.length}`);
+        logger.debug(`- 融合结果数量: ${fusedResults.length}`);
+        logger.debug(`- 重排序结果数量: ${finalResults.length}`);
+        logger.debug(`- 阈值: ${params.threshold || 0.7}`);
+        logger.debug(`- 限制数量: ${params.limit || knowledgeBase.documentCount || 5}`);
       }
 
       return processedResults;
 
     } catch (error) {
-      console.error('[EnhancedRAGService] 增强RAG搜索失败:', error);
+      logger.error('增强RAG搜索失败:', error);
       // 回退到简单搜索
       return this.fallbackSimpleSearch(params);
     }
@@ -189,10 +192,10 @@ export class EnhancedRAGService {
       // 缓存结果
       this.queryCache.set(cacheKey, expansion);
       
-      console.log(`[EnhancedRAGService] 查询扩展完成: ${expansion.expandedQueries.length}个查询`);
+      logger.debug(`查询扩展完成: ${expansion.expandedQueries.length}个查询`);
 
     } catch (error) {
-      console.warn('[EnhancedRAGService] 查询扩展失败，使用原始查询:', error);
+      logger.warn('查询扩展失败，使用原始查询:', error);
     }
 
     return expansion;
@@ -249,7 +252,7 @@ export class EnhancedRAGService {
     );
     results.push(semanticResults);
 
-    console.log(`[EnhancedRAGService] 多策略检索完成: ${results.length}个策略`);
+    logger.debug(`多策略检索完成: ${results.length}个策略`);
 
     return results;
   }
@@ -265,7 +268,7 @@ export class EnhancedRAGService {
   ): Promise<RetrievalResult> {
     const allResults: Array<{ doc: KnowledgeDocument; score: number }> = [];
 
-    console.log(`[EnhancedRAGService] 向量检索 - 查询数量: ${queryExpansion.expandedQueries.length}, 文档数量: ${documents.length}`);
+    logger.debug(`向量检索 - 查询数量: ${queryExpansion.expandedQueries.length}, 文档数量: ${documents.length}`);
 
     // 对每个扩展查询进行向量搜索
     for (const query of queryExpansion.expandedQueries) {
@@ -281,11 +284,11 @@ export class EnhancedRAGService {
 
         // 输出最高分数
         const maxScore = Math.max(...queryResults.map(r => r.score));
-        console.log(`[EnhancedRAGService] 向量检索 - 查询: "${query}", 最高相似度: ${maxScore.toFixed(4)}`);
+        logger.debug(`向量检索 - 查询: "${query}", 最高相似度: ${maxScore.toFixed(4)}`);
 
         allResults.push(...queryResults);
       } catch (error) {
-        console.warn(`[EnhancedRAGService] 向量检索失败: ${query}`, error);
+        logger.warn(`向量检索失败: ${query}`, error);
       }
     }
 
@@ -297,9 +300,9 @@ export class EnhancedRAGService {
       .sort((a, b) => b.score - a.score)
       .slice(0, maxCandidates);
 
-    console.log(`[EnhancedRAGService] 向量检索完成 - 去重后结果: ${deduplicatedResults.length}, 前${maxCandidates}个结果`);
+    logger.debug(`向量检索完成 - 去重后结果: ${deduplicatedResults.length}, 前${maxCandidates}个结果`);
     if (topResults.length > 0) {
-      console.log(`[EnhancedRAGService] 向量检索 - 最高分: ${topResults[0].score.toFixed(4)}, 最低分: ${topResults[topResults.length-1].score.toFixed(4)}`);
+      logger.debug(`向量检索 - 最高分: ${topResults[0].score.toFixed(4)}, 最低分: ${topResults[topResults.length-1].score.toFixed(4)}`);
     }
 
     return {
@@ -323,8 +326,8 @@ export class EnhancedRAGService {
       ...queryExpansion.relatedTerms
     ].filter(term => term.length > 1);
 
-    console.log(`[EnhancedRAGService] 关键词检索 - 关键词:`, allKeywords);
-    console.log(`[EnhancedRAGService] 关键词检索 - 文档数量: ${documents.length}`);
+    logger.debug(`关键词检索 - 关键词:`, allKeywords);
+    logger.debug(`关键词检索 - 文档数量: ${documents.length}`);
 
     const results = documents.map(doc => {
       const content = doc.content.toLowerCase();
@@ -349,7 +352,7 @@ export class EnhancedRAGService {
 
       // 调试：输出匹配详情
       if (score > 0) {
-        console.log(`[EnhancedRAGService] 关键词匹配 - 文档ID: ${doc.id}, 分数: ${score.toFixed(4)}, 匹配: [${matchDetails.join(', ')}]`);
+        logger.debug(`关键词匹配 - 文档ID: ${doc.id}, 分数: ${score.toFixed(4)}, 匹配: [${matchDetails.join(', ')}]`);
       }
 
       return { doc, score };
@@ -360,7 +363,7 @@ export class EnhancedRAGService {
       .sort((a, b) => b.score - a.score)
       .slice(0, maxCandidates);
 
-    console.log(`[EnhancedRAGService] 关键词检索完成 - 有效结果: ${topResults.length}/${results.length}`);
+    logger.debug(`关键词检索完成 - 有效结果: ${topResults.length}/${results.length}`);
 
     return {
       documents: topResults.map(r => r.doc),
@@ -504,14 +507,14 @@ export class EnhancedRAGService {
     // 按融合分数排序
     fusedResults.sort((a, b) => b.similarity - a.similarity);
 
-    console.log(`[EnhancedRAGService] 结果融合完成: ${fusedResults.length}个候选结果`);
+    logger.debug(`结果融合完成: ${fusedResults.length}个候选结果`);
 
     // 调试：输出融合结果的分数分布
     if (fusedResults.length > 0) {
-      console.log(`[EnhancedRAGService] 融合分数分布 - 最高: ${fusedResults[0].similarity.toFixed(4)}, 最低: ${fusedResults[fusedResults.length-1].similarity.toFixed(4)}`);
+      logger.debug(`融合分数分布 - 最高: ${fusedResults[0].similarity.toFixed(4)}, 最低: ${fusedResults[fusedResults.length-1].similarity.toFixed(4)}`);
       // 输出前3个结果的详细信息
       fusedResults.slice(0, 3).forEach((result, index) => {
-        console.log(`[EnhancedRAGService] 融合结果${index+1} - 分数: ${result.similarity.toFixed(4)}, 内容预览: "${result.content.substring(0, 50)}..."`);
+        logger.debug(`融合结果${index+1} - 分数: ${result.similarity.toFixed(4)}, 内容预览: "${result.content.substring(0, 50)}..."`);
       });
     }
 
@@ -551,12 +554,12 @@ export class EnhancedRAGService {
       // 重新排序
       rerankedResults.sort((a, b) => b.similarity - a.similarity);
 
-      console.log(`[EnhancedRAGService] 重排序完成`);
+      logger.debug(`重排序完成`);
 
       return rerankedResults;
 
     } catch (error) {
-      console.warn('[EnhancedRAGService] 重排序失败，使用原始排序:', error);
+      logger.warn('重排序失败，使用原始排序:', error);
       return results;
     }
   }
@@ -569,7 +572,7 @@ export class EnhancedRAGService {
     threshold: number,
     limit: number
   ): KnowledgeSearchResult[] {
-    console.log(`[EnhancedRAGService] 后处理前: ${results.length}个结果, 阈值: ${threshold}`);
+    logger.debug(`后处理前: ${results.length}个结果, 阈值: ${threshold}`);
 
     // 如果阈值过高导致没有结果，动态降低阈值
     let adjustedThreshold = threshold;
@@ -580,7 +583,7 @@ export class EnhancedRAGService {
       const maxScore = Math.max(...results.map(r => r.similarity));
       adjustedThreshold = Math.max(0.1, maxScore * 0.5);
       filteredResults = results.filter(result => result.similarity >= adjustedThreshold);
-      console.log(`[EnhancedRAGService] 动态调整阈值: ${threshold} → ${adjustedThreshold}, 结果: ${filteredResults.length}个`);
+      logger.debug(`动态调整阈值: ${threshold} → ${adjustedThreshold}, 结果: ${filteredResults.length}个`);
     }
 
     const finalResults = filteredResults
@@ -591,7 +594,7 @@ export class EnhancedRAGService {
         similarity: Math.min(1, Math.max(0, result.similarity))
       }));
 
-    console.log(`[EnhancedRAGService] 后处理完成: ${finalResults.length}个结果`);
+    logger.debug(`后处理完成: ${finalResults.length}个结果`);
     return finalResults;
   }
 
@@ -604,12 +607,12 @@ export class EnhancedRAGService {
     threshold?: number;
     limit?: number;
   }): Promise<KnowledgeSearchResult[]> {
-    console.log('[EnhancedRAGService] 使用回退简单搜索');
+    logger.debug('使用回退简单搜索');
 
     try {
       const knowledgeBase = await dexieStorage.knowledge_bases.get(params.knowledgeBaseId);
       if (!knowledgeBase) {
-        console.log('[EnhancedRAGService] 回退搜索 - 知识库不存在');
+        logger.debug('回退搜索 - 知识库不存在');
         return [];
       }
 
@@ -618,7 +621,7 @@ export class EnhancedRAGService {
         .equals(params.knowledgeBaseId)
         .toArray();
 
-      console.log(`[EnhancedRAGService] 回退搜索 - 找到 ${documents.length} 个文档`);
+      logger.debug(`回退搜索 - 找到 ${documents.length} 个文档`);
 
       if (documents.length === 0) {
         return [];
@@ -629,7 +632,7 @@ export class EnhancedRAGService {
         doc.content.toLowerCase().includes(params.query.toLowerCase())
       );
 
-      console.log(`[EnhancedRAGService] 回退搜索 - 关键词匹配: ${keywordResults.length} 个结果`);
+      logger.debug(`回退搜索 - 关键词匹配: ${keywordResults.length} 个结果`);
 
       if (keywordResults.length > 0) {
         // 如果有关键词匹配，直接返回
@@ -657,12 +660,12 @@ export class EnhancedRAGService {
         .sort((a, b) => b.similarity - a.similarity)
         .slice(0, limit);
 
-      console.log(`[EnhancedRAGService] 回退搜索 - 向量搜索结果: ${vectorResults.length} 个`);
+      logger.debug(`回退搜索 - 向量搜索结果: ${vectorResults.length} 个`);
 
       return vectorResults;
 
     } catch (error) {
-      console.error('[EnhancedRAGService] 回退搜索也失败:', error);
+      logger.error('回退搜索也失败:', error);
       return [];
     }
   }
@@ -724,7 +727,7 @@ export class EnhancedRAGService {
         if (relatedTerms.length >= 5) break;
       }
     } catch (error) {
-      console.warn('[EnhancedRAGService] 提取相关术语失败:', error);
+      logger.warn('提取相关术语失败:', error);
     }
 
     return relatedTerms;
@@ -793,7 +796,7 @@ export class EnhancedRAGService {
       
       return matches / queryWords.length;
     } catch (error) {
-      console.warn('[EnhancedRAGService] 计算相关性分数失败:', error);
+      logger.warn('计算相关性分数失败:', error);
       return 0.5; // 默认中等相关性
     }
   }

--- a/src/shared/services/knowledge/FileParserService.ts
+++ b/src/shared/services/knowledge/FileParserService.ts
@@ -6,6 +6,9 @@
 
 import { getPlatformInfo } from '../../utils/platformDetection';
 import type { PreprocessProviderConfig, PreprocessProgressCallback } from './preprocess/types';
+import { createLogger } from '../infra/logger';
+
+const logger = createLogger('FileParser');
 
 // 平台特定限制
 const PLATFORM_LIMITS = {
@@ -201,7 +204,7 @@ class FileParserService {
         content = await this.parseTextFile(file);
       }
     } catch (err) {
-      console.error(`解析文件失败: ${fileName}`, err);
+      logger.error(`解析文件失败: ${fileName}`, err);
       throw new Error(`解析文件失败: ${err instanceof Error ? err.message : '未知错误'}`);
     }
 
@@ -252,7 +255,7 @@ class FileParserService {
     // 强制云端模式：跳过本地解析
     if (mode === 'cloud' && this.cloudPreprocessConfig) {
       try {
-        console.log(`[FileParser] 强制云端模式，使用 ${this.cloudPreprocessConfig.id} 解析 PDF`);
+        logger.debug(`强制云端模式，使用 ${this.cloudPreprocessConfig.id} 解析 PDF`);
         const { preprocessPdfWithCloud } = await import('./preprocess');
         const result = await preprocessPdfWithCloud(
           arrayBuffer,
@@ -262,7 +265,7 @@ class FileParserService {
         );
         return result.content;
       } catch (err) {
-        console.error('[FileParser] 云端 PDF 解析失败，降级到本地:', err);
+        logger.error('云端 PDF 解析失败，降级到本地:', err);
         // 云端失败仍尝试本地
       }
     }
@@ -294,17 +297,17 @@ class FileParserService {
             return localResult;
           }
 
-          console.warn(`[FileParser] PDF 文本层过少 (${actualTextLength} 字符)，可能为扫描件`);
+          logger.warn(`PDF 文本层过少 (${actualTextLength} 字符)，可能为扫描件`);
         }
       } catch (err) {
-        console.warn('[FileParser] pdfjs 解析失败:', err);
+        logger.warn('pdfjs 解析失败:', err);
       }
     }
 
     // 2️⃣ 尝试云端 Provider 解析（仅 auto 模式）
     if (mode !== 'local' && this.cloudPreprocessConfig) {
       try {
-        console.log(`[FileParser] 使用云端 Provider (${this.cloudPreprocessConfig.id}) 解析 PDF`);
+        logger.debug(`使用云端 Provider (${this.cloudPreprocessConfig.id}) 解析 PDF`);
         const { preprocessPdfWithCloud } = await import('./preprocess');
         const result = await preprocessPdfWithCloud(
           arrayBuffer,
@@ -314,7 +317,7 @@ class FileParserService {
         );
         return result.content;
       } catch (err) {
-        console.error('[FileParser] 云端 PDF 解析失败:', err);
+        logger.error('云端 PDF 解析失败:', err);
       }
     }
 
@@ -377,7 +380,7 @@ class FileParserService {
       const result = await mammoth.extractRawText({ arrayBuffer });
       return result.value || '';
     } catch (err) {
-      console.warn('DOCX mammoth 解析失败，尝试简单解析:', err);
+      logger.warn('DOCX mammoth 解析失败，尝试简单解析:', err);
       return this.getDocxFallbackParse(file);
     }
   }

--- a/src/shared/services/knowledge/KnowledgeContextService.ts
+++ b/src/shared/services/knowledge/KnowledgeContextService.ts
@@ -5,6 +5,9 @@
 
 import { MobileKnowledgeService } from './MobileKnowledgeService';
 import { REFERENCE_PROMPT } from '../../config/prompts';
+import { createLogger } from '../infra/logger';
+
+const logger = createLogger('KnowledgeContextService');
 
 
 export interface KnowledgeReference {
@@ -82,7 +85,7 @@ export class KnowledgeContextService {
 
           allReferences.push(...references);
         } catch (error) {
-          console.error(`[KnowledgeContextService] 搜索知识库 ${kbId} 失败:`, error);
+          logger.error(`搜索知识库 ${kbId} 失败:`, error);
         }
       }
 
@@ -94,11 +97,11 @@ export class KnowledgeContextService {
       // 缓存结果
       this.knowledgeCache.set(`knowledge-search-${messageId}`, sortedReferences);
 
-      console.log(`[KnowledgeContextService] 为消息 ${messageId} 搜索到 ${sortedReferences.length} 个知识库引用`);
+      logger.debug(`为消息 ${messageId} 搜索到 ${sortedReferences.length} 个知识库引用`);
 
       return sortedReferences;
     } catch (error) {
-      console.error('[KnowledgeContextService] 搜索知识库失败:', error);
+      logger.error('搜索知识库失败:', error);
       return [];
     }
   }
@@ -206,7 +209,7 @@ export class KnowledgeContextService {
     // 在实际应用中，可以根据时间戳进行更精确的清理
     if (this.knowledgeCache.size > 100) {
       this.knowledgeCache.clear();
-      console.log('[KnowledgeContextService] 清理知识库缓存');
+      logger.debug('清理知识库缓存');
     }
   }
 }

--- a/src/shared/services/knowledge/KnowledgeTaskQueue.ts
+++ b/src/shared/services/knowledge/KnowledgeTaskQueue.ts
@@ -21,6 +21,9 @@ import type {
   QueueConfig,
   QueueStatus,
 } from '../../types/KnowledgeBase';
+import { createLogger } from '../infra/logger';
+
+const logger = createLogger('KnowledgeTaskQueue');
 
 // 默认队列配置（移动端保守值）
 const DEFAULT_QUEUE_CONFIG: QueueConfig = {
@@ -135,7 +138,7 @@ export class KnowledgeTaskQueue {
       // 注入 PDF 解析模式
       fileParserService.setPdfParseMode(pdfPreprocess.parseMode || 'auto');
     } catch (err) {
-      console.warn('[KnowledgeTaskQueue] 读取云端预处理配置失败:', err);
+      logger.warn('读取云端预处理配置失败:', err);
     }
   }
 
@@ -161,7 +164,7 @@ export class KnowledgeTaskQueue {
         try {
           (cb as Function)(...args);
         } catch (err) {
-          console.error(`[KnowledgeTaskQueue] 事件处理器错误 (${event}):`, err);
+          logger.error(`事件处理器错误 (${event}):`, err);
         }
       }
     }
@@ -240,8 +243,8 @@ export class KnowledgeTaskQueue {
       this.pendingQueue.push(task);
       this.emit('task:queued', task);
 
-      console.log(
-        `[KnowledgeTaskQueue] 任务入队: ${task.fileName} ` +
+      logger.debug(
+        `任务入队: ${task.fileName} ` +
         `(${this.formatBytes(task.fileSize)}, 队列: ${this.pendingQueue.length})`
       );
 
@@ -298,8 +301,8 @@ export class KnowledgeTaskQueue {
     for (const task of tasksToStart) {
       this.emit('task:started', task);
 
-      console.log(
-        `[KnowledgeTaskQueue] 任务开始: ${task.fileName} ` +
+      logger.debug(
+        `任务开始: ${task.fileName} ` +
         `(并发: ${this.processingMap.size}/${this.config.maxConcurrent}, ` +
         `负载: ${this.formatBytes(this.currentWorkload)}/${this.formatBytes(this.config.maxWorkload)})`
       );
@@ -312,8 +315,8 @@ export class KnowledgeTaskQueue {
           this.completedCount++;
           this.emit('task:completed', task);
 
-          console.log(
-            `[KnowledgeTaskQueue] 任务完成: ${task.fileName} ` +
+          logger.debug(
+            `任务完成: ${task.fileName} ` +
             `(耗时: ${Date.now() - (task.startedAt || Date.now())}ms)`
           );
         })
@@ -326,15 +329,15 @@ export class KnowledgeTaskQueue {
           this.failedCount++;
           this.emit('task:failed', task);
 
-          console.error(
-            `[KnowledgeTaskQueue] 任务失败: ${task.fileName}:`,
+          logger.error(
+            `任务失败: ${task.fileName}:`,
             error.message
           );
 
           // 自动重试
           if (task.retryCount < task.maxRetries) {
-            console.log(
-              `[KnowledgeTaskQueue] 将在 ${this.config.retryDelay}ms 后重试 ` +
+            logger.debug(
+              `将在 ${this.config.retryDelay}ms 后重试 ` +
               `(${task.retryCount + 1}/${task.maxRetries}): ${task.fileName}`
             );
             setTimeout(() => {
@@ -360,8 +363,8 @@ export class KnowledgeTaskQueue {
           // 检查队列是否完全清空
           if (this.processingMap.size === 0 && this.pendingQueue.length === 0) {
             this.emit('queue:drained');
-            console.log(
-              `[KnowledgeTaskQueue] 队列清空 — ` +
+            logger.debug(
+              `队列清空 — ` +
               `完成: ${this.completedCount}, 失败: ${this.failedCount}`
             );
           }
@@ -407,7 +410,7 @@ export class KnowledgeTaskQueue {
           contentToProcess = parsed.content;
         }
       } catch (parseErr) {
-        console.warn(`[KnowledgeTaskQueue] 文件解析失败: ${task.fileName}`, parseErr);
+        logger.warn(`文件解析失败: ${task.fileName}`, parseErr);
         contentToProcess = `[${task.fileName}]\n\n此文件格式需要额外依赖才能解析。\n\n${parseErr instanceof Error ? parseErr.message : '解析失败'}`;
       }
 
@@ -480,7 +483,7 @@ export class KnowledgeTaskQueue {
       task.state = 'cancelled';
       this.pendingQueue.splice(pendingIndex, 1);
       this.abortControllers.delete(taskId);
-      console.log(`[KnowledgeTaskQueue] 任务取消(等待中): ${task.fileName}`);
+      logger.debug(`任务取消(等待中): ${task.fileName}`);
       return true;
     }
 
@@ -490,7 +493,7 @@ export class KnowledgeTaskQueue {
       processingTask.state = 'cancelled';
       const controller = this.abortControllers.get(taskId);
       controller?.abort();
-      console.log(`[KnowledgeTaskQueue] 任务取消(处理中): ${processingTask.fileName}`);
+      logger.debug(`任务取消(处理中): ${processingTask.fileName}`);
       return true;
     }
 
@@ -516,7 +519,7 @@ export class KnowledgeTaskQueue {
 
     // 清理
     this.abortControllers.clear();
-    console.log('[KnowledgeTaskQueue] 所有任务已取消');
+    logger.debug('所有任务已取消');
   }
 
   /**
@@ -532,7 +535,7 @@ export class KnowledgeTaskQueue {
     }
 
     if (task.retryCount >= task.maxRetries) {
-      console.warn(`[KnowledgeTaskQueue] 任务已达最大重试次数: ${task.fileName}`);
+      logger.warn(`任务已达最大重试次数: ${task.fileName}`);
       return false;
     }
 

--- a/src/shared/services/knowledge/MobileEmbeddingService.ts
+++ b/src/shared/services/knowledge/MobileEmbeddingService.ts
@@ -9,6 +9,9 @@ import { getEmbeddingDimensions } from '../../config/embeddingModels';
 import { universalFetch } from '../../utils/universalFetch';
 import store from '../../store';
 import { createGeminiEmbeddingService } from "../../api/gemini-aisdk/embeddingService";
+import { createLogger } from '../infra/logger';
+
+const logger = createLogger('MobileEmbeddingService');
 
 /**
  * 获取模型的维度
@@ -56,7 +59,7 @@ export function getAvailableEmbeddingModels(): Model[] {
 
     return allModels;
   } catch (error) {
-    console.error('[MobileEmbeddingService] 获取嵌入模型失败:', error);
+    logger.error('获取嵌入模型失败:', error);
     return [];
   }
 }
@@ -109,7 +112,7 @@ export class MobileEmbeddingService {
       const testVector = await this.getEmbedding('test', modelId);
       return testVector.length;
     } catch (error) {
-      console.error('[MobileEmbeddingService] 获取模型维度失败:', error);
+      logger.error('获取模型维度失败:', error);
       // 回退到配置文件中的维度
       return getEmbeddingDimensions(modelId);
     }
@@ -216,7 +219,7 @@ export class MobileEmbeddingService {
       this.cleanExpiredCache();
       return embedding;
     } catch (error) {
-      console.error('[MobileEmbeddingService] 获取向量嵌入失败:', error);
+      logger.error('获取向量嵌入失败:', error);
       throw error;
     }
   }
@@ -364,7 +367,7 @@ export class MobileEmbeddingService {
       // 直接使用本地向量搜索，避免复杂的云端调用
       return this.localVectorSearch(params);
     } catch (error) {
-      console.error('[MobileEmbeddingService] 搜索向量失败:', error);
+      logger.error('搜索向量失败:', error);
       return [];
     }
   }

--- a/src/shared/services/knowledge/MobileKnowledgeService.ts
+++ b/src/shared/services/knowledge/MobileKnowledgeService.ts
@@ -16,6 +16,9 @@ import {
 import { cosineSimilarity } from '../../utils/vectorUtils';
 import { chunkText } from '../../utils/textChunker';
 import type { KnowledgeBase, KnowledgeDocument, KnowledgeSearchResult } from '../../types/KnowledgeBase';
+import { createLogger } from '../infra/logger';
+
+const logger = createLogger('MobileKnowledgeService');
 
 /**
  * 移动端知识库服务类
@@ -73,12 +76,12 @@ export class MobileKnowledgeService {
       // 保存到数据库
       await dexieStorage.knowledge_bases.put(knowledgeBase);
 
-      console.log(`[MobileKnowledgeService] 知识库创建成功: ${knowledgeBase.id}`);
+      logger.debug(`知识库创建成功: ${knowledgeBase.id}`);
       EventEmitter.emit(EVENT_NAMES.KNOWLEDGE_BASE_CREATED, knowledgeBase);
 
       return knowledgeBase;
     } catch (error) {
-      console.error('[MobileKnowledgeService] 创建知识库失败:', error);
+      logger.error('创建知识库失败:', error);
       throw error;
     }
   }
@@ -90,7 +93,7 @@ export class MobileKnowledgeService {
     try {
       return await dexieStorage.knowledge_bases.get(id);
     } catch (error) {
-      console.error(`[MobileKnowledgeService] 获取知识库失败: ${id}`, error);
+      logger.error(`获取知识库失败: ${id}`, error);
       return null;
     }
   }
@@ -102,7 +105,7 @@ export class MobileKnowledgeService {
     try {
       return await dexieStorage.knowledge_bases.toArray();
     } catch (error) {
-      console.error('[MobileKnowledgeService] 获取所有知识库失败:', error);
+      logger.error('获取所有知识库失败:', error);
       return [];
     }
   }
@@ -128,12 +131,12 @@ export class MobileKnowledgeService {
 
       await dexieStorage.knowledge_bases.put(updatedKnowledgeBase);
 
-      console.log(`[MobileKnowledgeService] 知识库更新成功: ${id}`);
+      logger.debug(`知识库更新成功: ${id}`);
       EventEmitter.emit(EVENT_NAMES.KNOWLEDGE_BASE_UPDATED, updatedKnowledgeBase);
 
       return updatedKnowledgeBase;
     } catch (error) {
-      console.error(`[MobileKnowledgeService] 更新知识库失败: ${id}`, error);
+      logger.error(`更新知识库失败: ${id}`, error);
       return null;
     }
   }
@@ -158,12 +161,12 @@ export class MobileKnowledgeService {
       // 删除知识库
       await dexieStorage.knowledge_bases.delete(id);
 
-      console.log(`[MobileKnowledgeService] 知识库删除成功: ${id}`);
+      logger.debug(`知识库删除成功: ${id}`);
       EventEmitter.emit(EVENT_NAMES.KNOWLEDGE_BASE_DELETED, { id, documentCount: documents.length });
 
       return true;
     } catch (error) {
-      console.error(`[MobileKnowledgeService] 删除知识库失败: ${id}`, error);
+      logger.error(`删除知识库失败: ${id}`, error);
       return false;
     }
   }
@@ -195,7 +198,7 @@ export class MobileKnowledgeService {
         strategy: knowledgeBase.chunkStrategy || 'fixed',
       });
 
-      console.log(`[MobileKnowledgeService] 文档分块: ${chunks.length} 个块`);
+      logger.debug(`文档分块: ${chunks.length} 个块`);
 
       // 批量获取嵌入向量（一次 API 请求处理多个文本）
       const documents: KnowledgeDocument[] = [];
@@ -244,14 +247,14 @@ export class MobileKnowledgeService {
             });
           }
 
-          console.log(`[MobileKnowledgeService] 批量嵌入完成: ${batchStart + batchChunks.length}/${chunks.length}`);
+          logger.debug(`批量嵌入完成: ${batchStart + batchChunks.length}/${chunks.length}`);
         } catch (error) {
-          console.error(`[MobileKnowledgeService] 批量嵌入失败 (${batchStart}-${batchStart + batchChunks.length}):`, error);
+          logger.error(`批量嵌入失败 (${batchStart}-${batchStart + batchChunks.length}):`, error);
           throw new Error(`无法获取文本向量嵌入，请检查嵌入模型配置和网络连接。错误: ${error instanceof Error ? error.message : String(error)}`);
         }
       }
 
-      console.log(`[MobileKnowledgeService] 文档添加成功: ${documents.length} 个块`);
+      logger.debug(`文档添加成功: ${documents.length} 个块`);
       EventEmitter.emit(EVENT_NAMES.KNOWLEDGE_DOCUMENTS_ADDED, {
         knowledgeBaseId: params.knowledgeBaseId,
         count: documents.length
@@ -259,7 +262,7 @@ export class MobileKnowledgeService {
 
       return documents;
     } catch (error) {
-      console.error('[MobileKnowledgeService] 添加文档失败:', error);
+      logger.error('添加文档失败:', error);
       throw error;
     }
   }
@@ -276,10 +279,10 @@ export class MobileKnowledgeService {
         .equals(knowledgeBaseId)
         .toArray();
 
-      console.log(`[MobileKnowledgeService] 获取知识库文档成功: ${knowledgeBaseId}, 共 ${documents.length} 个文档`);
+      logger.debug(`获取知识库文档成功: ${knowledgeBaseId}, 共 ${documents.length} 个文档`);
       return documents;
     } catch (error) {
-      console.error(`[MobileKnowledgeService] 获取知识库文档失败: ${knowledgeBaseId}`, error);
+      logger.error(`获取知识库文档失败: ${knowledgeBaseId}`, error);
       return [];
     }
   }
@@ -294,14 +297,14 @@ export class MobileKnowledgeService {
       // 获取文档信息，用于通知事件
       const document = await dexieStorage.knowledge_documents.get(documentId);
       if (!document) {
-        console.warn(`[MobileKnowledgeService] 尝试删除不存在的文档: ${documentId}`);
+        logger.warn(`尝试删除不存在的文档: ${documentId}`);
         return false;
       }
 
       // 删除文档
       await dexieStorage.knowledge_documents.delete(documentId);
 
-      console.log(`[MobileKnowledgeService] 删除文档成功: ${documentId}, 知识库: ${document.knowledgeBaseId}`);
+      logger.debug(`删除文档成功: ${documentId}, 知识库: ${document.knowledgeBaseId}`);
 
       // 发出文档删除事件
       EventEmitter.emit(EVENT_NAMES.KNOWLEDGE_DOCUMENT_DELETED, {
@@ -311,7 +314,7 @@ export class MobileKnowledgeService {
 
       return true;
     } catch (error) {
-      console.error(`[MobileKnowledgeService] 删除文档失败: ${documentId}`, error);
+      logger.error(`删除文档失败: ${documentId}`, error);
       return false;
     }
   }
@@ -343,7 +346,7 @@ export class MobileKnowledgeService {
     enableQueryExpansion?: boolean;
     enableHybridSearch?: boolean;
   }): Promise<KnowledgeSearchResult[]> {
-    console.log(`[MobileKnowledgeService] 使用增强RAG搜索: ${params.query}`);
+    logger.debug(`使用增强RAG搜索: ${params.query}`);
     return this.enhancedRAGService.enhancedSearch(params);
   }
 
@@ -359,7 +362,7 @@ export class MobileKnowledgeService {
   }): Promise<KnowledgeSearchResult[]> {
     // 如果启用增强RAG，使用新的搜索算法
     if (params.useEnhancedRAG !== false) {
-      console.log(`[MobileKnowledgeService] 使用增强RAG搜索模式`);
+      logger.debug(`使用增强RAG搜索模式`);
       try {
         return await this.enhancedRAGService.enhancedSearch({
           knowledgeBaseId: params.knowledgeBaseId,
@@ -376,13 +379,13 @@ export class MobileKnowledgeService {
           }
         });
       } catch (error) {
-        console.warn('[MobileKnowledgeService] 增强RAG搜索失败，回退到简单搜索:', error);
+        logger.warn('增强RAG搜索失败，回退到简单搜索:', error);
         // 继续执行简单搜索作为回退
       }
     }
 
     // 简单搜索模式（原有逻辑）
-    console.log(`[MobileKnowledgeService] 使用简单搜索模式`);
+    logger.debug(`使用简单搜索模式`);
     return this.simpleSearch(params);
   }
 
@@ -406,10 +409,10 @@ export class MobileKnowledgeService {
       try {
         const embeddingService = MobileEmbeddingService.getInstance();
         queryVector = await embeddingService.getEmbedding(params.query, knowledgeBase.model);
-        console.log(`[MobileKnowledgeService] 查询向量获取成功，维度: ${queryVector.length}`);
+        logger.debug(`查询向量获取成功，维度: ${queryVector.length}`);
       } catch (embeddingError) {
         // 不使用随机向量，直接抛出错误
-        console.error(`[MobileKnowledgeService] 查询向量获取失败:`, embeddingError);
+        logger.error(`查询向量获取失败:`, embeddingError);
         throw new Error(`无法获取查询向量，请检查嵌入模型配置和网络连接。`);
       }
 
@@ -419,13 +422,13 @@ export class MobileKnowledgeService {
         .equals(params.knowledgeBaseId)
         .toArray();
 
-      console.log(`[MobileKnowledgeService] 搜索知识库: ${documents.length} 个文档`);
+      logger.debug(`搜索知识库: ${documents.length} 个文档`);
 
       // 检查文档向量维度
       if (documents.length > 0) {
         const firstDocVector = documents[0].vector;
-        console.log(`[MobileKnowledgeService] 文档向量维度: ${firstDocVector?.length || '未知'}`);
-        console.log(`[MobileKnowledgeService] 查询向量维度: ${queryVector.length}`);
+        logger.debug(`文档向量维度: ${firstDocVector?.length || '未知'}`);
+        logger.debug(`查询向量维度: ${queryVector.length}`);
 
         if (firstDocVector && firstDocVector.length !== queryVector.length) {
           throw new Error(`向量维度不匹配: 查询向量(${queryVector.length}) vs 知识库文档向量(${firstDocVector.length})。请使用相同的嵌入模型或重新创建知识库。`);
@@ -439,11 +442,11 @@ export class MobileKnowledgeService {
       // 使用简单的相似度计算
       const results = this.localVectorSearch(queryVector, documents, threshold, limit);
 
-      console.log(`[MobileKnowledgeService] 简单搜索结果: ${results.length} 条`);
+      logger.debug(`简单搜索结果: ${results.length} 条`);
 
       return results;
     } catch (error) {
-      console.error('[MobileKnowledgeService] 简单搜索失败:', error);
+      logger.error('简单搜索失败:', error);
       return [];
     }
   }

--- a/src/shared/services/knowledge/preprocess/Doc2xProvider.ts
+++ b/src/shared/services/knowledge/preprocess/Doc2xProvider.ts
@@ -18,6 +18,9 @@ import BasePreprocessProvider from './BasePreprocessProvider';
 import { universalFetch } from '../../../utils/universalFetch';
 import { PREPROCESS_PROVIDER_METAS } from './types';
 import type { PreprocessResult } from './types';
+import { createLogger } from '../../infra/logger';
+
+const logger = createLogger('Doc2x');
 
 type ApiResponse<T> = {
   code: string;
@@ -89,7 +92,7 @@ export default class Doc2xProvider extends BasePreprocessProvider {
         providerId: 'doc2x',
       };
     } catch (error) {
-      console.error('[Doc2x] PDF 预处理失败:', error);
+      logger.error('PDF 预处理失败:', error);
       throw error;
     }
   }

--- a/src/shared/services/knowledge/preprocess/MistralOCRProvider.ts
+++ b/src/shared/services/knowledge/preprocess/MistralOCRProvider.ts
@@ -16,6 +16,9 @@
 import BasePreprocessProvider from './BasePreprocessProvider';
 import { PREPROCESS_PROVIDER_METAS } from './types';
 import type { PreprocessResult } from './types';
+import { createLogger } from '../../infra/logger';
+
+const logger = createLogger('MistralOCR');
 
 interface OCRPage {
   index: number;
@@ -76,7 +79,7 @@ export default class MistralOCRProvider extends BasePreprocessProvider {
         providerId: 'mistral',
       };
     } catch (error) {
-      console.error('[MistralOCR] PDF 预处理失败:', error);
+      logger.error('PDF 预处理失败:', error);
       throw error;
     }
   }

--- a/src/shared/services/knowledge/preprocess/OpenMineruProvider.ts
+++ b/src/shared/services/knowledge/preprocess/OpenMineruProvider.ts
@@ -18,6 +18,9 @@ import BasePreprocessProvider from './BasePreprocessProvider';
 import { PREPROCESS_PROVIDER_METAS } from './types';
 import type { PreprocessResult } from './types';
 import { universalFetch } from '../../../utils/universalFetch';
+import { createLogger } from '../../infra/logger';
+
+const logger = createLogger('MinerU');
 
 // ==================== API 响应类型 ====================
 
@@ -109,7 +112,7 @@ export default class OpenMineruProvider extends BasePreprocessProvider {
         providerId: 'open-mineru',
       };
     } catch (error) {
-      console.error('[MinerU] 预处理失败:', error);
+      logger.error('预处理失败:', error);
       throw error;
     }
   }
@@ -124,17 +127,17 @@ export default class OpenMineruProvider extends BasePreprocessProvider {
     // Step 1: 申请预签名上传 URL
     this.sendProgress(5, '申请上传链接...');
     const { batch_id, upload_url } = await this.requestUploadUrl(fileName);
-    console.log(`[MinerU] 获取上传链接成功, batch_id: ${batch_id}`);
+    logger.debug(`获取上传链接成功, batch_id: ${batch_id}`);
 
     // Step 2: 上传文件
     this.sendProgress(10, '上传文件...');
     await this.uploadFile(upload_url, fileData);
-    console.log(`[MinerU] 文件上传成功: ${fileName}`);
+    logger.debug(`文件上传成功: ${fileName}`);
 
     // Step 3: 轮询解析结果
     this.sendProgress(20, '等待解析...');
     const zipUrl = await this.pollBatchResult(batch_id, fileName);
-    console.log(`[MinerU] 解析完成, zip URL: ${zipUrl}`);
+    logger.debug(`解析完成, zip URL: ${zipUrl}`);
 
     // Step 4: 下载并解压
     this.sendProgress(85, '下载结果...');
@@ -206,7 +209,7 @@ export default class OpenMineruProvider extends BasePreprocessProvider {
         const result: MineruApiResponse<BatchExtractData> = await response.json();
 
         if (result.code !== 0) {
-          console.warn(`[MinerU] 轮询返回错误: ${result.msg}`);
+          logger.warn(`轮询返回错误: ${result.msg}`);
           continue;
         }
 
@@ -250,7 +253,7 @@ export default class OpenMineruProvider extends BasePreprocessProvider {
         if (i === OpenMineruProvider.MAX_POLL_ATTEMPTS - 1) {
           throw error;
         }
-        console.warn(`[MinerU] 轮询第 ${i + 1} 次失败:`, error);
+        logger.warn(`轮询第 ${i + 1} 次失败:`, error);
       }
     }
 
@@ -360,7 +363,7 @@ export default class OpenMineruProvider extends BasePreprocessProvider {
         }
       } catch (error) {
         if (i === OpenMineruProvider.MAX_POLL_ATTEMPTS - 1) throw error;
-        console.warn(`[MinerU] 轮询第 ${i + 1} 次失败:`, error);
+        logger.warn(`轮询第 ${i + 1} 次失败:`, error);
       }
     }
 


### PR DESCRIPTION
## Summary

日志系统 Phase 4 分模块迁移的 knowledge 子系统部分，配套已合并的 mcp(#241)、store(#242)、api(#244)、storage(#245)、messages(#246)。

将 `src/shared/services/knowledge/**`（9 个文件，约 105 处）的裸 `console.*` 全部迁移到统一日志器 `createLogger`。**仅替换日志出口，不改任何业务逻辑/控制流/返回值。**

每个文件在 import 之后新增模块级 logger，例如：

```ts
import { createLogger } from '../infra/logger';

const logger = createLogger('EnhancedRAGService');
```

### 范围（仅 knowledge）
顶层文件用 `'../infra/logger'`，`preprocess/` 子目录用 `'../../infra/logger'`（仓库 tsconfig 无 `@/` 别名，tsc 不认 `@`，故用相对路径）。各文件 context 命名：

| 文件 | context |
| --- | --- |
| `EnhancedRAGService.ts` | `EnhancedRAGService` |
| `FileParserService.ts` | `FileParser` |
| `KnowledgeContextService.ts` | `KnowledgeContextService` |
| `KnowledgeTaskQueue.ts` | `KnowledgeTaskQueue` |
| `MobileEmbeddingService.ts` | `MobileEmbeddingService` |
| `MobileKnowledgeService.ts` | `MobileKnowledgeService` |
| `preprocess/Doc2xProvider.ts` | `Doc2x` |
| `preprocess/MistralOCRProvider.ts` | `MistralOCR` |
| `preprocess/OpenMineruProvider.ts` | `MinerU` |

### 级别映射
- `console.log` → `logger.debug`（绝大多数，诊断/冗余信息）
- `console.warn` → `logger.warn`
- `console.error` → `logger.error`
- （本批次无 `console.info/debug/trace`）

### 前缀处理
带 `[Context]` 前缀的消息剥掉开头命名空间前缀（命名空间已由 logger context 携带），其余参数/顺序/emoji/末尾 error 对象原样保留；无前缀的消息保持完全不变（不硬塞前缀）。示例：

```diff
- console.error('[EnhancedRAGService] 增强RAG搜索失败:', error);
+ logger.error('增强RAG搜索失败:', error);

  // 无前缀的子详情行保持原样
- console.log(`- 查询扩展结果:`, queryExpansion);
+ logger.debug(`- 查询扩展结果:`, queryExpansion);
```

### 多行调用处理
`KnowledgeTaskQueue.ts` 中存在跨多行的 `console.log(...)`（开括号在行尾、参数分布在后续多行），整段替换为 `logger.debug(...)`，保留全部多行参数并剥掉首参前缀：

```diff
- console.log(
-   `[KnowledgeTaskQueue] 任务入队: ${task.fileName} ` +
+ logger.debug(
+   `任务入队: ${task.fileName} ` +
    `(${this.formatBytes(task.fileSize)}, 队列: ${this.pendingQueue.length})`
  );
```

### 自检结果
- `grep -rnE "console\.(log|info|warn|error|debug|trace|group)" src/shared/services/knowledge` → **0 残留**。
- `npm run type-check` → 通过。
- `npm run build` → 通过（`✓ built in 9.22s`）。
- `npx eslint src/shared/services/knowledge` → 无新增 `no-console` 告警（仅剩与本次迁移无关的既有 `Function` 类型 / `preserve-caught-error` 错误，不在本任务范围）。

### 不涉及
未改动 logger 核心 / 旧 `LoggerService.ts` / `debugLogger.ts` / eslint 配置，也未触碰 knowledge 以外任何文件。


Link to Devin session: https://app.devin.ai/sessions/840f6e79b6c049cb87e83820e87362a5
Requested by: @1600822305