### PR TITLE
fix(memory): 修正 replaceInCache 缓存键解析（TS2345 + 命中不一致）

### DIFF
--- a/src/shared/services/memory/MemoryService.ts
+++ b/src/shared/services/memory/MemoryService.ts
@@ -716,7 +716,8 @@ class MemoryService {
    * 用更新后的记忆替换缓存中的同名条目
    */
   private replaceInCache(item: Memory): void {
-    const cached = this.memoryCache.get(item.userId);
+    const filterKey = item.assistantId || item.userId || 'default';
+    const cached = this.memoryCache.get(filterKey);
     if (!cached) {
       return;
     }


### PR DESCRIPTION
## Summary
`MemoryService.replaceInCache` 用 `item.userId`(类型 `string | undefined`)直接作为 `memoryCache: Map<string, …>` 的键,在严格模式(`tsconfig.app.json` `strict: true`)下触发 **TS2345**(`string | undefined` 不能赋给 `string`)。同时这与缓存写入侧的键不一致,属潜在逻辑 bug。

改为与文件其它位置一致的键解析:

```diff
 private replaceInCache(item: Memory): void {
-  const cached = this.memoryCache.get(item.userId);
+  const filterKey = item.assistantId || item.userId || 'default';
+  const cached = this.memoryCache.get(filterKey);
```

`assistantId || userId || 'default'` 正是 `getMemories` / `addMemory` 等写入/读取缓存时用的键(见 MemoryService.ts:140/190/329/370/438)。原 `replaceInCache` 仅按 `userId` 取,**按 assistantId 隔离的记忆取不到、无法命中缓存**,会导致更新后的条目在缓存里残留旧值。

## 影响 / 背景
- 该行由 `b06df4fe`(记忆向量搜索缓存的性能提交)引入,**非**本轮日志迁移所致。
- 仓库的 `npm run type-check` 走的是 solution 式根 `tsconfig.json`(只有 `references`、无 `include`),`tsc --noEmit` 实际不检查任何源文件,因此一直没暴露此类严格模式错误;IDE 用 `tsconfig.app.json` 故能报出。本 PR 只修这一处,不触碰其余历史遗留的严格模式告警。

## 验证
- `tsc -p tsconfig.app.json --noEmit`:`MemoryService` 无报错。
- `npm run build`(vite)通过。

Link to Devin session: https://app.devin.ai/sessions/b18b37124c694c8ab02698a24264d4aa
Requested by: @1600822305